### PR TITLE
Allow java viewer to load without manifest properly

### DIFF
--- a/java/com/tigervnc/vncviewer/CConn.java
+++ b/java/com/tigervnc/vncviewer/CConn.java
@@ -781,7 +781,7 @@ public class CConn extends CConnection implements
       Attributes attributes = manifest.getMainAttributes();
       pkgDate = attributes.getValue("Package-Date");
       pkgTime = attributes.getValue("Package-Time");
-    } catch (IOException e) { }
+    } catch (java.lang.Exception e) { }
 
     Window fullScreenWindow = Viewport.getFullScreenWindow();
     if (fullScreenWindow != null)

--- a/java/com/tigervnc/vncviewer/VncViewer.java
+++ b/java/com/tigervnc/vncviewer/VncViewer.java
@@ -365,7 +365,7 @@ public class VncViewer extends javax.swing.JApplet
         build = attributes.getValue("Build");
         buildDate = attributes.getValue("Package-Date");
         buildTime = attributes.getValue("Package-Time");
-      } catch (java.io.IOException e) { }
+      } catch (java.lang.Exception e) { }
     }
   }
 


### PR DESCRIPTION
The java viewer would not run without a manifest file and caused an exception that is not an IOException like the original catch was. Bugged me while writing another thing.