### PR TITLE
Add user-specified geometry to RandR list.

### DIFF
--- a/unix/xserver/hw/vnc/xvnc.cc
+++ b/unix/xserver/hw/vnc/xvnc.cc
@@ -1326,11 +1326,12 @@ static RRCrtcPtr vncRandRCrtcCreate(ScreenPtr pScreen)
 
     int j;
     for (j = 0;j < sizeof(vncRandRWidths)/sizeof(*vncRandRWidths);j++)
-      if (vncRandRWidths[j] != vfbScreens[0].fb.width ||
-	  vncRandRHeights[j] != vfbScreens[0].fb.height)
+      if (vncRandRWidths[j] == vfbScreens[0].fb.width &&
+	  vncRandRHeights[j] == vfbScreens[0].fb.height)
 	break;
 
-    if (j < sizeof(vncRandRWidths)/sizeof(*vncRandRWidths)) {
+    if (j == sizeof(vncRandRWidths)/sizeof(*vncRandRWidths)) {
+      /* User-set geometry needs to be added */
       mode = vncRandRModeGet(vfbScreens[0].fb.width,
 			     vfbScreens[0].fb.height);
       modes[num_modes] = mode;

--- a/unix/xserver/hw/vnc/xvnc.cc
+++ b/unix/xserver/hw/vnc/xvnc.cc
@@ -1323,6 +1323,20 @@ static RRCrtcPtr vncRandRCrtcCreate(ScreenPtr pScreen)
     int num_modes;
 
     num_modes = 0;
+
+    int j;
+    for (j = 0;j < sizeof(vncRandRWidths)/sizeof(*vncRandRWidths);j++)
+      if (vncRandRWidths[j] != vfbScreens[0].fb.width ||
+	  vncRandRHeights[j] != vfbScreens[0].fb.height)
+	break;
+
+    if (j < sizeof(vncRandRWidths)/sizeof(*vncRandRWidths)) {
+      mode = vncRandRModeGet(vfbScreens[0].fb.width,
+			     vfbScreens[0].fb.height);
+      modes[num_modes] = mode;
+      num_modes++;
+    }
+
     for (int i = 0;i < sizeof(vncRandRWidths)/sizeof(*vncRandRWidths);i++) {
         mode = vncRandRModeGet(vncRandRWidths[i], vncRandRHeights[i]);
         if (mode != NULL) {


### PR DESCRIPTION
When Xvnc is started with a '-geometry' parameter, the specified geometry is not added to the RandR list. This causes problems when running e.g. GNOME, which adjusts resolution based on RandR.

How to test:

vncserver -geometry 1440x900 :1
DISPLAY=:1 randr | grep 1440

or run a GNOME session and see what resolution you get when connecting with 'vncviewer -RemoteResize=0'.