### PR TITLE
Fix some cmake quoting and escape issues.  The un-escaped parens generat...

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -19,17 +19,18 @@ if (GETTEXT_XGETTEXT_EXECUTABLE)
 
   add_custom_target(translations_update
     ${GETTEXT_XGETTEXT_EXECUTABLE}
-      --directory ${PROJECT_SOURCE_DIR}
+      --directory="${PROJECT_SOURCE_DIR}"
       --output="${CMAKE_CURRENT_SOURCE_DIR}/tigervnc.pot"
       --default-domain=tigervnc
       --keyword=_
       --keyword=N_
-      --copyright-holder='TigerVNC Team and many others (see README.txt)'
+      --copyright-holder="TigerVNC Team and many others \(see README.txt\)"
       --msgid-bugs-address="tigervnc-devel@lists.sourceforge.net"
       --sort-output
       --no-location
       ${po_source}
     COMMENT "Updating tigervnc.pot"
+    VERBATIM
   )
 endif (GETTEXT_XGETTEXT_EXECUTABLE)
 


### PR DESCRIPTION
...e a "Argument not separated from preceding token by whitespace" warning. The '--directory' argument might need to be quoted if PROJECT_SOURCE_DIR contains spaces.
