### PR TITLE
macOS performance fix fixes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,10 @@ set(FBPERF_SOURCES
 if(WIN32)
   set(FBPERF_SOURCES ${FBPERF_SOURCES} ../vncviewer/Surface_Win32.cxx)
 elseif(APPLE)
-  set(FBPERF_SOURCES ${FBPERF_SOURCES} ../vncviewer/Surface_OSX.cxx)
+  set(FBPERF_SOURCES
+      ${FBPERF_SOURCES} ../vncviewer/Surface_OSX.cxx
+      ${FBPERF_SOURCES} ../vncviewer/keysym2ucs.c
+      ${FBPERF_SOURCES} ../vncviewer/cocoa.mm)
 else()
   set(FBPERF_SOURCES ${FBPERF_SOURCES} ../vncviewer/Surface_X11.cxx)
 endif()

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -347,10 +347,12 @@ void DesktopWindow::draw()
 
     fl_clip_box(ox, oy, ow, oh, ox, oy, ow, oh);
 
-    if (offscreen)
-      statsGraph->blend(offscreen, ox - X, oy - Y, ox, oy, ow, oh, 204);
-    else
-      statsGraph->blend(ox - X, oy - Y, ox, oy, ow, oh, 204);
+    if ((ow != 0) && (oh != 0)) {
+      if (offscreen)
+        statsGraph->blend(offscreen, ox - X, oy - Y, ox, oy, ow, oh, 204);
+      else
+        statsGraph->blend(ox - X, oy - Y, ox, oy, ow, oh, 204);
+    }
   }
 
   // Overlay (if active)
@@ -364,10 +366,12 @@ void DesktopWindow::draw()
 
     fl_clip_box(ox, oy, ow, oh, ox, oy, ow, oh);
 
-    if (offscreen)
-      overlay->blend(offscreen, ox - X, oy - Y, ox, oy, ow, oh, overlayAlpha);
-    else
-      overlay->blend(ox - X, oy - Y, ox, oy, ow, oh, overlayAlpha);
+    if ((ow != 0) && (oh != 0)) {
+      if (offscreen)
+        overlay->blend(offscreen, ox - X, oy - Y, ox, oy, ow, oh, overlayAlpha);
+      else
+        overlay->blend(ox - X, oy - Y, ox, oy, ow, oh, overlayAlpha);
+    }
   }
 
   // Flush offscreen surface to screen

--- a/vncviewer/Surface.h
+++ b/vncviewer/Surface.h
@@ -60,7 +60,6 @@ protected:
   HBITMAP bitmap;
 #elif defined(__APPLE__)
   unsigned char* data;
-  CGImageRef image;
 #else
   Pixmap pixmap;
   Picture picture;

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -22,6 +22,10 @@
 int cocoa_capture_display(Fl_Window *win, bool all_displays);
 void cocoa_release_display(Fl_Window *win);
 
+typedef struct CGColorSpace *CGColorSpaceRef;
+
+CGColorSpaceRef cocoa_win_color_space(Fl_Window *win);
+
 int cocoa_is_keyboard_event(const void *event);
 
 int cocoa_is_key_press(const void *event);

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -110,6 +110,28 @@ void cocoa_release_display(Fl_Window *win)
     [nsw setLevel:newlevel];
 }
 
+CGColorSpaceRef cocoa_win_color_space(Fl_Window *win)
+{
+  NSWindow *nsw;
+  NSColorSpace *nscs;
+
+  nsw = (NSWindow*)fl_xid(win);
+
+  nscs = [nsw colorSpace];
+  if (nscs == nil) {
+    // Offscreen, so return standard SRGB color space
+    assert(false);
+    return CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+  }
+
+  CGColorSpaceRef lut = [nscs CGColorSpace];
+
+  // We want a permanent reference, not an autorelease
+  CGColorSpaceRetain(lut);
+
+  return lut;
+}
+
 int cocoa_is_keyboard_event(const void *event)
 {
   NSEvent *nsevent;


### PR DESCRIPTION
There was some fallout from the macOS performance improvement. Primarily the screen could stop updating if you moved the window to a secondary monitor.

This PR fixes that, along with some other tweaks.