### PR TITLE
Prevent double free by crafted fences.

### DIFF
--- a/common/rfb/SMsgWriter.cxx
+++ b/common/rfb/SMsgWriter.cxx
@@ -101,7 +101,9 @@ void SMsgWriter::writeFence(rdr::U32 flags, unsigned len, const char data[])
   os->writeU32(flags);
 
   os->writeU8(len);
-  os->writeBytes(data, len);
+
+  if (len > 0)
+    os->writeBytes(data, len);
 
   endMsg();
 }

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -666,6 +666,7 @@ void VNCSConnectionST::fence(rdr::U32 flags, unsigned len, const char data[])
       fenceFlags = flags & (fenceFlagBlockBefore | fenceFlagBlockAfter | fenceFlagSyncNext);
       fenceDataLen = len;
       delete [] fenceData;
+      fenceData = NULL;
       if (len > 0) {
         fenceData = new char[len];
         memcpy(fenceData, data, len);


### PR DESCRIPTION
If client sent fence with some data, followed by fence with no data (length 0), the original fence data were freed, but the pointer kept pointing at them. Sending one more fence would attempt to free them again.

fixes #437 