### PR TITLE
Properly name filehandle based on context of code

### DIFF
--- a/unix/vncserver
+++ b/unix/vncserver
@@ -362,9 +362,9 @@ if (! $skipxstartup) {
 
 if (!(-e "$vncUserDir/config")) {
     warn "Creating default config $vncUserDir/config\n";
-    open(XSTARTUP, ">$vncUserDir/config");
-    print XSTARTUP $defaultConfig;
-    close(XSTARTUP);
+    open(VNCUSERCONFIG, ">$vncUserDir/config");
+    print VNCUSERCONFIG $defaultConfig;
+    close(VNCUSERCONFIG);
     chmod 0644, "$vncUserDir/config";
 }
 


### PR DESCRIPTION
Old harmless copy/paste from code above left code confusing as it was reusing the filehandle "XSTARTUP" to write out $vncUserDir/config. This new small change uses a more topical filehandle name for the task at hand.