### PR TITLE
Xvnc.man: remove -i option

### DIFF
--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -48,7 +48,7 @@ next three green, and the least significant three represent red), the default
 for depth 16 is RGB565 and for depth 24 is RGB888.
 .
 .TP
-.B \-interface \fIIP address\fP or \-i \fIIP address\fP
+.B \-interface \fIIP address\fP
 Listen on interface. By default Xvnc listens on all available interfaces.
 .
 .TP


### PR DESCRIPTION
Xvnc does not understand -i as an alias to -interface anymore (since commit f8e3b34c69)
but it is still listed in the man page.

Fix man accordingly.