### PR TITLE
Compile legacy Xvnc with relative rpath for portability

### DIFF
--- a/contrib/packages/rpm/el5/SOURCES/tigervnc14-Add-dridir-param.patch
+++ b/contrib/packages/rpm/el5/SOURCES/tigervnc14-Add-dridir-param.patch
@@ -1,0 +1,103 @@
+From 0acffdd6f443198378012405e7f814f5abf278b3 Mon Sep 17 00:00:00 2001
+From: Adam Tkac <atkac@redhat.com>
+Date: Wed, 15 Sep 2010 15:37:01 +0200
+Subject: [PATCH] Add -dridir parameter to specify DRI drivers directory from command line.
+
+Signed-off-by: Adam Tkac <atkac@redhat.com>
+---
+ glx/glxdri.c       |    2 --
+ glx/glxdri2.c      |    2 --
+ glx/glxdriswrast.c |    2 --
+ glx/glxext.c       |   27 +++++++++++++++++++++++++++
+ glx/glxserver.h    |    3 +++
+ os/utils.c         |    9 +++++++++
+ 6 files changed, 39 insertions(+), 6 deletions(-)
+
+diff --git a/glx/glxext.c b/glx/glxext.c
+index 89e58b0..5e7cf23 100644
+--- a/glx/glxext.c
++++ b/glx/glxext.c
+@@ -608,3 +608,30 @@ static int __glXDispatch(ClientPtr client)
+ 
+     return retval;
+ }
++
++char *dri_driver_path = DRI_DRIVER_PATH;
++
++int GlxProcessArguments(int argc, char *argv[], int i)
++{
++    if (strncmp(argv[i], "-dridir", 7) == 0) {
++	if (++i < argc) {
++#if !defined(WIN32) && !defined(__CYGWIN__)
++	    if (getuid() != geteuid()) {
++		LogMessage(X_WARNING, "-dridir is not available for setuid X servers\n");
++		return -1;
++	    } else
++#endif
++	    {
++		if (strlen(argv[i]) < PATH_MAX) {
++		    dri_driver_path = argv[i];
++		    return 2;
++		} else {
++		    LogMessage(X_ERROR, "-dridir pathname too long\n");
++		    return -1;
++		}
++	    }
++        }
++    }
++
++    return 0;
++}
+diff --git a/glx/glxserver.h b/glx/glxserver.h
+index 1daf977..082ff82 100644
+--- a/glx/glxserver.h
++++ b/glx/glxserver.h
+@@ -251,4 +251,7 @@ extern unsigned glxMinorVersion;
+ 
+ extern int __glXEventBase;
+ 
++extern char *dri_driver_path;
++extern int GlxProcessArguments(int argc, char *argv[], int i);
++
+ #endif                          /* !__GLX_server_h__ */
+diff --git a/glx/glxdricommon.c b/glx/glxdricommon.c
+--- a/glx/glxdricommon.c
++++ b/glx/glxdricommon.c
+@@ -209,6 +209,4 @@
+     return head.next;
+ }
+ 
+-static const char dri_driver_path[] = DRI_DRIVER_PATH;
+-
+ void *
+ glxProbeDriver(const char *driverName,
+diff --git a/os/utils.c b/os/utils.c
+index 13d3b3f..ff97c86 100644
+--- a/os/utils.c
++++ b/os/utils.c
+@@ -139,6 +139,7 @@ Bool noDPMSExtension = FALSE;
+ #ifdef GLXEXT
+ Bool noGlxExtension = FALSE;
+ Bool noGlxVisualInit = FALSE;
++extern int GlxProcessArguments(int argc, char *argv[], int i);
+ #endif
+ #ifdef SCREENSAVER
+ Bool noScreenSaverExtension = FALSE;
+@@ -704,6 +705,14 @@ ProcessCommandLine(int argc, char *argv[])
+             else
+                 UseMsg();
+         }
++#ifdef GLXEXT
++	       else if ((skip = GlxProcessArguments(argc,argv,i)) != 0) {
++	           if (skip > 0)
++		             i += skip - 1;
++	           else
++		             UseMsg();
++	       }
++#endif
+ #ifdef RLIMIT_DATA
+         else if (strcmp(argv[i], "-ld") == 0) {
+             if (++i < argc) {
+-- 
+1.7.3.2
+

--- a/contrib/packages/rpm/el5/SOURCES/tigervnc14-Add-xkbcompdir-param.patch
+++ b/contrib/packages/rpm/el5/SOURCES/tigervnc14-Add-xkbcompdir-param.patch
@@ -1,0 +1,46 @@
+From 5e6e99eaef3ca346c78a3e520ed58ec8b8100b41 Mon Sep 17 00:00:00 2001
+From: Adam Tkac <atkac@redhat.com>
+Date: Thu, 2 Sep 2010 17:24:38 +0200
+Subject: [PATCH] Add -xkbcompdir parameter to modify "xkbcomp" path from commandline.
+
+Signed-off-by: Adam Tkac <atkac@redhat.com>
+---
+ xkb/xkbInit.c |   21 +++++++++++++++++++++
+ 1 files changed, 21 insertions(+), 0 deletions(-)
+
+diff --git a/xkb/xkbInit.c b/xkb/xkbInit.c
+index fbf8f14..29fb33e 100644
+--- a/xkb/xkbInit.c
++++ b/xkb/xkbInit.c
+@@ -742,7 +742,28 @@ XkbProcessArguments(int argc,char *argv[],int i)
+             }
+         }
+         return j;
++    } else if (strncmp(argv[i], "-xkbcompdir", 11)==0) {
++	if (++i < argc) {
++#if !defined(WIN32) && !defined(__CYGWIN__)
++            if (getuid() != geteuid()) {
++                LogMessage(X_WARNING, "-xkbdir is not available for setuid X servers\n");
++                return -1;
++            } else
++#endif
++	    {
++		if (strlen(argv[i]) < PATH_MAX) {
++		    XkbBinDirectory = argv[i];
++		    return 2;
++		} else {
++		    LogMessage(X_ERROR, "-xkbcompdir pathname too long\n");
++		    return -1;
++		}
++	    }
++	} else {
++	    return -1;
++	}
+     }
++
+     if ((strcmp(argv[i], "-ardelay") == 0) || (strcmp(argv[i], "-ar1") == 0)) { /* -ardelay int */
+         if (++i >= argc)
+             UseMsg();
+-- 
+1.7.2.3
+


### PR DESCRIPTION
Build with rpath link so that Xvnc finds our libGL even if
it's not installed in "/".  Also applied dridir and xkbcompdir
patches so that the correct DRI driver gets loaded.