### PR TITLE
Allow BUILD_TIMESTAMP to be set statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,9 @@ if(MSVC)
   message(FATAL_ERROR "TigerVNC cannot be built with Visual Studio.  Please use MinGW")
 endif()
 
-set(BUILD_TIMESTAMP "")
-execute_process(COMMAND "date" "+%Y-%m-%d %H:%M" OUTPUT_VARIABLE BUILD_TIMESTAMP)
-
 if(NOT BUILD_TIMESTAMP)
   set(BUILD_TIMESTAMP "")
-else()
+  execute_process(COMMAND "date" "+%Y-%m-%d %H:%M" OUTPUT_VARIABLE BUILD_TIMESTAMP)
   string(REGEX REPLACE "\n" "" BUILD_TIMESTAMP ${BUILD_TIMESTAMP})
 endif()
 
@@ -57,6 +54,7 @@ endif()
 message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
 message(STATUS "VERSION = ${VERSION}")
+message(STATUS "BUILD_TIMESTAMP = ${BUILD_TIMESTAMP}")
 add_definitions(-DBUILD_TIMESTAMP="${BUILD_TIMESTAMP}")
 
 # We want to keep our asserts even in release builds so remove NDEBUG


### PR DESCRIPTION
Otherwise, every time CMakeLists.txt changes, the entire source tree
must be rebuilt, which is a productivity killer for people who are
trying to work with this code.  I'm assuming that there is a good reason
why BUILD_TIMESTAMP is being set dynamically every time CMakeLists.txt
changes, so this patch retains that behavior as the default while
allowing developers to override it.