### PR TITLE
Ensure that libjpeg-turbo headers are included

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,8 @@ if(NOT FOUND_LIBJPEG_TURBO)
   message(STATUS "WARNING: You are not using libjpeg-turbo. Performance will suffer.")
 endif()
 
+include_directories(${JPEG_INCLUDE_DIR})
+
 option(BUILD_JAVA "Build Java version of the TigerVNC Viewer" FALSE)
 if(BUILD_JAVA)
   add_subdirectory(java)


### PR DESCRIPTION
On some systems, the build was picking up jpeglib.h from the system
include directories, and if the system's version of libjpeg[-turbo] used
a different API/ABI version than the one specified in JPEG_LIBRARY, this
led to a "Wrong JPEG library version" error at run time.