### PR TITLE
Allow X clients to change sharing and security options.

### DIFF
--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -51,6 +51,7 @@ static int vncErrorBase = 0;
 static int vncEventBase = 0;
 
 int vncNoClipboard = 0;
+int vncTrustXClient = 0;
 
 static char* clientCutText = NULL;
 static int clientCutTextLen = 0;
@@ -188,6 +189,17 @@ static int ProcVncExtSetParam(ClientPtr client)
    */
   if (strncasecmp(param, "desktop", 7) != 0 &&
       strncasecmp(param, "AcceptPointerEvents", 19) != 0 &&
+      (!vncTrustXClient || strncasecmp(param, "AlwaysShared", 12) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "NeverShared", 11) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "DisconnectClients", 17) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "SecurityTypes", 13) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "PlainUsers", 10) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "PasswordFile", 12) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "RFBAuth", 7) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "Password", 8) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "MaxDisconnectionTime", 20) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "MaxConnectionTime", 17) != 0) &&
+      (!vncTrustXClient || strncasecmp(param, "MaxIdleTime", 11) != 0) &&
       (vncNoClipboard || strncasecmp(param, "SendCutText", 11) != 0) &&
       (vncNoClipboard || strncasecmp(param, "AcceptCutText", 13) != 0))
     goto deny;

--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -208,7 +208,7 @@ static int ProcVncExtSetParam(ClientPtr client)
   rep.success = 1;
 
   // Send DesktopName update if desktop name has been changed
-  if (strncasecmp(param, "desktop", 7) != 0)
+  if (strncasecmp(param, "desktop", 7) == 0)
     vncUpdateDesktopName();
 
 deny:

--- a/unix/xserver/hw/vnc/vncExtInit.h
+++ b/unix/xserver/hw/vnc/vncExtInit.h
@@ -36,6 +36,7 @@ extern "C" {
 
 // vncExt.c
 extern int vncNoClipboard;
+extern int vncTrustXClient;
 
 int vncAddExtension(void);
 

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -314,6 +314,7 @@ void ddxUseMsg(void)
     ErrorF("-pixelformat fmt       set pixel format (rgbNNN or bgrNNN)\n");
     ErrorF("-inetd                 has been launched from inetd\n");
     ErrorF("-noclipboard           disable clipboard settings modification via vncconfig utility\n");
+    ErrorF("-trustxclient          allow vncconfig utility to change sharing and security options\n");
     ErrorF("-verbose [n]           verbose startup messages\n");
     ErrorF("-quiet                 minimal startup messages\n");
     ErrorF("-version               show the server version\n");
@@ -596,6 +597,11 @@ ddxProcessArgument(int argc, char *argv[], int i)
 
     if (strcmp(argv[i], "-noclipboard") == 0) {
 	vncNoClipboard = 1;
+	return 1;
+    }
+
+    if (strcmp(argv[i], "-trustxclient") == 0) {
+	vncTrustXClient = 1;
 	return 1;
     }
 


### PR DESCRIPTION
This is meant more like proof-of-concept or suggestion rather than final implementation.

The VNC extension allows X clients (vncconfig for example) to read and change the VNC parameters. But most of the parameters can not be actually changed because of possible security problems. I would like to allow changing of some of the parameters if enabled via extra parameter.

Use case: I am working on a setup where Xvnc is spawned with login screen from display manager and allows single client without any authentication. After some user logs into a session, he could optionally use some tool inside the session to set up security and then allow additional clients to connect.

The list of the allowed parameters is getting bit long and ugly, maybe the `VoidParameter` class could have some extra property telling by what means it can be changed?