### PR TITLE
IPv6 support using per-family sockets (#77, #108)

### DIFF
--- a/common/network/TcpSocket.cxx
+++ b/common/network/TcpSocket.cxx
@@ -152,7 +152,7 @@ TcpSocket::TcpSocket(const char *host, int port)
 
   if ((result = getaddrinfo(host, NULL, &hints, &ai)) != 0) {
     throw Exception("unable to resolve host by name: %s",
-		    gai_strerror(result));
+                    gai_strerror(result));
   }
 
   // This logic is too complex for the compiler to determine if
@@ -222,7 +222,7 @@ TcpSocket::TcpSocket(const char *host, int port)
       err = errorNumber;
 #ifndef WIN32
       if (err == EINTR)
-	continue;
+        continue;
 #endif
       closesocket(sock);
       break;
@@ -356,7 +356,7 @@ bool TcpSocket::sameMachine() {
 #ifdef HAVE_GETADDRINFO
   if (peeraddr.u.sa.sa_family == AF_INET6)
       return IN6_ARE_ADDR_EQUAL(&peeraddr.u.sin6.sin6_addr,
-				&myaddr.u.sin6.sin6_addr);
+                                &myaddr.u.sin6.sin6_addr);
 #endif
 
   if (peeraddr.u.sa.sa_family == AF_INET)
@@ -375,7 +375,7 @@ void TcpSocket::shutdown()
 bool TcpSocket::enableNagles(int sock, bool enable) {
   int one = enable ? 0 : 1;
   if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
-		 (char *)&one, sizeof(one)) < 0) {
+                 (char *)&one, sizeof(one)) < 0) {
     int e = errorNumber;
     vlog.error("unable to setsockopt TCP_NODELAY: %d", e);
     return false;

--- a/common/network/TcpSocket.h
+++ b/common/network/TcpSocket.h
@@ -29,6 +29,7 @@
 #define __NETWORK_TCP_SOCKET_H__
 
 #include <network/Socket.h>
+#include <sys/socket.h>
 
 #include <list>
 
@@ -66,19 +67,23 @@ namespace network {
 
   class TcpListener : public SocketListener {
   public:
-    TcpListener(const char *listenaddr, int port, bool localhostOnly=false,
-		int sock=-1, bool close=true);
+    TcpListener(const struct sockaddr *listenaddr, socklen_t listenaddrlen);
+    TcpListener(int sock);
+    TcpListener(const TcpListener& other);
+    TcpListener& operator= (const TcpListener& other);
     virtual ~TcpListener();
 
     virtual void shutdown();
     virtual Socket* accept();
 
-    void getMyAddresses(std::list<char*>* addrs);
     int getMyPort();
-
-  private:
-    bool closeFd;
   };
+
+  void createLocalTcpListeners(std::list<TcpListener> *listeners,
+                               int port);
+  void createTcpListeners(std::list<TcpListener> *listeners,
+                          const char *addr,
+                          int port);
 
   class TcpFilter : public ConnectionFilter {
   public:

--- a/unix/xserver/hw/vnc/RFBGlue.cc
+++ b/unix/xserver/hw/vnc/RFBGlue.cc
@@ -187,7 +187,10 @@ int vncGetSocketPort(int fd)
 int vncIsTCPPortUsed(int port)
 {
   try {
-    network::TcpListener l(NULL, port);
+    // Attempt to create TCPListeners on that port.
+    // They go out of scope immediately and are destroyed.
+    std::list<network::TcpListener> dummy;
+    network::createTcpListeners (&dummy, 0, port);
   } catch (rdr::Exception& e) {
     return 0;
   }

--- a/unix/xserver/hw/vnc/XserverDesktop.h
+++ b/unix/xserver/hw/vnc/XserverDesktop.h
@@ -50,8 +50,9 @@ class XserverDesktop : public rfb::SDesktop, public rfb::FullFramePixelBuffer,
                        public rfb::VNCServerST::QueryConnectionHandler {
 public:
 
-  XserverDesktop(int screenIndex, network::TcpListener* listener,
-                 network::TcpListener* httpListener_,
+  XserverDesktop(int screenIndex,
+                 std::list<network::TcpListener> listeners_,
+                 std::list<network::TcpListener> httpListeners_,
                  const char* name, const rfb::PixelFormat &pf,
                  int width, int height, void* fbptr, int stride);
   virtual ~XserverDesktop();
@@ -112,8 +113,8 @@ private:
   int screenIndex;
   rfb::VNCServerST* server;
   rfb::HTTPServer* httpServer;
-  network::TcpListener* listener;
-  network::TcpListener* httpListener;
+  std::list<network::TcpListener> listeners;
+  std::list<network::TcpListener> httpListeners;
   bool deferredUpdateTimerSet;
   bool directFbptr;
   struct timeval dixTimeout;


### PR DESCRIPTION
Here's a rebased version of the 'multisocket' branch, with fixes from local testing. It needs work for win32 targets.

I've tested it with an IPv6-capable host on an IPv4-only interface, and on an IPv4-only Linux host (booted with ipv6.disabled=1).