### PR TITLE
Add support for X server 1.17.X

### DIFF
--- a/unix/xserver/hw/vnc/xorg-version.h
+++ b/unix/xserver/hw/vnc/xorg-version.h
@@ -48,8 +48,10 @@
 #define XORG 115
 #elif XORG_VERSION_CURRENT < ((1 * 10000000) + (16 * 100000) + (99 * 1000))
 #define XORG 116
+#elif XORG_VERSION_CURRENT < ((1 * 10000000) + (17 * 100000) + (99 * 1000))
+#define XORG 117
 #else
-#error "X.Org newer than 1.16 is not supported"
+#error "X.Org newer than 1.17 is not supported"
 #endif
 
 #endif

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -679,9 +679,9 @@ vfbInstallColormap(ColormapPtr pmap)
 	entries = pmap->pVisual->ColormapEntries;
 	pVisual = pmap->pVisual;
 
-	ppix = (Pixel *)xalloc(entries * sizeof(Pixel));
-	prgb = (xrgb *)xalloc(entries * sizeof(xrgb));
-	defs = (xColorItem *)xalloc(entries * sizeof(xColorItem));
+	ppix = (Pixel *)malloc(entries * sizeof(Pixel));
+	prgb = (xrgb *)malloc(entries * sizeof(xrgb));
+	defs = (xColorItem *)malloc(entries * sizeof(xColorItem));
 
 	for (i = 0; i < entries; i++)  ppix[i] = i;
 	/* XXX truecolor */
@@ -700,9 +700,9 @@ vfbInstallColormap(ColormapPtr pmap)
 	}
 	(*pmap->pScreen->StoreColors)(pmap, entries, defs);
 	
-	xfree(ppix);
-	xfree(prgb);
-	xfree(defs);
+	free(ppix);
+	free(prgb);
+	free(defs);
     }
 }
 

--- a/unix/xserver117.patch
+++ b/unix/xserver117.patch
@@ -1,0 +1,137 @@
+diff -up xorg-server-1.16.0/configure.ac.vnc xorg-server-1.16.0/configure.ac
+--- xorg-server-1.16.0/configure.ac.vnc	2014-07-17 08:00:51.000000000 +0100
++++ xorg-server-1.16.0/configure.ac	2014-09-03 10:21:49.506109235 +0100
+@@ -74,6 +74,7 @@ dnl forcing an entire recompile.x
+ AC_CONFIG_HEADERS(include/version-config.h)
+ 
+ AM_PROG_AS
++AC_PROG_CXX
+ AC_PROG_LN_S
+ LT_PREREQ([2.2])
+ LT_INIT([disable-static win32-dll])
+@@ -1795,6 +1796,10 @@ if test "x$XVFB" = xyes; then
+ 	AC_SUBST([XVFB_SYS_LIBS])
+ fi
+ 
++dnl Xvnc DDX
++AC_SUBST([XVNC_CPPFLAGS], ["-DHAVE_DIX_CONFIG_H $XSERVER_CFLAGS"])
++AC_SUBST([XVNC_LIBS], ["$FB_LIB $FIXES_LIB $XEXT_LIB $CONFIG_LIB $DBE_LIB $RECORD_LIB $GLX_LIBS $RANDR_LIB $RENDER_LIB $DAMAGE_LIB $DRI3_LIB $PRESENT_LIB $MIEXT_SYNC_LIB $MIEXT_DAMAGE_LIB $MIEXT_SHADOW_LIB $XI_LIB $XKB_LIB $XKB_STUB_LIB $COMPOSITE_LIB $MAIN_LIB"])
++AC_SUBST([XVNC_SYS_LIBS], ["$GLX_SYS_LIBS"])
+ 
+ dnl Xnest DDX
+ 
+@@ -1830,6 +1835,8 @@ if test "x$XORG" = xauto; then
+ fi
+ AC_MSG_RESULT([$XORG])
+ 
++AC_DEFINE_UNQUOTED(XORG_VERSION_CURRENT, [$VENDOR_RELEASE], [Current Xorg version])
++
+ if test "x$XORG" = xyes; then
+ 	XORG_DDXINCS='-I$(top_srcdir)/hw/xfree86 -I$(top_srcdir)/hw/xfree86/include -I$(top_srcdir)/hw/xfree86/common'
+ 	XORG_OSINCS='-I$(top_srcdir)/hw/xfree86/os-support -I$(top_srcdir)/hw/xfree86/os-support/bus -I$(top_srcdir)/os'
+@@ -2051,7 +2058,6 @@ if test "x$XORG" = xyes; then
+ 	AC_DEFINE(XORG_SERVER, 1, [Building Xorg server])
+ 	AC_DEFINE(XORGSERVER, 1, [Building Xorg server])
+ 	AC_DEFINE(XFree86Server, 1, [Building XFree86 server])
+-	AC_DEFINE_UNQUOTED(XORG_VERSION_CURRENT, [$VENDOR_RELEASE], [Current Xorg version])
+ 	AC_DEFINE(NEED_XF86_TYPES, 1, [Need XFree86 typedefs])
+ 	AC_DEFINE(NEED_XF86_PROTOTYPES, 1, [Need XFree86 helper functions])
+ 	AC_DEFINE(__XSERVERNAME__, "Xorg", [Name of X server])
+@@ -2589,6 +2595,7 @@ hw/dmx/Makefile
+ hw/dmx/man/Makefile
+ hw/vfb/Makefile
+ hw/vfb/man/Makefile
++hw/vnc/Makefile
+ hw/xnest/Makefile
+ hw/xnest/man/Makefile
+ hw/xwin/Makefile
+diff -up xorg-server-1.16.0/hw/Makefile.am.vnc xorg-server-1.16.0/hw/Makefile.am
+--- xorg-server-1.16.0/hw/Makefile.am.vnc	2014-04-16 21:24:00.000000000 +0100
++++ xorg-server-1.16.0/hw/Makefile.am	2014-09-03 10:21:49.507109234 +0100
+@@ -38,7 +38,8 @@ SUBDIRS =			\
+ 	$(DMX_SUBDIRS)		\
+ 	$(KDRIVE_SUBDIRS)	\
+ 	$(XQUARTZ_SUBDIRS)	\
+-	$(XWAYLAND_SUBDIRS)
++	$(XWAYLAND_SUBDIRS)	\
++	vnc
+ 
+ DIST_SUBDIRS = dmx xfree86 vfb xnest xwin xquartz kdrive xwayland
+ 
+diff -up xorg-server-1.16.0/mi/miinitext.c.vnc xorg-server-1.16.0/mi/miinitext.c
+--- xorg-server-1.16.0/mi/miinitext.c.vnc	2014-04-16 21:24:00.000000000 +0100
++++ xorg-server-1.16.0/mi/miinitext.c	2014-09-03 10:21:49.508109234 +0100
+@@ -111,6 +111,10 @@ SOFTWARE.
+ #include "micmap.h"
+ #include "globals.h"
+ 
++#ifdef TIGERVNC
++extern void vncExtensionInit(INITARGS);
++#endif
++
+ /* The following is only a small first step towards run-time
+  * configurable extensions.
+  */
+@@ -235,6 +239,9 @@ EnableDisableExtensionError(const char *
+ 
+ /* List of built-in (statically linked) extensions */
+ static const ExtensionModule staticExtensions[] = {
++#ifdef TIGERVNC
++    {vncExtensionInit, "VNC-EXTENSION", NULL},
++#endif
+     {GEExtensionInit, "Generic Event Extension", &noGEExtension},
+     {ShapeExtensionInit, "SHAPE", NULL},
+ #ifdef MITSHM
+diff -up xorg-server-1.16.0/os/WaitFor.c.vnc xorg-server-1.16.0/os/WaitFor.c
+--- xorg-server-1.16.0/os/WaitFor.c.vnc	2014-02-05 03:08:57.000000000 +0000
++++ xorg-server-1.16.0/os/WaitFor.c	2014-09-03 10:21:49.508109234 +0100
+@@ -125,6 +125,9 @@ static void DoTimer(OsTimerPtr timer, CA
+ static void CheckAllTimers(void);
+ static OsTimerPtr timers = NULL;
+ 
++extern void vncWriteBlockHandler(fd_set *fds);
++extern void vncWriteWakeupHandler(int nfds, fd_set *fds);
++
+ /*****************
+  * WaitForSomething:
+  *     Make the server suspend until there is
+@@ -150,6 +153,7 @@ WaitForSomething(int *pClientsReady)
+     INT32 timeout = 0;
+     fd_set clientsReadable;
+     fd_set clientsWritable;
++    fd_set socketsWritable;
+     int curclient;
+     int selecterr;
+     static int nready;
+@@ -212,6 +216,9 @@ WaitForSomething(int *pClientsReady)
+             XFD_COPYSET(&AllSockets, &LastSelectMask);
+         }
+ 
++        FD_ZERO(&socketsWritable);
++        vncWriteBlockHandler(&socketsWritable);
++
+         BlockHandler((void *) &wt, (void *) &LastSelectMask);
+         if (NewOutputPending)
+             FlushAllOutput();
+@@ -223,10 +223,20 @@ WaitForSomething(int *pClientsReady)
+             i = Select(MaxClients, &LastSelectMask, &clientsWritable, NULL, wt);
+         }
+         else {
+-            i = Select(MaxClients, &LastSelectMask, NULL, NULL, wt);
++	    if (AnyClientsWriteBlocked)
++		XFD_ORSET(&socketsWritable, &ClientsWriteBlocked, &socketsWritable);
++
++	    if (XFD_ANYSET(&socketsWritable)) {
++		i = Select(MaxClients, &LastSelectMask, &socketsWritable, NULL, wt);
++		if (AnyClientsWriteBlocked)
++		    XFD_ANDSET(&clientsWritable, &socketsWritable, &ClientsWriteBlocked);
++	    } else {
++		i = Select(MaxClients, &LastSelectMask, NULL, NULL, wt);
++	    }
+         }
+         selecterr = GetErrno();
+         WakeupHandler(i, (void *) &LastSelectMask);
++	vncWriteWakeupHandler(i, &socketsWritable);
+         if (i <= 0) {           /* An error or timeout occurred */
+             if (dispatchException)
+                 return 0;


### PR DESCRIPTION
* xalloc and xfree were removed after being marked as deprecated for long time.
* unix/xserver117.patch is a copy of unix/xserver116.patch which works fine with X server 1.17.