### PR TITLE
Fix ptr usage in vncconfig

### DIFF
--- a/unix/vncconfig/vncExt.c
+++ b/unix/vncconfig/vncExt.c
@@ -146,7 +146,7 @@ char* XVncExtGetParamDesc(Display* dpy, const char* param)
   }
   if (rep.success) {
     desc = (char*)Xmalloc(rep.descLen+1);
-    if (!*desc) {
+    if (!desc) {
       _XEatData(dpy, (rep.descLen+1)&~1);
       return False;
     }


### PR DESCRIPTION
Hi all!
The proposed change fixes at least two issues:
1) NULL ptr dereference in a case of Xmalloc() failure (i.e. desc is NULL).
2) Wrong assumption that memory allocation failed in case when Xmalloc() returns ptr to memory with the first zero byte.
Case (2) may lead (and this is actually the exact reason this issue was investigated) to unavailability to get parameter's description (e.g. vncconfig -desc AvoidShiftNumLock).

Best regards.