### PR TITLE
Do not die on no mcookie

### DIFF
--- a/unix/vncserver
+++ b/unix/vncserver
@@ -293,8 +293,24 @@ $desktopLog = "$vncUserDir/$host:$displayNumber.log";
 unlink($desktopLog);
 
 # Make an X server cookie and set up the Xauthority file
-
+# mcookie is a part of util-linux, usually only GNU/Linux systems have it.
 $cookie = `mcookie`;
+# Fallback for non GNU/Linux OS - use /dev/urandom on systems that have it,
+# otherwise use perl's random number generator, seeded with the sum
+# of the current time, our PID and part of the encrypted form of the password.
+if ($cookie eq "" && open(URANDOM, '<', '/dev/urandom')) {
+  my $randata;
+  if (sysread(URANDOM, $randata, 16) == 16) {
+    $cookie = unpack 'h*', $randata;
+  }
+  close(URANDOM);
+}
+if ($cookie eq "") {
+  srand(time+$$+unpack("L",`cat $vncUserDir/passwd`));
+  for (1..16) {
+    $cookie .= sprintf("%02x", int(rand(256)) % 256);
+  }
+}
 
 open(XAUTH, "|xauth -f $xauthorityFile source -");
 print XAUTH "add $host:$displayNumber . $cookie\n";
@@ -818,7 +834,7 @@ sub SanityCheck
     #
 
  cmd:
-    foreach $cmd ("uname","mcookie","xauth") {
+    foreach $cmd ("uname","xauth") {
 	for (split(/:/,$ENV{PATH})) {
 	    if (-x "$_/$cmd") {
 		next cmd;

--- a/unix/vncserver
+++ b/unix/vncserver
@@ -47,7 +47,7 @@ $geometry = "1024x768";
 $vncJavaFiles = (((-d "$vncClasses") && "$vncClasses") ||
                  ((-d "/usr/share/vnc/classes") && "/usr/share/vnc/classes") ||
                  ((-d "/usr/local/vnc/classes") && "/usr/local/vnc/classes"));
-                 
+
 $vncUserDir = "$ENV{HOME}/.vnc";
 $vncUserConfig = "$vncUserDir/config";
 
@@ -178,7 +178,7 @@ if (!(-e $vncUserDir)) {
 	die "$prog: Could not create $vncUserDir.\n";
     }
 }
-    
+
 # Find display number.
 if ((@ARGV > 0) && ($ARGV[0] =~ /^:(\d+)$/)) {
     $displayNumber = $1;
@@ -329,7 +329,7 @@ system("$cmd & echo \$! >$pidFile");
 
 # Give Xvnc a chance to start up
 
-sleep(3); 
+sleep(3);
 if ($fontPath ne $defFontPath) {
     unless (kill 0, `cat $pidFile`) {
         if ($fpArgSpecified) {
@@ -499,7 +499,7 @@ sub GetDisplayNumber
 	    return $n+0; # Bruce Mah's workaround for bug in perl 5.005_02
 	}
     }
-    
+
     die "$prog: no free display number on $host.\n";
 }
 
@@ -743,7 +743,7 @@ sub Kill
     } else {
 	warn "Xvnc process ID $pid already killed\n";
 	$opt{'-kill'} =~ s/://;
-    
+
 	if (-e "/tmp/.X11-unix/X$opt{'-kill'}") {
 	    print "Xvnc did not appear to shut down cleanly.";
 	    print " Removing /tmp/.X11-unix/X$opt{'-kill'}\n";


### PR DESCRIPTION
for operating systems other than GNU/Linux.

mcookie is a part of util-linux. Usually only GNU/Linux systems have it.
Do not die even if mcookie is not found. Try to generate cookie from
/dev/random.

I thought generating cookie with pure perl. For example, using
Crypt::Random::Source but it requires additional dependency on another
perl module.  In order to keep it simple, I chose shell one-liner.
