### PR TITLE
Fix relative PATH to SRCDIR

### DIFF
--- a/contrib/xorg/build-xorg
+++ b/contrib/xorg/build-xorg
@@ -12,7 +12,7 @@ PARALLEL_MAKE=0
 XORG_VERSION=7.5
 XONLY=0
 CFGHOST=
-SRCDIR=`dirname $0`/..
+SRCDIR=`dirname $0`/../..
 
 modules="dri2proto \
     libpthread-stubs \


### PR DESCRIPTION
The `build-xorg` script had the wrong relative directory:

    %: mkdir build
    %: cd build
    %: sh ../contrib/xorg/build-xorg init
    ~/proj/tigervnc/contrib ~/proj/tigervnc/build
    *** Using TigerVNC source tree at /home/shr/proj/tigervnc/contrib ***
    ~/proj/tigervnc/build
    ~/proj/tigervnc/build/xorg ~/proj/tigervnc/build
    ../contrib/xorg/build-xorg: line 89: /home/shr/proj/tigervnc/contrib/contrib/xorg/download-xorg-7.5: No such file or directory