### PR TITLE
Don't violate RFB spec by sending UTF-8

### DIFF
--- a/java/com/tigervnc/rfb/CMsgWriter.java
+++ b/java/com/tigervnc/rfb/CMsgWriter.java
@@ -20,6 +20,8 @@
 
 package com.tigervnc.rfb;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import com.tigervnc.rdr.*;
 
 abstract public class CMsgWriter {
@@ -155,12 +157,9 @@ abstract public class CMsgWriter {
     startMsg(MsgTypes.msgTypeClientCutText);
     os.pad(3);
     os.writeU32(len);
-    try {
-      byte[] utf8str = str.getBytes("UTF8");
-      os.writeBytes(utf8str, 0, len);
-    } catch(java.io.UnsupportedEncodingException e) {
-      e.printStackTrace();
-    }
+    Charset latin1 = Charset.forName("ISO-8859-1");
+    ByteBuffer bytes = latin1.encode(str);
+    os.writeBytes(bytes.array(), 0, len);
     endMsg();
   }
 


### PR DESCRIPTION
Java viewer was violating the RFB specification by sending UTF-8 encoded clipboard text rather than ISO-8859-1.