### PR TITLE
Fix inverted logic in ProcVncExtSetParam.

### DIFF
--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -196,7 +196,7 @@ static int ProcVncExtSetParam(ClientPtr client)
   rep.success = 1;
 
   // Send DesktopName update if desktop name has been changed
-  if (strncasecmp(param, "desktop", 7) != 0)
+  if (strncasecmp(param, "desktop", 7) == 0)
     vncUpdateDesktopName();
 
 deny:


### PR DESCRIPTION
Using vncconfig to set the desktop parameter doesn't propagate the change because the check for "desktop" is inverted.