### PR TITLE
Remove "Print" from keys that can open F8 menu

### DIFF
--- a/vncviewer/menukey.cxx
+++ b/vncviewer/menukey.cxx
@@ -43,7 +43,6 @@ static const MenuKeySymbol menuSymbols[] = {
   {"F11", FL_F + 11, XK_F11},
   {"F12", FL_F + 12, XK_F12},
   {"Pause", FL_Pause, XK_Pause},
-  {"Print", FL_Print, XK_Print},
   {"Scroll_Lock", FL_Scroll_Lock, XK_Scroll_Lock},
   {"Escape", FL_Escape, XK_Escape},
   {"Insert", FL_Insert, XK_Insert},

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -257,8 +257,7 @@ specific source file if you know the name of its "LogWriter".  Default is
 .B \-MenuKey \fIkeysym-name\fP
 This option specifies the key which brings up the popup menu. The currently
 supported list is: F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, Pause,
-Print, Scroll_Lock, Escape, Insert, Delete, Home, Page_Up, Page_Down).
-Default is F8.
+Scroll_Lock, Escape, Insert, Delete, Home, Page_Up, Page_Down). Default is F8.
 .
 .TP
 \fB\-via\fR \fIgateway\fR


### PR DESCRIPTION
Since it is caught by the local system on most platforms.