### PR TITLE
Remove OpenSuse clean-pressed-key patch

### DIFF
--- a/contrib/packages/rpm/sle11/SPECS/tigervnc.spec
+++ b/contrib/packages/rpm/sle11/SPECS/tigervnc.spec
@@ -72,7 +72,7 @@ Source12:       http://downloads.sourceforge.net/project/libjpeg-turbo/1.3.0/lib
 # Tiger vnc patches
 Patch3:         u_tigervnc-1.3.0-fix-use-after-free.patch
 #Patch4:         tigervnc-newfbsize.patch
-Patch5:         tigervnc-clean-pressed-key-on-exit.patch
+#Patch5:         tigervnc-clean-pressed-key-on-exit.patch
 
 # Xserver patches
 Patch1:         fpic.diff
@@ -193,7 +193,7 @@ cp -r ./xorg-server-*/* unix/xserver/
 
 %patch3 -p1
 #%patch4 -p1
-%patch5 -p1
+#%patch5 -p1
 
 pushd unix/xserver
 for all in `find . -type f -perm -001`; do


### PR DESCRIPTION
Remove clean-pressed-key-on-exit inherited from original spec file that
ours was derived from.
