### PR TITLE
Moved call to initEventq() into InitInputDevice() to prevent NULL events.

### DIFF
--- a/unix/xserver/hw/vnc/Input.cc
+++ b/unix/xserver/hw/vnc/Input.cc
@@ -126,10 +126,6 @@ InputDevice::InputDevice()
 
 	vncInputDevice = this;
 
-#if XORG < 111
-	initEventq();
-#endif
-
 	for (i = 0;i < 256;i++)
 		pressedKeys[i] = NoSymbol;
 }
@@ -359,6 +355,10 @@ void InputDevice::InitInputDevice(void)
 	    !EnableDevice(keyboardDev, TRUE))
 		FatalError("Failed to activate TigerVNC devices\n");
 #endif /* 17 */
+
+#if XORG < 111
+	initEventq();
+#endif
 
 	PrepareInputDevices();
 }


### PR DESCRIPTION
Moved call to initEventq() into InitInputDevice() to prevent NULL events from being passed in.  The surrounding IFDEF explains why BZ bug #820443 just went away - EL6 bumped the version of xorg-x11-server-source to 1.13 at EL6.4, which caused the call to initEventq() to no longer be evaluated.
