### PR TITLE
Fix mistake in TightEncoder::setCompressLevel.

### DIFF
--- a/common/rfb/TightEncoder.cxx
+++ b/common/rfb/TightEncoder.cxx
@@ -77,7 +77,7 @@ void TightEncoder::setCompressLevel(int level)
     level = 2;
 
   idxZlibLevel = conf[level].idxZlibLevel;
-  monoZlibLevel = conf[level].idxZlibLevel;
+  monoZlibLevel = conf[level].monoZlibLevel;
   rawZlibLevel = conf[level].rawZlibLevel;
 }
 


### PR DESCRIPTION
Hi, this looks like a copy-paste mistake. I am guessing it should be this way instead.