### PR TITLE
Separate 'Grab Keys' from 'Fullscreen'

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -472,11 +472,10 @@ void DesktopWindow::fullscreen_on()
 }
 
 void DesktopWindow::toggleGrabKeys() {
-  this->grabActive = !(this->grabActive);
   if(this->grabActive)
-    grabKeyboard();
-  else
     ungrabKeyboard();
+  else
+    grabKeyboard();
 }
 
 void DesktopWindow::grabKeyboard()

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -59,7 +59,7 @@ DesktopWindow::DesktopWindow(int w, int h, const char *name,
                              const rfb::PixelFormat& serverPF,
                              CConn* cc_)
   : Fl_Window(w, h), cc(cc_), firstUpdate(true),
-    delayedFullscreen(false), delayedDesktopSize(false)
+    delayedFullscreen(false), delayedDesktopSize(false), grab_keys(false)
 {
   scroll = new Fl_Scroll(0, 0, w, h);
   scroll->color(FL_BLACK);
@@ -387,6 +387,10 @@ int DesktopWindow::handle(int event)
 }
 
 
+bool DesktopWindow::grab_active() {
+  return grab_keys;
+}
+
 int DesktopWindow::fltkHandle(int event, Fl_Window *win)
 {
   int ret;
@@ -469,8 +473,14 @@ void DesktopWindow::fullscreen_on()
   fullscreen();
 }
 
+void DesktopWindow::toggle_grab_keys() {
+  this->grab_keys = !(this->grab_keys);
+  grabKeyboard();
+}
+
 void DesktopWindow::grabKeyboard()
 {
+  if(!(this->grab_keys)) { ungrabKeyboard(); return; }
   // Grabbing the keyboard is fairly safe as FLTK reroutes events to the
   // correct widget regardless of which low level window got the system
   // event.

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -59,7 +59,7 @@ DesktopWindow::DesktopWindow(int w, int h, const char *name,
                              const rfb::PixelFormat& serverPF,
                              CConn* cc_)
   : Fl_Window(w, h), cc(cc_), firstUpdate(true),
-    delayedFullscreen(false), delayedDesktopSize(false), grab_keys(false)
+    delayedFullscreen(false), delayedDesktopSize(false), grabActive(false)
 {
   scroll = new Fl_Scroll(0, 0, w, h);
   scroll->color(FL_BLACK);
@@ -359,13 +359,12 @@ int DesktopWindow::handle(int event)
     if (!fullscreenSystemKeys)
       break;
 
-    if (fullscreen_active())
+    if (isGrabActive())
       grabKeyboard();
     else
       ungrabKeyboard();
 
     break;
-
   case FL_ENTER:
   case FL_LEAVE:
   case FL_DRAG:
@@ -387,8 +386,8 @@ int DesktopWindow::handle(int event)
 }
 
 
-bool DesktopWindow::grab_active() {
-  return grab_keys;
+bool DesktopWindow::isGrabActive() {
+  return grabActive;
 }
 
 int DesktopWindow::fltkHandle(int event, Fl_Window *win)
@@ -403,7 +402,6 @@ int DesktopWindow::fltkHandle(int event, Fl_Window *win)
   // need. Fortunately we can grab them here...
 
   DesktopWindow *dw = dynamic_cast<DesktopWindow*>(win);
-
   if (dw && fullscreenSystemKeys) {
     switch (event) {
     case FL_FOCUS:
@@ -412,7 +410,7 @@ int DesktopWindow::fltkHandle(int event, Fl_Window *win)
       //        a) Fl::grab(0) on X11 will release the keyboard grab for us.
       //        b) Gaining focus on the system level causes FLTK to switch
       //           window level on OS X.
-      if (dw->fullscreen_active())
+      if (dw->isGrabActive())
         dw->grabKeyboard();
       break;
 
@@ -473,19 +471,23 @@ void DesktopWindow::fullscreen_on()
   fullscreen();
 }
 
-void DesktopWindow::toggle_grab_keys() {
-  this->grab_keys = !(this->grab_keys);
-  grabKeyboard();
+void DesktopWindow::toggleGrabKeys() {
+  this->grabActive = !(this->grabActive);
+  if(this->grabActive)
+    grabKeyboard();
+  else
+    ungrabKeyboard();
 }
 
 void DesktopWindow::grabKeyboard()
 {
-  if(!(this->grab_keys)) { ungrabKeyboard(); return; }
   // Grabbing the keyboard is fairly safe as FLTK reroutes events to the
   // correct widget regardless of which low level window got the system
   // event.
 
   // FIXME: Push this stuff into FLTK.
+
+  this->grabActive = true;
 
 #if defined(WIN32)
   int ret;
@@ -531,6 +533,7 @@ void DesktopWindow::grabKeyboard()
 void DesktopWindow::ungrabKeyboard()
 {
   Fl::remove_timeout(handleGrab, this);
+  this->grabActive = false;
 
 #if defined(WIN32)
   win32_disable_lowlevel_keyboard(fl_xid(this));
@@ -555,7 +558,7 @@ void DesktopWindow::handleGrab(void *data)
 
   if (!fullscreenSystemKeys)
     return;
-  if (!self->fullscreen_active())
+  if (!self->isGrabActive())
     return;
 
   self->grabKeyboard();

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -63,12 +63,14 @@ public:
   int handle(int event);
 
   void fullscreen_on();
+  void grabKeyboard();
+  void ungrabKeyboard();
+  void toggle_grab_keys();
+  bool grab_active();
 
 private:
   static int fltkHandle(int event, Fl_Window *win);
 
-  void grabKeyboard();
-  void ungrabKeyboard();
 
   static void handleGrab(void *data);
 
@@ -96,6 +98,7 @@ private:
   bool firstUpdate;
   bool delayedFullscreen;
   bool delayedDesktopSize;
+  bool grab_keys;
 };
 
 #endif

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -65,8 +65,8 @@ public:
   void fullscreen_on();
   void grabKeyboard();
   void ungrabKeyboard();
-  void toggle_grab_keys();
-  bool grab_active();
+  void toggleGrabKeys();
+  bool isGrabActive();
 
 private:
   static int fltkHandle(int event, Fl_Window *win);
@@ -98,7 +98,7 @@ private:
   bool firstUpdate;
   bool delayedFullscreen;
   bool delayedDesktopSize;
-  bool grab_keys;
+  bool grabActive;
 };
 
 #endif

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -96,7 +96,7 @@ static rfb::LogWriter vlog("Viewport");
 
 enum { ID_EXIT, ID_FULLSCREEN, ID_MINIMIZE, ID_RESIZE,
        ID_CTRL, ID_ALT, ID_MENUKEY, ID_CTRLALTDEL,
-       ID_REFRESH, ID_OPTIONS, ID_INFO, ID_ABOUT, ID_DISMISS };
+       ID_REFRESH, ID_OPTIONS, ID_INFO, ID_ABOUT, ID_DISMISS, ID_GRAB };
 
 // Fake key presses use this value and above
 static const int fakeKeyBase = 0x200;
@@ -753,6 +753,9 @@ void Viewport::initContextMenu()
   fltk_menu_add(contextMenu, p_("ContextMenu|", "&Full screen"),
                 0, NULL, (void*)ID_FULLSCREEN,
                 FL_MENU_TOGGLE | (window()->fullscreen_active()?FL_MENU_VALUE:0));
+  fltk_menu_add(contextMenu, p_("ContextMenu|", "&Grab keys"),
+                0, NULL, (void*)ID_GRAB,
+                FL_MENU_TOGGLE | (((DesktopWindow*)window())->grab_active()?FL_MENU_VALUE:0));
   fltk_menu_add(contextMenu, p_("ContextMenu|", "Minimi&ze"),
                 0, NULL, (void*)ID_MINIMIZE, 0);
   fltk_menu_add(contextMenu, p_("ContextMenu|", "Resize &window to session"),
@@ -828,6 +831,9 @@ void Viewport::popupContextMenu()
       window()->fullscreen_off();
     else
       ((DesktopWindow*)window())->fullscreen_on();
+    break;
+  case ID_GRAB:
+    ((DesktopWindow*)window())->toggle_grab_keys();
     break;
   case ID_MINIMIZE:
     window()->iconize();

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -755,7 +755,7 @@ void Viewport::initContextMenu()
                 FL_MENU_TOGGLE | (window()->fullscreen_active()?FL_MENU_VALUE:0));
   fltk_menu_add(contextMenu, p_("ContextMenu|", "&Grab keys"),
                 0, NULL, (void*)ID_GRAB,
-                FL_MENU_TOGGLE | (((DesktopWindow*)window())->grab_active()?FL_MENU_VALUE:0));
+                FL_MENU_TOGGLE | (((DesktopWindow*)window())->isGrabActive()?FL_MENU_VALUE:0));
   fltk_menu_add(contextMenu, p_("ContextMenu|", "Minimi&ze"),
                 0, NULL, (void*)ID_MINIMIZE, 0);
   fltk_menu_add(contextMenu, p_("ContextMenu|", "Resize &window to session"),
@@ -833,7 +833,7 @@ void Viewport::popupContextMenu()
       ((DesktopWindow*)window())->fullscreen_on();
     break;
   case ID_GRAB:
-    ((DesktopWindow*)window())->toggle_grab_keys();
+    ((DesktopWindow*)window())->toggleGrabKeys();
     break;
   case ID_MINIMIZE:
     window()->iconize();


### PR DESCRIPTION
Currently, vncviewer will intercept special key combinations such as "Alt+Tab" and send them to the remote host if and only if vncviewer is in "Fullscreen" mode. This patch adds an option to the F8 menu that allows users to select "Grab Keys" mode separately from "Fullscreen" mode.