### PR TITLE
Add missing headers

### DIFF
--- a/vncviewer/PlatformPixelBuffer.h
+++ b/vncviewer/PlatformPixelBuffer.h
@@ -20,6 +20,9 @@
 #define __PLATFORMPIXELBUFFER_H__
 
 #if !defined(WIN32) && !defined(__APPLE__)
+#include <X11/Xlib.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
 #include <X11/extensions/XShm.h>
 #endif
 


### PR DESCRIPTION
Encountered this error on Arch when tried to build vncviewer:
<pre>
Scanning dependencies of target vncviewer
[ 82%] Building CXX object vncviewer/CMakeFiles/vncviewer.dir/menukey.cxx.o
[ 82%] Building CXX object vncviewer/CMakeFiles/vncviewer.dir/CConn.cxx.o
In file included from /home/uglym8/tigervnc/vncviewer/PlatformPixelBuffer.h:23:0,
                 from /home/uglym8/tigervnc/vncviewer/CConn.cxx:49:
/usr/include/X11/extensions/XShm.h:41:5: error: ‘Bool’ does not name a type
     Bool send_event;     /* true if this came frome a SendEvent request */
     ^~~~
</pre>

I guess it'd be correct to include additional headers when using XSHM extension (as per man xshm)
