### PR TITLE
Fix for broken GLX extension in rhel6u6

### DIFF
--- a/contrib/packages/rpm/el6/SOURCES/tigervnc-xorg115-glx-tls.patch
+++ b/contrib/packages/rpm/el6/SOURCES/tigervnc-xorg115-glx-tls.patch
@@ -1,0 +1,11 @@
+--- a/unix/xserver/configure.ac	2014-12-06 18:06:03.477010977 -0500
++++ b/unix/xserver/configure.ac	2014-12-06 18:06:49.768005867 -0500
+@@ -1309,7 +1309,7 @@
+ 
+ if test "x$GLX_USE_TLS" = xyes ; then
+ 	GLX_DEFINES="-DGLX_USE_TLS -DPTHREADS"
+-	GLX_SYS_LIBS="$GLX_SYS_LIBS -lpthread"
++	GLX_SYS_LIBS="$GLX_SYS_LIBS -lglapi -lpthread"
+ fi
+ AC_SUBST([GLX_DEFINES])
+ AC_SUBST([GLX_SYS_LIBS])

--- a/contrib/packages/rpm/el6/SPECS/tigervnc.spec
+++ b/contrib/packages/rpm/el6/SPECS/tigervnc.spec
@@ -49,6 +49,7 @@ Patch4: tigervnc-cookie.patch
 Patch10: tigervnc11-ldnow.patch
 Patch11: tigervnc11-gethomedir.patch
 Patch16: tigervnc-xorg-manpages.patch
+Patch17: tigervnc-xorg115-glx-tls.patch
 
 %description
 Virtual Network Computing (VNC) is a remote display system which
@@ -160,6 +161,7 @@ patch -p1 -b --suffix .vnc < ../xserver115.patch
 popd
 
 %patch16 -p0 -b .man
+%patch17 -p1 -b .glx
 
 %build
 %define tigervnc_src_dir %{_builddir}/%{name}-%{version}%{?snap:-%{snap}}


### PR DESCRIPTION
RHEL/CentOS 6.6 bumped the version of xorg to 6u6, which broke
software GLX because Xvnc wasn't properly linked against libglapi.
