### PR TITLE
MacOS package: Added NSHighResolutionCapable tag to Info.plist

### DIFF
--- a/release/Info.plist.in
+++ b/release/Info.plist.in
@@ -6,6 +6,8 @@
 	<string>English</string>
 	<key>CFBundleExecutable</key>
 	<string>TigerVNC Viewer</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
 	<key>CFBundleGetInfoString</key>
 	<string>@VERSION@, Copyright © 1998-2011 [many holders]</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
With the flag the application will start enable the high resolution
display. I tested this on a Macbook Pro with a High Resolution Display.
The fonts are better to read.

Here you can see the difference in font rendering on my Macbook:

![highres-display](https://cloud.githubusercontent.com/assets/1280457/19693804/2c2c863e-9add-11e6-97b5-4a15438b3dab.JPG)
