### PR TITLE
Fix warnings in xserver tree

### DIFF
--- a/unix/xserver/hw/vnc/Input.c
+++ b/unix/xserver/hw/vnc/Input.c
@@ -26,6 +26,7 @@
 
 #include "Input.h"
 #include "vncExtInit.h"
+#include "RFBGlue.h"
 
 #include "inputstr.h"
 #if XORG >= 110

--- a/unix/xserver/hw/vnc/XorgGlue.c
+++ b/unix/xserver/hw/vnc/XorgGlue.c
@@ -30,10 +30,6 @@
 
 #include "XorgGlue.h"
 
-#ifdef RANDR
-extern RRModePtr vncRandRModeGet(int width, int height);
-#endif
-
 const char *vncGetDisplay(void)
 {
   return display;

--- a/unix/xserver/hw/vnc/XorgGlue.h
+++ b/unix/xserver/hw/vnc/XorgGlue.h
@@ -57,7 +57,9 @@ intptr_t vncRandRGetOutputId(int scrIdx, int outputIdx);
 void vncRandRGetOutputDimensions(int scrIdx, int outputIdx,
                                  int *x, int *y, int *width, int *height);
 
-// This one hides in xvnc.c or vncModule.c
+// These hide in xvnc.c or vncModule.c
+void vncClientGone(int fd);
+void *vncRandRModeGet(int width, int height);
 int vncRandRCreateOutputs(int scrIdx, int extraOutputs);
 
 #ifdef __cplusplus

--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -46,9 +46,6 @@
 #include "XorgGlue.h"
 #include "Input.h"
 
-// Hack to catch when inetd has let us go
-extern "C" void vncClientGone(int fd);
-
 using namespace rfb;
 using namespace network;
 

--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -331,7 +331,7 @@ static int ProcVncExtGetParamDesc(ClientPtr client)
   }
   WriteToClient(client, sizeof(xVncExtGetParamDescReply), (char *)&rep);
   if (desc)
-    WriteToClient(client, len, (char*)desc);
+    WriteToClient(client, len, desc);
   return (client->noClientException);
 }
 
@@ -613,9 +613,9 @@ static int ProcVncExtGetQueryConnect(ClientPtr client)
   }
   WriteToClient(client, sizeof(xVncExtGetQueryConnectReply), (char *)&rep);
   if (qcTimeout)
-    WriteToClient(client, strlen(qcAddress), (char*)qcAddress);
+    WriteToClient(client, strlen(qcAddress), qcAddress);
   if (qcTimeout)
-    WriteToClient(client, strlen(qcUsername), (char*)qcUsername);
+    WriteToClient(client, strlen(qcUsername), qcUsername);
   return (client->noClientException);
 }
 

--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -123,6 +123,8 @@ int vncNotifyQueryConnect(void)
 
 void vncClientCutText(const char* str, int len)
 {
+  xVncExtClientCutTextNotifyEvent ev;
+
   if (clientCutText != NULL)
     free(clientCutText);
   clientCutTextLen = 0;
@@ -136,7 +138,6 @@ void vncClientCutText(const char* str, int len)
   memcpy(clientCutText, str, len);
   clientCutTextLen = len;
 
-  xVncExtClientCutTextNotifyEvent ev;
   ev.type = vncEventBase + VncExtClientCutTextNotify;
   for (struct VncInputSelect* cur = vncInputSelectHead; cur; cur = cur->next) {
     if (cur->mask & VncExtClientCutTextMask) {
@@ -164,6 +165,7 @@ void vncClientCutText(const char* str, int len)
 static int ProcVncExtSetParam(ClientPtr client)
 {
   char *param;
+  xVncExtSetParamReply rep;
 
   REQUEST(xVncExtSetParamReq);
   REQUEST_FIXED_SIZE(xVncExtSetParamReq, stuff->paramLen);
@@ -174,7 +176,6 @@ static int ProcVncExtSetParam(ClientPtr client)
   strncpy(param, (char*)&stuff[1], stuff->paramLen);
   param[stuff->paramLen] = '\0';
 
-  xVncExtSetParamReply rep;
   rep.type = X_Reply;
   rep.length = 0;
   rep.success = 0;
@@ -233,6 +234,7 @@ static int ProcVncExtGetParam(ClientPtr client)
   char* param;
   char* value;
   size_t len;
+  xVncExtGetParamReply rep;
 
   REQUEST(xVncExtGetParamReq);
   REQUEST_FIXED_SIZE(xVncExtGetParamReq, stuff->paramLen);
@@ -248,7 +250,6 @@ static int ProcVncExtGetParam(ClientPtr client)
 
   free(param);
 
-  xVncExtGetParamReply rep;
   rep.type = X_Reply;
   rep.sequenceNumber = client->sequence;
   rep.success = 0;
@@ -293,6 +294,7 @@ static int ProcVncExtGetParamDesc(ClientPtr client)
   char* param;
   const char* desc;
   size_t len;
+  xVncExtGetParamDescReply rep;
 
   REQUEST(xVncExtGetParamDescReq);
   REQUEST_FIXED_SIZE(xVncExtGetParamDescReq, stuff->paramLen);
@@ -308,7 +310,6 @@ static int ProcVncExtGetParamDesc(ClientPtr client)
 
   free(param);
 
-  xVncExtGetParamDescReply rep;
   rep.type = X_Reply;
   rep.sequenceNumber = client->sequence;
   rep.success = 0;
@@ -349,15 +350,15 @@ static int SProcVncExtGetParamDesc(ClientPtr client)
 
 static int ProcVncExtListParams(ClientPtr client)
 {
+  xVncExtListParamsReply rep;
+  char *params;
+  size_t len;
+
   REQUEST(xVncExtListParamsReq);
   REQUEST_SIZE_MATCH(xVncExtListParamsReq);
 
-  xVncExtListParamsReply rep;
   rep.type = X_Reply;
   rep.sequenceNumber = client->sequence;
-
-  char *params;
-  size_t len;
 
   params = vncGetParamList();
   if (params == NULL)
@@ -426,10 +427,11 @@ static int SProcVncExtSetServerCutText(ClientPtr client)
 
 static int ProcVncExtGetClientCutText(ClientPtr client)
 {
+  xVncExtGetClientCutTextReply rep;
+
   REQUEST(xVncExtGetClientCutTextReq);
   REQUEST_SIZE_MATCH(xVncExtGetClientCutTextReq);
 
-  xVncExtGetClientCutTextReply rep;
   rep.type = X_Reply;
   rep.length = (clientCutTextLen + 3) >> 2;
   rep.sequenceNumber = client->sequence;
@@ -522,6 +524,7 @@ static int SProcVncExtSelectInput(ClientPtr client)
 static int ProcVncExtConnect(ClientPtr client)
 {
   char *address;
+  xVncExtConnectReply rep;
 
   REQUEST(xVncExtConnectReq);
   REQUEST_FIXED_SIZE(xVncExtConnectReq, stuff->strLen);
@@ -532,7 +535,6 @@ static int ProcVncExtConnect(ClientPtr client)
   strncpy(address, (char*)&stuff[1], stuff->strLen);
   address[stuff->strLen] = 0;
 
-  xVncExtConnectReply rep;
   rep.success = 0;
   if (vncConnectClient(address) == 0)
         rep.success = 1;
@@ -573,16 +575,17 @@ static int SProcVncExtConnect(ClientPtr client)
 
 static int ProcVncExtGetQueryConnect(ClientPtr client)
 {
-  REQUEST(xVncExtGetQueryConnectReq);
-  REQUEST_SIZE_MATCH(xVncExtGetQueryConnectReq);
-
   uint32_t opaqueId;
   const char *qcAddress, *qcUsername;
   int qcTimeout;
 
+  xVncExtGetQueryConnectReply rep;
+
+  REQUEST(xVncExtGetQueryConnectReq);
+  REQUEST_SIZE_MATCH(xVncExtGetQueryConnectReq);
+
   vncGetQueryConnect(&opaqueId, &qcAddress, &qcUsername, &qcTimeout);
 
-  xVncExtGetQueryConnectReply rep;
   rep.type = X_Reply;
   rep.sequenceNumber = client->sequence;
   rep.timeout = qcTimeout;

--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -354,7 +354,6 @@ static int ProcVncExtListParams(ClientPtr client)
   char *params;
   size_t len;
 
-  REQUEST(xVncExtListParamsReq);
   REQUEST_SIZE_MATCH(xVncExtListParamsReq);
 
   rep.type = X_Reply;
@@ -429,7 +428,6 @@ static int ProcVncExtGetClientCutText(ClientPtr client)
 {
   xVncExtGetClientCutTextReply rep;
 
-  REQUEST(xVncExtGetClientCutTextReq);
   REQUEST_SIZE_MATCH(xVncExtGetClientCutTextReq);
 
   rep.type = X_Reply;
@@ -581,7 +579,6 @@ static int ProcVncExtGetQueryConnect(ClientPtr client)
 
   xVncExtGetQueryConnectReply rep;
 
-  REQUEST(xVncExtGetQueryConnectReq);
   REQUEST_SIZE_MATCH(xVncExtGetQueryConnectReq);
 
   vncGetQueryConnect(&opaqueId, &qcAddress, &qcUsername, &qcTimeout);

--- a/unix/xserver/hw/vnc/vncModule.c
+++ b/unix/xserver/hw/vnc/vncModule.c
@@ -35,6 +35,7 @@
 
 #include "vncExtInit.h"
 #include "RFBGlue.h"
+#include "XorgGlue.h"
 
 static void vncModuleInit(INITARGS);
 
@@ -103,8 +104,12 @@ static void vncModuleInit(INITARGS)
   vncExtensionInit();
 }
 
+void vncClientGone(int fd)
+{
+}
+
 #ifdef RANDR
-RRModePtr vncRandRModeGet(int width, int height)
+void *vncRandRModeGet(int width, int height)
 {
     return NULL;
 }

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -34,6 +34,7 @@ from the X Consortium.
 
 #include "vncExtInit.h"
 #include "RFBGlue.h"
+#include "XorgGlue.h"
 #include "xorg-version.h"
 
 #ifdef WIN32
@@ -1053,7 +1054,6 @@ xf86SetRootClip (ScreenPtr pScreen, Bool enable)
     FlushAllOutput ();
 }
 
-RRModePtr vncRandRModeGet(int width, int height);
 static Bool vncRandRCrtcSet(ScreenPtr pScreen, RRCrtcPtr crtc, RRModePtr mode,
                             int x, int y, Rotation rotation, int num_outputs,
                             RROutputPtr *outputs);
@@ -1234,8 +1234,8 @@ static const int vncRandRHeights[] = { 1200, 1080, 1200, 1050, 1050,  768, 1024,
 
 static int vncRandRIndex = 0;
 
-/* This is a global symbol since XserverDesktop also uses it */
-RRModePtr vncRandRModeGet(int width, int height)
+/* This is a global symbol since findRandRMode() also uses it */
+void *vncRandRModeGet(int width, int height)
 {
     xRRModeInfo	modeInfo;
     char name[100];

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -211,7 +211,7 @@ int DPMSSet(ClientPtr client, int level)
     return Success;
 }
 
-Bool DPMSSupported()
+Bool DPMSSupported(void)
 {
     /* Causes DPMSCapable to return false, meaning no devices are DPMS
        capable */
@@ -270,7 +270,7 @@ DarwinGlxWrapInitVisuals(
 #endif
 
 void
-OsVendorInit()
+OsVendorInit(void)
 {
 }
 
@@ -288,8 +288,7 @@ void ddxBeforeReset(void)
     return;
 }
 
-void 
-ddxUseMsg()
+void ddxUseMsg(void)
 {
     ErrorF("\nXvnc %s - built %s\n%s", XVNCVERSION, buildtime, XVNCCOPYRIGHT);
     ErrorF("Underlying X server release %d, %s\n\n", VENDOR_RELEASE,
@@ -1678,7 +1677,7 @@ Bool LegalModifier(unsigned int key, DeviceIntPtr pDev)
   return TRUE;
 }
 
-void ProcessInputEvents()
+void ProcessInputEvents(void)
 {
   mieqProcessInputEvents();
 #if XORG == 15

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -69,11 +69,15 @@ from the X Consortium.
 #include <sys/shm.h>
 #endif /* HAS_SHM */
 #include "dix.h"
+#include "os.h"
 #include "miline.h"
 #include "inputstr.h"
 #ifdef RANDR
 #include "randrstr.h"
 #endif /* RANDR */
+#ifdef DPMSExtension
+#include "dpmsproc.h"
+#endif
 #include <X11/keysym.h>
   extern char buildtime[];
 #if XORG >= 17

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -424,10 +424,10 @@ ddxProcessArgument(int argc, char *argv[], int i)
 	pix = atoi(argv[i]);
 	if (-1 == lastScreen)
 	{
-	    int i;
-	    for (i = 0; i < MAXSCREENS; i++)
+	    int j;
+	    for (j = 0; j < MAXSCREENS; j++)
 	    {
-		vfbScreens[i].blackPixel = pix;
+		vfbScreens[j].blackPixel = pix;
 	    }
 	}
 	else
@@ -444,10 +444,10 @@ ddxProcessArgument(int argc, char *argv[], int i)
 	pix = atoi(argv[i]);
 	if (-1 == lastScreen)
 	{
-	    int i;
-	    for (i = 0; i < MAXSCREENS; i++)
+	    int j;
+	    for (j = 0; j < MAXSCREENS; j++)
 	    {
-		vfbScreens[i].whitePixel = pix;
+		vfbScreens[j].whitePixel = pix;
 	    }
 	}
 	else
@@ -464,10 +464,10 @@ ddxProcessArgument(int argc, char *argv[], int i)
 	linebias = atoi(argv[i]);
 	if (-1 == lastScreen)
 	{
-	    int i;
-	    for (i = 0; i < MAXSCREENS; i++)
+	    int j;
+	    for (j = 0; j < MAXSCREENS; j++)
 	    {
-		vfbScreens[i].lineBias = linebias;
+		vfbScreens[j].lineBias = linebias;
 	    }
 	}
 	else
@@ -532,10 +532,10 @@ ddxProcessArgument(int argc, char *argv[], int i)
 
 	if (-1 == lastScreen)
 	{
-	    int i;
-	    for (i = 0; i < MAXSCREENS; i++)
+	    int j;
+	    for (j = 0; j < MAXSCREENS; j++)
 	    {
-		SET_PIXEL_FORMAT(vfbScreens[i]);
+		SET_PIXEL_FORMAT(vfbScreens[j]);
 	    }
 	}
 	else
@@ -1585,7 +1585,7 @@ static ExtensionModule glxExt = {
 #endif
 
 void
-InitOutput(ScreenInfo *screenInfo, int argc, char **argv)
+InitOutput(ScreenInfo *scrInfo, int argc, char **argv)
 {
     int i;
     int NumFormats = 0;
@@ -1630,18 +1630,18 @@ InitOutput(ScreenInfo *screenInfo, int argc, char **argv)
 	{
 	    if (NumFormats >= MAXFORMATS)
 		FatalError ("MAXFORMATS is too small for this server\n");
-	    screenInfo->formats[NumFormats].depth = i;
-	    screenInfo->formats[NumFormats].bitsPerPixel = vfbBitsPerPixel(i);
-	    screenInfo->formats[NumFormats].scanlinePad = BITMAP_SCANLINE_PAD;
+	    scrInfo->formats[NumFormats].depth = i;
+	    scrInfo->formats[NumFormats].bitsPerPixel = vfbBitsPerPixel(i);
+	    scrInfo->formats[NumFormats].scanlinePad = BITMAP_SCANLINE_PAD;
 	    NumFormats++;
 	}
     }
 
-    screenInfo->imageByteOrder = IMAGE_BYTE_ORDER;
-    screenInfo->bitmapScanlineUnit = BITMAP_SCANLINE_UNIT;
-    screenInfo->bitmapScanlinePad = BITMAP_SCANLINE_PAD;
-    screenInfo->bitmapBitOrder = BITMAP_BIT_ORDER;
-    screenInfo->numPixmapFormats = NumFormats;
+    scrInfo->imageByteOrder = IMAGE_BYTE_ORDER;
+    scrInfo->bitmapScanlineUnit = BITMAP_SCANLINE_UNIT;
+    scrInfo->bitmapScanlinePad = BITMAP_SCANLINE_PAD;
+    scrInfo->bitmapBitOrder = BITMAP_BIT_ORDER;
+    scrInfo->numPixmapFormats = NumFormats;
 
     /* initialize screens */
 

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -283,10 +283,12 @@ OsVendorFatalError(const char *f, va_list args)
 {
 }
 
+#ifdef DDXBEFORERESET
 void ddxBeforeReset(void)
 {
     return;
 }
+#endif
 
 void ddxUseMsg(void)
 {

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -96,9 +96,6 @@ from the X Consortium.
 #define XVNCCOPYRIGHT ("Copyright (C) 1999-2013 TigerVNC Team and many others (see README.txt)\n" \
                        "See http://www.tigervnc.org for information on TigerVNC.\n")
 
-
-extern int monitorResolution;
-
 #define VFB_DEFAULT_WIDTH  1024
 #define VFB_DEFAULT_HEIGHT 768
 #define VFB_DEFAULT_DEPTH  24

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -328,11 +328,6 @@ void ddxUseMsg(void)
     vncListParams(79, 14);
 }
 
-/* ddxInitGlobals - called by |InitGlobals| from os/util.c */
-void ddxInitGlobals(void)
-{
-}
-
 static 
 Bool displayNumFree(int num)
 {


### PR DESCRIPTION
Clean up most of the warnings under unix/xserver. Some of them turn into hard errors depending on your compiler and Xorg versions.