### PR TITLE
Handle PrintScreen and SysReq on Windows

### DIFF
--- a/doc/keyboard-test.txt
+++ b/doc/keyboard-test.txt
@@ -81,6 +81,7 @@ Client
   - Insert, Delete, Home, End, PageUp, PageDown
   - Arrow keys
   - Menu
+  - Alt+PrntScrn sends Sys_Req [Win]
 
 - French layout (AZERTY and inverted shift behaviour for many keys)
 

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -695,6 +695,12 @@ int Viewport::handleSystemEvent(void *event, void *data)
     if (isExtended)
       keyCode |= 0x100;
 
+    // VK_SNAPSHOT sends different scan codes depending on the state of
+    // Alt. This means that we can get different scan codes on press and
+    // release. Force it to be something standard.
+    if (vKey == VK_SNAPSHOT)
+      keyCode = 0x137;
+
     keySym = win32_vkey_to_keysym(vKey, isExtended);
     if (keySym == NoSymbol) {
       if (isExtended)
@@ -720,6 +726,8 @@ int Viewport::handleSystemEvent(void *event, void *data)
       keyCode = MapVirtualKey(vKey, MAPVK_VK_TO_VSC);
     if (isExtended)
       keyCode |= 0x100;
+    if (vKey == VK_SNAPSHOT)
+      keyCode = 0x137;
 
     self->handleKeyRelease(keyCode);
 

--- a/vncviewer/win32.c
+++ b/vncviewer/win32.c
@@ -148,7 +148,7 @@ static const int vkey_map[][3] = {
   { VK_UP,                  XK_KP_Up,       XK_Up },
   { VK_RIGHT,               XK_KP_Right,    XK_Right },
   { VK_DOWN,                XK_KP_Down,     XK_Down },
-  { VK_SNAPSHOT,            XK_Print,       NoSymbol },
+  { VK_SNAPSHOT,            XK_Sys_Req,     XK_Print },
   { VK_INSERT,              XK_KP_Insert,   XK_Insert },
   { VK_DELETE,              XK_KP_Delete,   XK_Delete },
   { VK_LWIN,                NoSymbol,       XK_Super_L },


### PR DESCRIPTION
This key requires a bit extra care on Windows. We get wildly
different messages depending on if Alt is pressed or not. The symbol
chosen now follows the standard behaviour on X11.
