### PR TITLE
Avoid warning when compiling with gcc's -Wformat-security option.

### DIFF
--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -330,7 +330,6 @@ interpretViaParam(char *remoteHost, int *remotePort, int localPort)
 
   snprintf(vncServerName, VNCSERVERNAMELEN, "localhost::%d", localPort);
   vncServerName[VNCSERVERNAMELEN - 1] = '\0';
-  vlog.error("%s", vncServerName);
 
   return 0;
 }

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -330,7 +330,7 @@ interpretViaParam(char *remoteHost, int *remotePort, int localPort)
 
   snprintf(vncServerName, VNCSERVERNAMELEN, "localhost::%d", localPort);
   vncServerName[VNCSERVERNAMELEN - 1] = '\0';
-  vlog.error(vncServerName);
+  vlog.error("%s", vncServerName);
 
   return 0;
 }


### PR DESCRIPTION
The -Wformat-security option warns whenever a non-const string is given as a format string.