### PR TITLE
Make RandR calls optional as they were before

### DIFF
--- a/unix/xserver/hw/vnc/vncHooks.c
+++ b/unix/xserver/hw/vnc/vncHooks.c
@@ -312,9 +312,13 @@ int vncHooksInit(int scrIdx)
 #ifdef RANDR
   rp = rrGetScrPriv(pScreen);
   if (rp) {
-    wrap(vncHooksScreen, rp, rrSetConfig, vncHooksRandRSetConfig);
-    wrap(vncHooksScreen, rp, rrScreenSetSize, vncHooksRandRScreenSetSize);
-    wrap(vncHooksScreen, rp, rrCrtcSet, vncHooksRandRCrtcSet);
+    /* Some RandR callbacks are optional */
+    if (rp->rrSetConfig)
+      wrap(vncHooksScreen, rp, rrSetConfig, vncHooksRandRSetConfig);
+    if (rp->rrScreenSetSize)
+      wrap(vncHooksScreen, rp, rrScreenSetSize, vncHooksRandRScreenSetSize);
+    if (rp->rrCrtcSet)
+      wrap(vncHooksScreen, rp, rrCrtcSet, vncHooksRandRCrtcSet);
   }
 #endif
 


### PR DESCRIPTION
Previously tigervnc had RandR callbacks optional, after it was rewritten in https://github.com/TigerVNC/tigervnc/commit/84c72feb3999339fc to use wrap/unwrap macros this has been removed, which causes a crash https://github.com/TigerVNC/tigervnc/issues/448. This commit makes them optional again and I cannot reproduce the mentioned crash.

Sorry for creating a new PR, didn't know how to change my previous one to master.