### PR TITLE
Warn about not reseting Xvnc and terminate instead.

### DIFF
--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -1566,7 +1566,12 @@ vfbScreenInit(ScreenPtr pScreen, int argc, char **argv)
 
 
 static void vfbClientStateChange(CallbackListPtr *a, void *b, void *c) {
-  dispatchException &= ~DE_RESET;
+    if (dispatchException & DE_RESET) {
+        ErrorF("Warning: VNC extension does not support -reset, terminating instead. Use -noreset to prevent termination.\n");
+
+        dispatchException |= DE_TERMINATE;
+        dispatchException &= ~DE_RESET;
+    }
 }
  
 #if XORG >= 113


### PR DESCRIPTION
Some time ago I was debugging problem with "Xvnc -query hostname": You get login screen, can log in and out, but then Xvnc doesn't display login screen again. It just keeps running displaying nothing.

It is because the internal reset is intentionally prevented. When allowed, Xvnc and especially normal X server with VNC extension fail in various ways during the reset. I gave up on trying to fix the resetting for now.

I think Xvnc should warn about not supporting reset. Also in my opinion it is better to terminate than do nothing when reset is expected. User can still use "-noreset" to prevent the resetting/terminating.