### PR TITLE
Fix buffer overflow in ModifiablePixelBuffer::fillRect.

### DIFF
--- a/common/rfb/PixelBuffer.cxx
+++ b/common/rfb/PixelBuffer.cxx
@@ -101,15 +101,26 @@ void ModifiablePixelBuffer::fillRect(const Rect& r, const void* pix)
   int stride;
   U8 *buf;
   int w, h, b;
+  Rect drect;
 
-  w = r.width();
-  h = r.height();
+  drect = r;
+  if (!drect.enclosed_by(getRect())) {
+    vlog.error("Destination rect %dx%d at %d,%d exceeds framebuffer %dx%d",
+               drect.width(), drect.height(), drect.tl.x, drect.tl.y, width_, height_);
+    drect = drect.intersect(getRect());
+  }
+
+  if (drect.is_empty())
+    return;
+
+  w = drect.width();
+  h = drect.height();
   b = format.bpp/8;
 
   if (h == 0)
     return;
 
-  buf = getBufferRW(r, &stride);
+  buf = getBufferRW(drect, &stride);
 
   if (b == 1) {
     while (h--) {
@@ -136,7 +147,7 @@ void ModifiablePixelBuffer::fillRect(const Rect& r, const void* pix)
     }
   }
 
-  commitBufferRW(r);
+  commitBufferRW(drect);
 }
 
 void ModifiablePixelBuffer::imageRect(const Rect& r,


### PR DESCRIPTION
LibVNC had security bug and the reproducer can trigger similar kind of security bug in vncviewer as well:
https://github.com/LibVNC/libvncserver/pull/137
(Using the `send_copyrect_crash` function, which has bit misleading name because the issue is in RRE and filling rectangles, not copying.)

Malicious VNC server can send RRE message with subrectangle which is out of the framebuffer rectangle. Vncviewer then fills this rectangle and writes into random memory.

I wasn't sure at what level should the test whether the subrectangle is inside framebuffer be. I've added it to `PixelBuffer::fillRect` inspired by the checks inside `PixelBuffer::copyRect`.