### PR TITLE
Don't exit completely if single viewer declines server cert

### DIFF
--- a/java/com/tigervnc/rdr/WarningException.java
+++ b/java/com/tigervnc/rdr/WarningException.java
@@ -1,0 +1,30 @@
+/* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
+ * Copyright (C) 2011 Brian P. Hinz
+ * Copyright (C) 2012 D. R. Commander.  All Rights Reserved.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ * USA.
+ */
+
+package com.tigervnc.rdr;
+
+/* We use this to communicate exceptions that are generally the result of user
+   actions. */
+
+public class WarningException extends RuntimeException {
+  public WarningException(String s) {
+    super(s);
+  }
+}

--- a/java/com/tigervnc/rfb/CSecurityTLS.java
+++ b/java/com/tigervnc/rfb/CSecurityTLS.java
@@ -3,7 +3,8 @@
  * Copyright (C) 2005 Martin Koegler
  * Copyright (C) 2010 m-privacy GmbH
  * Copyright (C) 2010 TigerVNC Team
- * Copyright (C) 2011-2012,2015 Brian P. Hinz
+ * Copyright (C) 2011-2015 Brian P. Hinz
+ * Copyright (C) 2015 D. R. Commander.  All Rights Reserved.
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -138,7 +139,10 @@ public class CSecurityTLS extends CSecurity {
       manager = new SSLEngineManager(engine, is, os);
       manager.doHandshake();
     } catch(java.lang.Exception e) {
-      throw new Exception(e.getMessage());
+      if (e.getMessage().equals("X.509 certificate not trusted"))
+        throw new WarningException(e.getMessage());
+      else
+        throw new SystemException(e.toString());
     }
 
     //checkSession();
@@ -345,10 +349,10 @@ public class CSecurityTLS extends CSecurity {
               }
             }
           } else {
-            System.exit(1);
+            throw new WarningException("X.509 certificate not trusted");
           }
         } else {
-          throw new Exception(e.getCause().getMessage());
+          throw new SystemException(e.getCause().getMessage());
         }
       } catch (java.lang.Exception e) {
         throw new Exception(e.getCause().getMessage());


### PR DESCRIPTION
Prevents viewer from exiting completely just because user
declined to trust the server certificate for a single connection.
Copied from TurboVNC.