### PR TITLE
Implement resize on connect UI bits for java viewer

### DIFF
--- a/java/com/tigervnc/vncviewer/CConn.java
+++ b/java/com/tigervnc/vncviewer/CConn.java
@@ -981,6 +981,11 @@ public class CConn extends CConnection implements
         options.secIdent.isSelected());
     }
 
+    options.resizeOnConnect.setSelected(UserPreferences.getBool("global", "ResizeOnConnect"));
+    String resizeWidth = UserPreferences.get("global", "ResizeWidth");
+    options.resizeWidth.setText(resizeWidth != null && resizeWidth.length() > 0 ? resizeWidth : "1024");
+    String resizeHeight = UserPreferences.get("global", "ResizeHeight");
+    options.resizeHeight.setText(resizeHeight != null && resizeHeight.length() > 0 ? resizeHeight : "768");
     options.fullScreen.setSelected(fullScreen);
     options.useLocalCursor.setSelected(viewer.useLocalCursor.getValue());
     options.acceptBell.setSelected(viewer.acceptBell.getValue());
@@ -1060,6 +1065,11 @@ public class CConn extends CConnection implements
     viewer.acceptClipboard.setParam(options.acceptClipboard.isSelected());
     viewer.sendClipboard.setParam(options.sendClipboard.isSelected());
     viewer.acceptBell.setParam(options.acceptBell.isSelected());
+
+    if (options.resizeOnConnect.isSelected()) {
+      viewer.desktopSize.setParam(options.resizeWidth.getText() + "x"  + options.resizeHeight.getText());
+    }
+
     String scaleString =
       options.scalingFactor.getSelectedItem().toString();
     String oldScaleFactor = viewer.scalingFactor.getValue();

--- a/java/com/tigervnc/vncviewer/OptionsDialog.java
+++ b/java/com/tigervnc/vncviewer/OptionsDialog.java
@@ -45,12 +45,13 @@ class OptionsDialog extends Dialog implements
   JRadioButton zrle, hextile, tight, raw;
   JRadioButton fullColour, mediumColour, lowColour, veryLowColour;
   JCheckBox viewOnly, acceptClipboard, sendClipboard, acceptBell;
-  JCheckBox fullScreen, shared, useLocalCursor;
+  JCheckBox resizeOnConnect, fullScreen, shared, useLocalCursor;
   JCheckBox secVeNCrypt, encNone, encTLS, encX509;
   JCheckBox secNone, secVnc, secPlain, secIdent, sendLocalUsername;
   JButton okButton, cancelButton;
   JButton ca, crl;
   JButton cfLoadButton, cfSaveAsButton, defSaveButton, defReloadButton, defClearButton;
+  JTextField resizeWidth, resizeHeight;
 
   @SuppressWarnings({"rawtypes","unchecked"})
   public OptionsDialog(CConn cc_) {
@@ -147,6 +148,14 @@ class OptionsDialog extends Dialog implements
     // Misc tab
     MiscPanel=new JPanel(new GridBagLayout());
 
+    resizeOnConnect = new JCheckBox("Resize remote session on connect");
+    resizeOnConnect.addItemListener(this);
+    resizeWidth = new JTextField("1024", 4);
+    resizeWidth.addActionListener(this);
+    resizeWidth.setEnabled(false);
+    resizeHeight = new JTextField("768", 4);
+    resizeHeight.addActionListener(this);
+    resizeHeight.setEnabled(false);
     fullScreen = new JCheckBox("Full-screen mode");
     fullScreen.addItemListener(this);
     fullScreen.setEnabled(!cc.viewer.embed.getValue());
@@ -171,15 +180,21 @@ class OptionsDialog extends Dialog implements
       sfeTextField.setBorder(new CompoundBorder(sfeTextField.getBorder(),
                                                 new EmptyBorder(0,2,0,0)));
     }
+    JPanel resizePanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+    resizePanel.add(resizeWidth);
+    resizePanel.add(new JLabel("x"));
+    resizePanel.add(resizeHeight);
     scalingFactor.setEditable(true);
     scalingFactor.addItemListener(this);
     scalingFactor.setEnabled(!cc.viewer.embed.getValue());
-    addGBComponent(fullScreen,MiscPanel,     0, 0, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(4,5,0,5));
-    addGBComponent(shared,MiscPanel,         0, 1, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(4,5,0,5));
-    addGBComponent(useLocalCursor,MiscPanel, 0, 2, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(4,5,0,5));
-    addGBComponent(acceptBell,MiscPanel,     0, 3, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.FIRST_LINE_START, new Insets(4,5,0,5));
-    addGBComponent(scalingFactorLabel,MiscPanel, 0, 4, 1, GridBagConstraints.REMAINDER, 2, 2, 1, 1, GridBagConstraints.NONE, GridBagConstraints.FIRST_LINE_START, new Insets(8,8,0,5));
-    addGBComponent(scalingFactor,MiscPanel, 1, 4, 1, GridBagConstraints.REMAINDER, 2, 2, 25, 1, GridBagConstraints.NONE, GridBagConstraints.FIRST_LINE_START, new Insets(4,5,0,5));
+    addGBComponent(resizeOnConnect,MiscPanel,0, 0, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(4,5,0,5));
+    addGBComponent(resizePanel,MiscPanel,    0, 1, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(0,20,0,5));
+    addGBComponent(fullScreen,MiscPanel,     0, 2, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(4,5,0,5));
+    addGBComponent(shared,MiscPanel,         0, 3, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(4,5,0,5));
+    addGBComponent(useLocalCursor,MiscPanel, 0, 4, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.LINE_START, new Insets(4,5,0,5));
+    addGBComponent(acceptBell,MiscPanel,     0, 5, 2, 1, 2, 2, 1, 0, GridBagConstraints.HORIZONTAL, GridBagConstraints.FIRST_LINE_START, new Insets(4,5,0,5));
+    addGBComponent(scalingFactorLabel,MiscPanel, 0, 6, 1, GridBagConstraints.REMAINDER, 2, 2, 1, 1, GridBagConstraints.NONE, GridBagConstraints.FIRST_LINE_START, new Insets(8,8,0,5));
+    addGBComponent(scalingFactor,MiscPanel, 1, 6, 1, GridBagConstraints.REMAINDER, 2, 2, 25, 1, GridBagConstraints.NONE, GridBagConstraints.FIRST_LINE_START, new Insets(4,5,0,5));
 
     // load/save tab
     DefaultsPanel=new JPanel(new GridBagLayout());
@@ -330,6 +345,9 @@ class OptionsDialog extends Dialog implements
     UserPreferences.set("global", "SendClipboard", sendClipboard.isSelected());
     String menuKeyStr = MenuKey.getMenuKeySymbols()[menuKey.getSelectedIndex()].name;
     UserPreferences.set("global", "MenuKey", menuKeyStr);
+    UserPreferences.set("global", "ResizeOnConnect", resizeOnConnect.isSelected());
+    UserPreferences.set("global", "ResizeWidth", resizeWidth.getText());
+    UserPreferences.set("global", "ResizeHeight", resizeHeight.getText());
     UserPreferences.set("global", "FullScreen", fullScreen.isSelected());
     UserPreferences.set("global", "Shared", shared.isSelected());
     UserPreferences.set("global", "UseLocalCursor", useLocalCursor.isSelected());
@@ -401,6 +419,11 @@ class OptionsDialog extends Dialog implements
     acceptClipboard.setSelected(UserPreferences.getBool("global", "AcceptClipboard"));
     sendClipboard.setSelected(UserPreferences.getBool("global", "SendClipboard"));
     menuKey.setSelectedItem(UserPreferences.get("global", "MenuKey"));
+    resizeOnConnect.setSelected(UserPreferences.getBool("global", "ResizeOnConnect"));
+    resizeWidth.setText(UserPreferences.get("global", "ResizeWidth"));
+    resizeWidth.setEnabled(resizeOnConnect.isSelected());
+    resizeHeight.setText(UserPreferences.get("global", "ResizeHeight"));
+    resizeHeight.setEnabled(resizeOnConnect.isSelected());
     fullScreen.setSelected(UserPreferences.getBool("global", "FullScreen"));
     if (shared.isEnabled())
       shared.setSelected(UserPreferences.getBool("global", "Shared"));
@@ -573,6 +596,10 @@ class OptionsDialog extends Dialog implements
     if (s instanceof JCheckBox && (JCheckBox)s == secIdent ||
         s instanceof JCheckBox && (JCheckBox)s == secPlain) {
       sendLocalUsername.setEnabled(secIdent.isSelected()||secPlain.isSelected());
+    }
+    if (s instanceof JCheckBox && (JCheckBox)s == resizeOnConnect) {
+      resizeWidth.setEnabled(resizeOnConnect.isSelected());
+      resizeHeight.setEnabled(resizeOnConnect.isSelected());
     }
   }
 


### PR DESCRIPTION
Should implement everything required, including saving/loading the defaults. UI arrangement is based on TigerVNC native client. GridBagLayout threw me a curve ball and I went with FlowLayout for the input fields, hopefully that's ok.

The feature itself seems to work. I couldn't find any way to actually enable it other than implement the UI.

I also have a patch to enable "Resize remote session to the local window" with timed/delayed resize event to prevent flooding and I'll rebase it on top of this if merged.