### PR TITLE
Check CMake version for MinGW RC file handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,9 @@ else()
   message(STATUS "32-bit build")
 endif()
 
-# CMake doesn't properly support resource compilation with MinGW.  Boo!
-if(MINGW)
+# Versions of CMake before 2.8.7 do not properly support resource compilation
+# with MinGW.  Boo!
+if(MINGW AND "${CMAKE_VERSION}" VERSION_LESS "2.8.7")
   if(NOT DEFINED RC)
     set(CMAKE_RC_COMPILER_INIT windres)
   else()


### PR DESCRIPTION
CMake now does work with MinGW to build RC files

I've only tested this with CMake 3.5. For CMake 3.4 an up <INCLUDES> needs to be added to the RC compile line, however that would break CMake before 3.4. This fixes that as it looks to me like MinGW RC files with CMake was fixed in CMake 2.8.7