### PR TITLE
Link libvnc.so with '-z now' to make symbol resolution failures obvious.

### DIFF
--- a/unix/xserver/hw/vnc/Makefile.am
+++ b/unix/xserver/hw/vnc/Makefile.am
@@ -62,7 +62,7 @@ libvnc_la_CPPFLAGS = $(XVNC_CPPFLAGS) -I$(TIGERVNC_SRCDIR)/common -UHAVE_CONFIG_
 	-I$(top_srcdir)/include \
 	${XSERVERLIBS_CFLAGS} -I$(includedir)
 
-libvnc_la_LDFLAGS = -module -avoid-version
+libvnc_la_LDFLAGS = -module -avoid-version -Wl,-z,now
 
 libvnc_la_LIBADD = libvnccommon.la $(COMMON_LIBS)
 


### PR DESCRIPTION
This branch, from master, replaces PR #129.