### PR TITLE
Workaround for shared memory leakage.

### DIFF
--- a/vncviewer/X11PixelBuffer.cxx
+++ b/vncviewer/X11PixelBuffer.cxx
@@ -187,8 +187,9 @@ int X11PixelBuffer::setupShm()
     goto free_xim;
 
   shminfo->shmaddr = xim->data = (char*)shmat(shminfo->shmid, 0, 0);
+  shmctl(shminfo->shmid, IPC_RMID, 0); // to avoid memory leakage
   if (shminfo->shmaddr == (char *)-1)
-    goto free_shm;
+    goto free_xim;
 
   shminfo->readOnly = True;
 
@@ -215,9 +216,6 @@ int X11PixelBuffer::setupShm()
 
 free_shmaddr:
   shmdt(shminfo->shmaddr);
-
-free_shm:
-  shmctl(shminfo->shmid, IPC_RMID, 0);
 
 free_xim:
   XDestroyImage(xim);


### PR DESCRIPTION
Description of problem:
   vncviewer creates a shared memory segment for MIT-SHM. It is not removed when vncviewer is killed
   by signal, because PlatformPixelBuffer destructor is never called after CleanupSignalHandler().
Workaround:
   Mark the shared memory as "destroyed" as soon as possible.
   It will be invisible soon after the vncviewer is killed.

See https://bugzilla.redhat.com/show_bug.cgi?id=1358090
