### PR TITLE
Delete underlying ssecurity in SSecurityVeNCrypt.

### DIFF
--- a/common/rfb/SSecurityVeNCrypt.cxx
+++ b/common/rfb/SSecurityVeNCrypt.cxx
@@ -55,6 +55,8 @@ SSecurityVeNCrypt::SSecurityVeNCrypt(SecurityServer *sec) : security(sec)
 
 SSecurityVeNCrypt::~SSecurityVeNCrypt()
 {
+  delete ssecurity;
+
   if (subTypes) {
     delete [] subTypes;
     subTypes = NULL;


### PR DESCRIPTION
Otherwise it gets leaked which would allow even not authenticated clients to exhaust server memory.