### PR TITLE
Static build fix - only attempt to link against libtasn1 if it's present

### DIFF
--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -30,9 +30,14 @@ if(BUILD_STATIC)
       HINTS ${PC_GNUTLS_LIBDIR} ${PC_GNUTLS_LIBRARY_DIRS})
     FIND_LIBRARY(NETTLE_LIBRARY NAMES nettle libnettle
       HINTS ${PC_GNUTLS_LIBDIR} ${PC_GNUTLS_LIBRARY_DIRS})
+    FIND_LIBRARY(TASN1_LIBRARY NAMES tasn1 libtasn1
+      HINTS ${PC_GNUTLS_LIBDIR} ${PC_GNUTLS_LIBRARY_DIRS})
 
-    set(GNUTLS_LIBRARIES "-Wl,-Bstatic -lgnutls -ltasn1")
+    set(GNUTLS_LIBRARIES "-Wl,-Bstatic -lgnutls")
 
+    if(TASN1_LIBRARY)
+      set(GNUTLS_LIBRARIES "${GNUTLS_LIBRARIES} -ltasn1")
+    endif()
     if(NETTLE_LIBRARY)
       set(GNUTLS_LIBRARIES "${GNUTLS_LIBRARIES} -lnettle -lhogweed -lgmp")
     endif()


### PR DESCRIPTION
More static build fixes.  Not all distros (eg: EL5) have standalone libtasn1, so we can't assume that it's a GnuTLS dependency.
