### PR TITLE
SPEC file cleanup

### DIFF
--- a/contrib/packages/rpm/el5/SPECS/tigervnc.spec
+++ b/contrib/packages/rpm/el5/SPECS/tigervnc.spec
@@ -1,9 +1,8 @@
 %define _default_patch_fuzz 2
-%define snap 20141119git59c5a55c
 %define mesa_version 7.7.1
 
 Name: tigervnc
-Version: 1.3.80
+Version: @VERSION@
 Release: 18%{?snap:.%{snap}}%{?dist}
 Summary: A TigerVNC remote display system
 

--- a/contrib/packages/rpm/el6/SPECS/tigervnc.spec
+++ b/contrib/packages/rpm/el6/SPECS/tigervnc.spec
@@ -1,7 +1,5 @@
-%define		snap 20131128svn5139
-
 Name: tigervnc
-Version: 1.3.80
+Version: @VERSION@
 Release: 18%{?snap:.%{snap}}%{?dist}
 Summary: A TigerVNC remote display system
 

--- a/contrib/packages/rpm/sle11/SPECS/tigervnc.spec
+++ b/contrib/packages/rpm/sle11/SPECS/tigervnc.spec
@@ -14,12 +14,11 @@
 
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
-%define         snap 20131202svn5145
 %define         debug_package %{nil}
 
 
 Name:           tigervnc
-Version:        1.3.80
+Version:        @VERSION@
 Release:        1%{?snap:.%{snap}}%{?dist}
 Packager:       Brian P. Hinz <bphinz@users.sourceforge.net>
 License:        GPL-2.0 and MIT


### PR DESCRIPTION
- Removed the hard coded snap tag, if needed it should be passed in
  via "rpmbuild --define 'snap ...'".
- Changed the hard coded version to "@VERSION@" to make it clear
  that the copy of the spec file in the repository needs to be
  updated manually.
