### PR TITLE
Use Travis CI to verify build does not break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+compiler: gcc
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq cmake xorg-server-source libgnutls-dev
+        libfltk1.3-dev libjpeg-dev libpng-dev libfontconfig-dev
+        libxft-dev libxinerama-dev gettext
+# Define FL_SOCKET so we can build against fltk-1.3.0 (Travis CI build
+# hosts have this older version)
+script: tar Jxf /usr/src/xorg-server.tar.xz -C unix/xserver --strip-components=1
+        && cmake -G "Unix Makefiles" -D "CMAKE_CXX_FLAGS=-DFL_SOCKET=int" .
+        && make


### PR DESCRIPTION
Here is a Travis CI configuration file for TigerVNC which you can use to enable continuous build testing. After merging this pull request you can enable the Travis CI service by following these steps:
http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in