### PR TITLE
Include VeNCrypt only if any subtype is present.

### DIFF
--- a/common/rfb/Security.cxx
+++ b/common/rfb/Security.cxx
@@ -68,10 +68,15 @@ const std::list<rdr::U8> Security::GetEnabledSecTypes(void)
   list<rdr::U8> result;
   list<U32>::iterator i;
 
-  result.push_back(secTypeVeNCrypt);
+  bool VeNCryptPresent = false;
   for (i = enabledSecTypes.begin(); i != enabledSecTypes.end(); i++)
-    if (*i < 0x100)
+    if (*i < 0x100) {
       result.push_back(*i);
+    } else {
+      if(!VeNCryptPresent)
+        result.push_back(secTypeVeNCrypt);
+      VeNCryptPresent = true;
+    }
 
   return result;
 }


### PR DESCRIPTION
Tigervnc can select VeNCrypt automatically, but only when any of it's subtypes is selected.

I found this when debugging why some clients (like vinagre from GNOME) fail to connect to tigervnc Xvnc server. The problem is that since SVN revision 4301, tigervnc implicitly offers VeNCrypt as first option. Even
if there are no VeNCrypt subtypes selected. For example when using "-securitytypes=none".
The VNC clients then typically selects the first option - VeNCrypt - and then receives empty list of VeNCrypt subtypes. While some clients ignore that and proceed with next security type, others interpret this (correctly?) as an error and close the connection.
