### PR TITLE
Make RandR callbacks optional as they were before

### DIFF
--- a/unix/xserver/hw/vnc/vncHooks.c
+++ b/unix/xserver/hw/vnc/vncHooks.c
@@ -312,9 +312,21 @@ int vncHooksInit(int scrIdx)
 #ifdef RANDR
   rp = rrGetScrPriv(pScreen);
   if (rp) {
-    wrap(vncHooksScreen, rp, rrSetConfig, vncHooksRandRSetConfig);
-    wrap(vncHooksScreen, rp, rrScreenSetSize, vncHooksRandRScreenSetSize);
-    wrap(vncHooksScreen, rp, rrCrtcSet, vncHooksRandRCrtcSet);
+    if (rp->rrSetConfig) {
+      wrap(vncHooksScreen, rp, rrSetConfig, vncHooksRandRSetConfig);
+    } else {
+      vncHooksScreen->rrSetConfig = rp->rrSetConfig;
+    }
+    if (rp->rrScreenSetSize) {
+      wrap(vncHooksScreen, rp, rrScreenSetSize, vncHooksRandRScreenSetSize);
+    } else {
+      vncHooksScreen->rrScreenSetSize = rp->rrScreenSetSize;
+    }
+    if (rp->rrCrtcSet) {
+      wrap(vncHooksScreen, rp, rrCrtcSet, vncHooksRandRCrtcSet);
+    } else {
+      vncHooksScreen->rrCrtcSet = rp->rrCrtcSet;
+    }
   }
 #endif
 


### PR DESCRIPTION
Previously tigervnc had RandR callbacks optional, after it was rewritten in https://github.com/TigerVNC/tigervnc/commit/84c72feb3999339fc to use wrap/unwrap macros this has been removed, which causes a crash https://github.com/TigerVNC/tigervnc/issues/448. This commit makes them optional again and I cannot reproduce the mentioned crash.