### PR TITLE
Xvnc: abort argument processing on error.

### DIFF
--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -408,7 +408,7 @@ ddxProcessArgument(int argc, char *argv[], int i)
 	    {
 		ErrorF("Invalid pixmap depth %d\n", depth);
 		UseMsg();
-		return;
+		return 0;
 	    }
 	    vfbPixmapDepths[depth] = TRUE;
 	    ret++;

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -346,6 +346,13 @@ Bool displayNumFree(int num)
     return TRUE;
 }
 
+#define fail_unless_args(_argc,_i,_n)		\
+    if (_i + _n >= _argc)			\
+    {						\
+        UseMsg();				\
+        return 0;				\
+    }
+
 int 
 ddxProcessArgument(int argc, char *argv[], int i)
 {
@@ -365,12 +372,13 @@ ddxProcessArgument(int argc, char *argv[], int i)
     if (strcmp (argv[i], "-screen") == 0)	/* -screen n WxHxD */
     {
 	int screenNum;
-	if (i + 2 >= argc) UseMsg();
+	fail_unless_args(argc, i, 2);
 	screenNum = atoi(argv[i+1]);
 	if (screenNum < 0 || screenNum >= MAXSCREENS)
 	{
 	    ErrorF("Invalid screen number %d\n", screenNum);
 	    UseMsg();
+	    return 0;
 	}
 	if (3 != sscanf(argv[i+2], "%dx%dx%d",
 			&vfbScreens[screenNum].fb.width,
@@ -379,6 +387,7 @@ ddxProcessArgument(int argc, char *argv[], int i)
 	{
 	    ErrorF("Invalid screen configuration %s\n", argv[i+2]);
 	    UseMsg();
+	    return 0;
 	}
 
 	if (screenNum >= vfbNumScreens)
@@ -391,13 +400,15 @@ ddxProcessArgument(int argc, char *argv[], int i)
     {
 	int depth, ret = 1;
 
-	if (++i >= argc) UseMsg();
+	fail_unless_args(argc, i, 1);
+	++i;
 	while ((i < argc) && (depth = atoi(argv[i++])) != 0)
 	{
 	    if (depth < 0 || depth > 32)
 	    {
 		ErrorF("Invalid pixmap depth %d\n", depth);
 		UseMsg();
+		return;
 	    }
 	    vfbPixmapDepths[depth] = TRUE;
 	    ret++;
@@ -420,7 +431,8 @@ ddxProcessArgument(int argc, char *argv[], int i)
     if (strcmp (argv[i], "-blackpixel") == 0)	/* -blackpixel n */
     {
 	Pixel pix;
-	if (++i >= argc) UseMsg();
+	fail_unless_args(argc, i, 1);
+	++i;
 	pix = atoi(argv[i]);
 	if (-1 == lastScreen)
 	{
@@ -440,7 +452,8 @@ ddxProcessArgument(int argc, char *argv[], int i)
     if (strcmp (argv[i], "-whitepixel") == 0)	/* -whitepixel n */
     {
 	Pixel pix;
-	if (++i >= argc) UseMsg();
+	fail_unless_args(argc, i, 1);
+	++i;
 	pix = atoi(argv[i]);
 	if (-1 == lastScreen)
 	{
@@ -460,7 +473,8 @@ ddxProcessArgument(int argc, char *argv[], int i)
     if (strcmp (argv[i], "-linebias") == 0)	/* -linebias n */
     {
 	unsigned int linebias;
-	if (++i >= argc) UseMsg();
+	fail_unless_args(argc, i, 1);
+	++i;
 	linebias = atoi(argv[i]);
 	if (-1 == lastScreen)
 	{
@@ -487,18 +501,21 @@ ddxProcessArgument(int argc, char *argv[], int i)
     
     if (strcmp(argv[i], "-geometry") == 0)
     {
-	if (++i >= argc) UseMsg();
+	fail_unless_args(argc, i, 1);
+	++i;
 	if (sscanf(argv[i],"%dx%d",&vfbScreens[0].fb.width,
 		   &vfbScreens[0].fb.height) != 2) {
 	    ErrorF("Invalid geometry %s\n", argv[i]);
 	    UseMsg();
+	    return 0;
 	}
 	return 2;
     }
     
     if (strcmp(argv[i], "-depth") == 0)
     {
-	if (++i >= argc) UseMsg();
+	fail_unless_args(argc, i, 1);
+	++i;
 	vfbScreens[0].fb.depth = atoi(argv[i]);
 	return 2;
     }
@@ -507,10 +524,12 @@ ddxProcessArgument(int argc, char *argv[], int i)
     {
 	char rgbbgr[4];
 	int bits1, bits2, bits3;
-	if (++i >= argc) UseMsg();
+	fail_unless_args(argc, i, 1);
+	++i;
 	if (sscanf(argv[i], "%3s%1d%1d%1d", rgbbgr,&bits1,&bits2,&bits3) < 4) {
 	    ErrorF("Invalid pixel format %s\n", argv[i]);
 	    UseMsg();
+	    return 0;
 	}
 
 #define SET_PIXEL_FORMAT(vfbScreen)                     \
@@ -528,6 +547,7 @@ ddxProcessArgument(int argc, char *argv[], int i)
     } else {                                            \
         ErrorF("Invalid pixel format %s\n", argv[i]);   \
         UseMsg();                                       \
+        return 0;					\
     }
 
 	if (-1 == lastScreen)


### PR DESCRIPTION
This prevents e.g. 'Xvnc -screen x' crashing.