### PR TITLE
Syslog logging

### DIFF
--- a/common/rfb/CMakeLists.txt
+++ b/common/rfb/CMakeLists.txt
@@ -29,6 +29,7 @@ set(RFB_SOURCES
   Logger.cxx
   Logger_file.cxx
   Logger_stdio.cxx
+  Logger_syslog.cxx
   Password.cxx
   PixelBuffer.cxx
   PixelFormat.cxx

--- a/common/rfb/LogWriter.h
+++ b/common/rfb/LogWriter.h
@@ -72,10 +72,15 @@ namespace rfb {
       }
     }
 
-    DEF_LOGFUNCTION(error, 0)
-    DEF_LOGFUNCTION(status, 10)
-    DEF_LOGFUNCTION(info, 30)
-    DEF_LOGFUNCTION(debug, 100)
+    static const int LEVEL_ERROR  = 0;
+    static const int LEVEL_STATUS = 10;
+    static const int LEVEL_INFO   = 30;
+    static const int LEVEL_DEBUG  = 100;
+
+    DEF_LOGFUNCTION(error, LEVEL_ERROR)
+    DEF_LOGFUNCTION(status, LEVEL_STATUS)
+    DEF_LOGFUNCTION(info, LEVEL_INFO)
+    DEF_LOGFUNCTION(debug, LEVEL_DEBUG)
 
     // -=- DIAGNOSTIC & HELPER ROUTINES
 

--- a/common/rfb/Logger_syslog.cxx
+++ b/common/rfb/Logger_syslog.cxx
@@ -1,0 +1,65 @@
+/* Copyright (C) 2015 TigerVNC
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+// -=- Logger_syslog.cxx - Logger instance for a syslog
+
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#include <rfb/util.h>
+#include <rfb/Logger_syslog.h>
+#include <rfb/LogWriter.h>
+#include <rfb/Threading.h>
+
+using namespace rfb;
+
+
+Logger_Syslog::Logger_Syslog(const char* loggerName)
+  : Logger(loggerName)
+{
+  openlog("Xvnc", LOG_CONS | LOG_PID, LOG_USER);
+}
+
+Logger_Syslog::~Logger_Syslog()
+{
+  closelog();
+}
+
+void Logger_Syslog::write(int level, const char *logname, const char *message)
+{
+  // Convert our priority level into syslog level
+  int priority;
+  if (level >= LogWriter::LEVEL_DEBUG) {
+    priority = LOG_DEBUG;
+  } else if (level >= LogWriter::LEVEL_INFO) {
+    priority = LOG_INFO;
+  } else if (level >= LogWriter::LEVEL_STATUS) {
+    priority = LOG_NOTICE;
+  } else {
+    priority = LOG_ERR;
+  }
+
+  syslog(priority, "%s: %s", logname, message);
+}
+
+static Logger_Syslog logger("syslog");
+
+void rfb::initSyslogLogger() {
+  logger.registerLogger();
+}

--- a/common/rfb/Logger_syslog.cxx
+++ b/common/rfb/Logger_syslog.cxx
@@ -33,7 +33,7 @@ using namespace rfb;
 Logger_Syslog::Logger_Syslog(const char* loggerName)
   : Logger(loggerName)
 {
-  openlog("Xvnc", LOG_CONS | LOG_PID, LOG_USER);
+  openlog(0, LOG_CONS | LOG_PID, LOG_USER);
 }
 
 Logger_Syslog::~Logger_Syslog()

--- a/common/rfb/Logger_syslog.h
+++ b/common/rfb/Logger_syslog.h
@@ -1,0 +1,40 @@
+/* Copyright (C) 2015 TigerVNC
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+// -=- Logger_syslog - log to syslog
+
+#ifndef __RFB_LOGGER_SYSLOG_H__
+#define __RFB_LOGGER_SYSLOG_H__
+
+#include <time.h>
+#include <rfb/Logger.h>
+
+namespace rfb {
+
+  class Logger_Syslog : public Logger {
+  public:
+    Logger_Syslog(const char* loggerName);
+    virtual ~Logger_Syslog();
+
+    virtual void write(int level, const char *logname, const char *message);
+  };
+
+  void initSyslogLogger();
+};
+
+#endif

--- a/unix/xserver/hw/vnc/RFBGlue.cc
+++ b/unix/xserver/hw/vnc/RFBGlue.cc
@@ -23,6 +23,7 @@
 #include <rfb/Configuration.h>
 #include <rfb/LogWriter.h>
 #include <rfb/Logger_stdio.h>
+#include <rfb/Logger_syslog.h>
 
 #include "RFBGlue.h"
 
@@ -34,6 +35,7 @@ static LogWriter inputLog("Input");
 void vncInitRFB(void)
 {
   rfb::initStdIOLoggers();
+  rfb::initSyslogLogger();
   rfb::LogWriter::setLogParams("*:stderr:30");
   rfb::Configuration::enableServerParams();
 }

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -274,11 +274,11 @@ stop non-SSH connections from any other hosts.
 .
 .TP
 .B \-Log \fIlogname\fP:\fIdest\fP:\fIlevel\fP
-Configures the debug log settings.  \fIdest\fP can currently be \fBstderr\fP or
-\fBstdout\fP, and \fIlevel\fP is between 0 and 100, 100 meaning most verbose
-output.  \fIlogname\fP is usually \fB*\fP meaning all, but you can target a
-specific source file if you know the name of its "LogWriter".  Default is
-\fB*:stderr:30\fP.
+Configures the debug log settings.  \fIdest\fP can currently be \fBstderr\fP,
+\fBstdout\fP or \fBsyslog\fP, and \fIlevel\fP is between 0 and 100, 100 meaning
+most verbose output.  \fIlogname\fP is usually \fB*\fP meaning all, but you can
+target a specific source file if you know the name of its "LogWriter".  Default
+is \fB*:stderr:30\fP.
 .
 .TP
 .B \-RemapKeys \fImapping


### PR DESCRIPTION
This is a syslog logger. Currently enabled for Xvnc, but it could be used in other places as well. The main motivation is to have nice logging when Xvnc is started from xinet.d.

Logger_syslog.cxx and Logger_syslog.h are new files. I am not sure if I placed correct comment to the start of the file.