### PR TITLE
Override connection to an untrusted remote host

### DIFF
--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -309,13 +309,14 @@ void CSecurityTLS::checkSession()
   if (gnutls_x509_crt_import(crt, &cert_list[0], GNUTLS_X509_FMT_DER) < 0)
     throw AuthFailureException("decoding of certificate failed");
 
+char *const override(getenv("VNCVIEWER_JANKRATOCHVIL_OVERRIDE"));
   if (gnutls_x509_crt_check_hostname(crt, client->getServerName()) == 0) {
     char buf[255];
     vlog.debug("hostname mismatch");
     snprintf(buf, sizeof(buf), "Hostname (%s) does not match any certificate, "
 			       "do you want to continue?", client->getServerName());
     buf[sizeof(buf) - 1] = '\0';
-    if (!msg->showMsgBox(UserMsgBox::M_YESNO, "hostname mismatch", buf))
+    if (!override&&!msg->showMsgBox(UserMsgBox::M_YESNO, "hostname mismatch", buf))
       throw AuthFailureException("hostname mismatch");
   }
 
@@ -335,6 +336,7 @@ void CSecurityTLS::checkSession()
   if ((status & (~allowed_errors)) != 0) {
     /* No other errors are allowed */
     vlog.debug("GNUTLS status of certificate verification: %u", status);
+if (!override)
     throw AuthFailureException("Invalid status of server certificate verification");
   }
 


### PR DESCRIPTION
Sorry but there should be an option to override a certificate.  I do not have the public CA file or public key from a remote server.  I have only its fingerprint (but I do not need to even have that).  I know it is insecure but I just have no other option.
A missing feature is also to verify the remote server only by its fingerprint.
Being tested on: 15191.vm91.wedos.net:25191
I get there:
```
 TLS:         GNUTLS status of certificate verification: 322
 CConn:       Invalid status of server certificate verification
322 = 0x142
        GNUTLS_CERT_INVALID = 1 << 1,
        GNUTLS_CERT_SIGNER_NOT_FOUND = 1 << 6,
        GNUTLS_CERT_INSECURE_ALGORITHM = 1 << 8,
```
