### PR TITLE
Fix int <--> ptr conversion

### DIFF
--- a/unix/xserver/hw/vnc/vncBlockHandler.c
+++ b/unix/xserver/hw/vnc/vncBlockHandler.c
@@ -66,7 +66,7 @@ void vncSetNotifyFd(int fd, int scrIdx, int read, int write)
 {
 #if XORG >= 119
   int mask = (read ? X_NOTIFY_READ : 0) | (write ? X_NOTIFY_WRITE : 0);
-  SetNotifyFd(fd, vncSocketNotify, mask, (void*)scrIdx);
+  SetNotifyFd(fd, vncSocketNotify, mask, (void*)(uintptr_t)scrIdx);
 #else
   struct vncFdEntry* entry;
 
@@ -122,7 +122,7 @@ static void vncSocketNotify(int fd, int xevents, void *data)
 {
   int scrIdx;
 
-  scrIdx = (int)data;
+  scrIdx = (int)(uintptr_t)data;
   vncHandleSocketEvent(fd, scrIdx,
                        xevents & X_NOTIFY_READ,
                        xevents & X_NOTIFY_WRITE);


### PR DESCRIPTION
Encountered this error on Arch when tried to build Xvnc:

<pre>
....  
CC       libvnccommon_la-vncBlockHandler.lo
vncBlockHandler.c: In function ‘vncSetNotifyFd’:
vncBlockHandler.c:69:42: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   SetNotifyFd(fd, vncSocketNotify, mask, (void*)scrIdx);
                                          ^
vncBlockHandler.c: In function ‘vncSocketNotify’:
vncBlockHandler.c:125:12: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
   scrIdx = (int)data;

</pre>

Used this discussion as a quick rationale: http://stackoverflow.com/questions/25381610/cast-int-to-pointer-why-cast-to-long-first-as-in-p-void-42