### PR TITLE
Don't use MIT-SHM on remote displays.

### DIFF
--- a/vncviewer/X11PixelBuffer.cxx
+++ b/vncviewer/X11PixelBuffer.cxx
@@ -189,7 +189,11 @@ int X11PixelBuffer::setupShm()
   caughtError = false;
   old_handler = XSetErrorHandler(XShmAttachErrorHandler);
 
-  XShmAttach(fl_display, shminfo);
+  if (!XShmAttach(fl_display, shminfo)) {
+    XSetErrorHandler(old_handler);
+    goto free_shmaddr;
+  }
+
   XSync(fl_display, False);
 
   XSetErrorHandler(old_handler);


### PR DESCRIPTION
When run from within 'ssh -X' or 'ssh -Y', MIT-SHM will appear to be
available even though it won't work: the shared memory will be on the
machine running vncviewer, not on the machine running the X server it
displays to. Depending on what shm segments are available on the
machine running the X server, the failure may not be apparent when
checking that MIT-SHM works.

Avoid this by not using MIT-SHM when XDisplayName() indicates we may
not be running locally.

Original bug report:
  https://bugzilla.redhat.com/show_bug.cgi?id=1072733
