### PR TITLE
Add AllowOverride parameter.

### DIFF
--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -300,6 +300,21 @@ Key affected by NumLock often require a fake Shift to be inserted in order
 for the correct symbol to be generated. Turning on this option avoids these
 extra fake Shift events but may result in a slightly different symbol
 (e.g. a Return instead of a keypad Enter).
+.
+.TP
+.B \-AllowOverride
+Comma separated list of parameters that can be modified using VNC extension.
+Parameters can be modified for example using \fBvncconfig\fP(1) program from
+inside a running session.
+
+Allowing override of parameters such as \fBPAMService\fP or \fBPasswordFile\fP
+can negatively impact security if Xvnc runs under different user than the
+programs allowed to override the parameters.
+
+When \fBNoClipboard\fP parameter is set, allowing override of \fBSendCutText\fP
+and \fBAcceptCutText\fP has no effect.
+
+Default is \fBdesktop,AcceptPointerEvents,SendCutText,AcceptCutText\fP.
 
 .SH USAGE WITH INETD
 By configuring the \fBinetd\fP(1) service appropriately, Xvnc can be launched

--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -182,17 +182,16 @@ static int ProcVncExtSetParam(ClientPtr client)
   rep.sequenceNumber = client->sequence;
 
   /*
-   * Allow to change only certain parameters.
-   * Changing other parameters (for example PAM service name)
-   * could have negative security impact.
+   * Prevent change of clipboard related parameters if clipboard is disabled.
    */
-  if (strncasecmp(param, "desktop", 7) != 0 &&
-      strncasecmp(param, "AcceptPointerEvents", 19) != 0 &&
-      (vncNoClipboard || strncasecmp(param, "SendCutText", 11) != 0) &&
-      (vncNoClipboard || strncasecmp(param, "AcceptCutText", 13) != 0))
+  if (vncNoClipboard &&
+      (strncasecmp(param, "SendCutText", 11) == 0 ||
+       strncasecmp(param, "AcceptCutText", 13) == 0))
     goto deny;
 
-  vncSetParamSimple(param);
+  if (!vncOverrideParam(param))
+    goto deny;
+
   rep.success = 1;
 
   // Send DesktopName update if desktop name has been changed

--- a/unix/xserver/hw/vnc/vncExtInit.h
+++ b/unix/xserver/hw/vnc/vncExtInit.h
@@ -90,6 +90,8 @@ void vncPreScreenResize(int scrIdx);
 void vncPostScreenResize(int scrIdx, int success, int width, int height);
 void vncRefreshScreenLayout(int scrIdx);
 
+int vncOverrideParam(const char *nameAndValue);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Allows to specify which configuration parameters can be modified on runtime. `ProcVncExtSetParam` now calls `vncOverrideParam` from `vncExtInit.cc` instead of directly calling `vncSetParamSimple`. `vncOverrideParam` verifies the parameter name against list of allowed parameters.

This is alternative for pull request #195.