### PR TITLE
Allow static linking against only the GCC libs

### DIFF
--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -10,8 +10,13 @@
 option(BUILD_STATIC
     "Link statically against most libraries, if possible" OFF)
 
+option(BUILD_STATIC_GCC
+    "Link statically against only libgcc and libstdc++" OFF)
+
 if(BUILD_STATIC)
   message(STATUS "Attempting to link static binaries...")
+
+  set(BUILD_STATIC_GCC 1)
 
   set(JPEG_LIBRARIES "-Wl,-Bstatic -ljpeg -Wl,-Bdynamic")
 
@@ -105,7 +110,9 @@ if(BUILD_STATIC)
       set(X11_Xdamage_LIB "-Wl,-Bstatic -lXdamage -Wl,-Bdynamic")
     endif()
   endif()
+endif()
 
+if(BUILD_STATIC_GCC)
   # This ensures that we don't depend on libstdc++ or libgcc_s
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -nodefaultlibs")
   set(STATIC_BASE_LIBRARIES "-Wl,-Bstatic -lstdc++ -Wl,-Bdynamic")
@@ -122,5 +129,4 @@ if(BUILD_STATIC)
     set(STATIC_BASE_LIBRARIES "${STATIC_BASE_LIBRARIES} -lgcc -lgcc_eh -lc")
   endif()
   set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE} ${STATIC_BASE_LIBRARIES}")
-
 endif()


### PR DESCRIPTION
BUILD_STATIC was originally intended as a way of preventing dependencies
on libgcc and libstdc++ in the TigerVNC binaries, thus allowing the
binaries to be built on an older Linux distro and then run on any newer
Linux distro.  In practice, the X11 libraries and most system libraries
tend to be forward compatible, so really the only libraries that need to
be statically linked are libjpeg-turbo (easy, since libjpeg-turbo
supplies static libs in its packages) and GnuTLS (requires building
GnuTLS from source.)

Over the years, BUILD_STATIC has been changed such that it attempts to
link TigerVNC statically with everything, but this is a very difficult
(and usually unnecessary) build environment to set up.  This patch adds
a new CMake variable (BUILD_STATIC_GCC) that behaves like BUILD_STATIC
was originally intended to behave.  BUILD_STATIC now implies
BUILD_STATIC_GCC.