### PR TITLE
Support for building with AOSP

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,3 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(call first-makefiles-under,$(LOCAL_PATH))

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -90,11 +90,8 @@ LOCAL_C_INCLUDES := \
     external/libjpeg-turbo \
 	external/zlib
 
-LOCAL_CFLAGS := -Ofast -Wall -Wformat=2 -DNDEBUG -UNDEBUG
-
-# !! FIXME FIXME FIXME !!
-LOCAL_CFLAGS += -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-mismatched-tags \
-                -Wno-unused-parameter -Wno-format-nonliteral -Wno-tautological-compare 
+LOCAL_CFLAGS := -Ofast -Wall -Wformat=2 -DNDEBUG -UNDEBUG -Werror
+LOCAL_CFLAGS += -Wno-unused-parameter
 
 LOCAL_CPPFLAGS := -std=c++11 -fexceptions -frtti
 

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -1,0 +1,108 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_CPP_EXTENSION := cxx
+
+LOCAL_SRC_FILES := \
+    network/TcpSocket.cxx \
+    os/Mutex.cxx \
+    os/os.cxx \
+    os/Thread.cxx \
+    rdr/Exception.cxx \
+    rdr/FdInStream.cxx \
+    rdr/FdOutStream.cxx \
+    rdr/FileInStream.cxx \
+    rdr/HexInStream.cxx \
+    rdr/HexOutStream.cxx \
+    rdr/InStream.cxx \
+    rdr/RandomStream.cxx \
+    rdr/TLSException.cxx \
+    rdr/TLSInStream.cxx \
+    rdr/TLSOutStream.cxx \
+    rdr/ZlibInStream.cxx \
+    rdr/ZlibOutStream.cxx \
+    rfb/Blacklist.cxx \
+    rfb/CConnection.cxx \
+    rfb/CMsgHandler.cxx \
+    rfb/CMsgReader.cxx \
+    rfb/CMsgWriter.cxx \
+    rfb/ComparingUpdateTracker.cxx \
+    rfb/Configuration.cxx \
+    rfb/ConnParams.cxx \
+    rfb/CopyRectDecoder.cxx \
+    rfb/CSecurityPlain.cxx \
+    rfb/CSecurityStack.cxx \
+    rfb/CSecurityVeNCrypt.cxx \
+    rfb/CSecurityVncAuth.cxx \
+    rfb/Cursor.cxx \
+    rfb/DecodeManager.cxx \
+    rfb/Decoder.cxx \
+    rfb/EncodeManager.cxx \
+    rfb/Encoder.cxx \
+    rfb/encodings.cxx \
+    rfb/HextileDecoder.cxx \
+    rfb/HextileEncoder.cxx \
+    rfb/HTTPServer.cxx \
+    rfb/JpegCompressor.cxx \
+    rfb/JpegDecompressor.cxx \
+    rfb/KeyRemapper.cxx \
+    rfb/Logger.cxx \
+    rfb/Logger_android.cxx \
+    rfb/Logger_stdio.cxx \
+    rfb/LogWriter.cxx \
+    rfb/Password.cxx \
+    rfb/PixelBuffer.cxx \
+    rfb/PixelFormat.cxx \
+    rfb/RawDecoder.cxx \
+    rfb/RawEncoder.cxx \
+    rfb/Region.cxx \
+    rfb/RREDecoder.cxx \
+    rfb/RREEncoder.cxx \
+    rfb/ScaleFilters.cxx \
+    rfb/SConnection.cxx \
+    rfb/SecurityClient.cxx \
+    rfb/Security.cxx \
+    rfb/SecurityServer.cxx \
+    rfb/ServerCore.cxx \
+    rfb/SMsgHandler.cxx \
+    rfb/SMsgReader.cxx \
+    rfb/SMsgWriter.cxx \
+    rfb/SSecurityPlain.cxx \
+    rfb/SSecurityStack.cxx \
+    rfb/SSecurityVeNCrypt.cxx \
+    rfb/SSecurityVncAuth.cxx \
+    rfb/TightDecoder.cxx \
+    rfb/TightEncoder.cxx \
+    rfb/TightJPEGEncoder.cxx \
+    rfb/Timer.cxx \
+    rfb/UpdateTracker.cxx \
+    rfb/util.cxx \
+    rfb/VNCSConnectionST.cxx \
+    rfb/VNCServerST.cxx \
+    rfb/ZRLEDecoder.cxx \
+    rfb/ZRLEEncoder.cxx \
+    rfb/d3des.c \
+    Xregion/Region.c
+
+LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH) \
+    external/libjpeg-turbo \
+	external/zlib
+
+LOCAL_CFLAGS := -Ofast -Wall -Wformat=2 -DNDEBUG -UNDEBUG
+
+# !! FIXME FIXME FIXME !!
+LOCAL_CFLAGS += -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-mismatched-tags \
+                -Wno-unused-parameter -Wno-format-nonliteral -Wno-tautological-compare 
+
+LOCAL_CPPFLAGS := -std=c++11 -fexceptions -frtti
+
+LOCAL_SHARED_LIBRARIES := \
+    libjpeg \
+    libz
+
+LOCAL_MODULE := libtigervnc
+LOCAL_MODULE_TAGS := optional
+
+include $(BUILD_STATIC_LIBRARY)

--- a/common/network/Socket.h
+++ b/common/network/Socket.h
@@ -82,6 +82,7 @@ namespace network {
   class ConnectionFilter {
   public:
     virtual bool verifyConnection(Socket* s) = 0;
+    virtual ~ConnectionFilter() {}
   };
 
   class SocketListener {

--- a/common/rdr/FdInStream.h
+++ b/common/rdr/FdInStream.h
@@ -30,6 +30,7 @@ namespace rdr {
   class FdInStreamBlockCallback {
   public:
     virtual void blockCallback() = 0;
+    virtual ~FdInStreamBlockCallback() {}
   };
 
   class FdInStream : public InStream {

--- a/common/rdr/FileInStream.cxx
+++ b/common/rdr/FileInStream.cxx
@@ -70,12 +70,12 @@ int FileInStream::overrun(int itemSize, int nItems, bool wait)
 
   while (end < b + itemSize) {
     size_t n = fread((U8 *)end, b + sizeof(b) - end, 1, file);
-    if (n < 1) {
-      if (n < 0 || ferror(file))
+    if (n == 0) {
+      if (ferror(file))
         throw SystemException("fread", errno);
       if (feof(file))
         throw EndOfStream();
-      if (n == 0) { return 0; }
+      return 0;
     }
     end += b + sizeof(b) - end;
   }

--- a/common/rdr/RandomStream.cxx
+++ b/common/rdr/RandomStream.cxx
@@ -87,7 +87,7 @@ int RandomStream::pos() {
   return offset + ptr - start;
 }
 
-int RandomStream::overrun(int itemSize, int nItems, bool wait) {
+int RandomStream::overrun(int itemSize, int nItems, bool /* wait */) {
   if (itemSize > DEFAULT_BUF_LEN)
     throw Exception("RandomStream overrun: max itemSize exceeded");
 

--- a/common/rfb/CMsgWriter.cxx
+++ b/common/rfb/CMsgWriter.cxx
@@ -239,7 +239,7 @@ void CMsgWriter::pointerEvent(const Point& pos, int buttonMask)
 }
 
 
-void CMsgWriter::clientCutText(const char* str, rdr::U32 len)
+void CMsgWriter::clientCutText(const char* str, int len)
 {
   startMsg(msgTypeClientCutText);
   os->pad(3);

--- a/common/rfb/CMsgWriter.h
+++ b/common/rfb/CMsgWriter.h
@@ -33,7 +33,7 @@ namespace rfb {
 
   class PixelFormat;
   class ConnParams;
-  class ScreenSet;
+  struct ScreenSet;
   struct Rect;
 
   class CMsgWriter : public InputHandler {
@@ -57,7 +57,7 @@ namespace rfb {
 
     virtual void keyEvent(rdr::U32 key, bool down);
     virtual void pointerEvent(const Point& pos, int buttonMask);
-    virtual void clientCutText(const char* str, rdr::U32 len);
+    virtual void clientCutText(const char* str, int len);
 
   protected:
     void startMsg(int type);

--- a/common/rfb/Configuration.h
+++ b/common/rfb/Configuration.h
@@ -215,6 +215,7 @@ namespace rfb {
     IntParameter(const char* name_, const char* desc_, int v,
                  int minValue=INT_MIN, int maxValue=INT_MAX,
 		 ConfigurationObject co=ConfGlobal);
+    using VoidParameter::setParam;
     virtual bool setParam(const char* value);
     virtual bool setParam(int v);
     virtual char* getDefaultStr() const;
@@ -251,6 +252,7 @@ namespace rfb {
   public:
     BinaryParameter(const char* name_, const char* desc_, const void* v, int l,
 		    ConfigurationObject co=ConfGlobal);
+    using VoidParameter::setParam;
     virtual ~BinaryParameter();
     virtual bool setParam(const char* value);
     virtual void setParam(const void* v, int l);

--- a/common/rfb/DecodeManager.h
+++ b/common/rfb/DecodeManager.h
@@ -32,7 +32,7 @@ namespace os {
 }
 
 namespace rdr {
-  class Exception;
+  struct Exception;
   class MemOutStream;
 }
 
@@ -40,7 +40,7 @@ namespace rfb {
   class CConnection;
   class Decoder;
   class ModifiablePixelBuffer;
-  class Rect;
+  struct Rect;
 
   class DecodeManager {
   public:

--- a/common/rfb/Decoder.h
+++ b/common/rfb/Decoder.h
@@ -27,8 +27,9 @@ namespace rdr {
 namespace rfb {
   class ConnParams;
   class ModifiablePixelBuffer;
-  class Rect;
   class Region;
+
+  struct Rect;
 
   enum DecoderFlags {
     // A constant for decoders that don't need anything special

--- a/common/rfb/EncodeManager.h
+++ b/common/rfb/EncodeManager.h
@@ -32,7 +32,7 @@ namespace rfb {
   class PixelBuffer;
   class RenderedCursor;
   class Region;
-  class Rect;
+  struct Rect;
 
   struct RectInfo;
 

--- a/common/rfb/InputHandler.h
+++ b/common/rfb/InputHandler.h
@@ -31,9 +31,9 @@ namespace rfb {
   class InputHandler {
   public:
     virtual ~InputHandler() {}
-    virtual void keyEvent(rdr::U32 key, bool down) {}
-    virtual void pointerEvent(const Point& pos, int buttonMask) {}
-    virtual void clientCutText(const char* str, int len) {}
+    virtual void keyEvent(rdr::U32 /* key */, bool /* down */) {}
+    virtual void pointerEvent(const Point& /* pos */, int /* buttonMask */) {}
+    virtual void clientCutText(const char* /* str */, int /* len */) {}
   };
 
 }

--- a/common/rfb/Logger.cxx
+++ b/common/rfb/Logger.cxx
@@ -37,6 +37,9 @@ Logger::~Logger() {
   // *** Should remove this logger here!
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+
 void Logger::write(int level, const char *logname, const char* format,
                    va_list ap)
 {

--- a/common/rfb/Logger_android.cxx
+++ b/common/rfb/Logger_android.cxx
@@ -1,0 +1,60 @@
+/* Copyright (C) 2015 TigerVNC
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+// -=- Logger_syslog.cxx - Logger instance for a syslog
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <utils/Log.h>
+
+#include <rfb/util.h>
+#include <rfb/Logger_android.h>
+#include <rfb/LogWriter.h>
+
+using namespace rfb;
+
+
+Logger_Android::Logger_Android(const char* loggerName)
+  : Logger(loggerName)
+{
+}
+
+Logger_Android::~Logger_Android()
+{
+}
+
+void Logger_Android::write(int level, const char *logname, const char *message)
+{
+  // Convert our priority level into syslog level
+  if (level >= LogWriter::LEVEL_DEBUG) {
+    ALOGD("%s: %s", logname, message);
+  } else if (level >= LogWriter::LEVEL_INFO) {
+    ALOGI("%s: %s", logname, message);
+  } else if (level >= LogWriter::LEVEL_STATUS) {
+    ALOGW("%s: %s", logname, message);
+  } else {
+    ALOGE("%s: %s", logname, message);
+  }
+}
+
+static Logger_Android logger("android");
+
+void rfb::initAndroidLogger() {
+  logger.registerLogger();
+}

--- a/common/rfb/Logger_android.h
+++ b/common/rfb/Logger_android.h
@@ -1,0 +1,40 @@
+/* Copyright (C) 2015 TigerVNC
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+// -=- Logger_syslog - log to syslog
+
+#ifndef __RFB_LOGGER_ANDROID_H__
+#define __RFB_LOGGER_ANDROID_H__
+
+#include <time.h>
+#include <rfb/Logger.h>
+
+namespace rfb {
+
+  class Logger_Android : public Logger {
+  public:
+    Logger_Android(const char* loggerName);
+    virtual ~Logger_Android();
+
+    virtual void write(int level, const char *logname, const char *message);
+  };
+
+  void initAndroidLogger();
+};
+
+#endif

--- a/common/rfb/PixelBuffer.h
+++ b/common/rfb/PixelBuffer.h
@@ -85,7 +85,7 @@ namespace rfb {
     // Ensure that the specified rectangle of buffer is up to date.
     //   Overridden by derived classes implementing framebuffer access
     //   to copy the required display data into place.
-    virtual void grabRegion(const Region& region) {}
+    virtual void grabRegion(const Region& /* region */) {}
 
   protected:
     PixelBuffer();

--- a/common/rfb/SDesktop.h
+++ b/common/rfb/SDesktop.h
@@ -55,7 +55,7 @@ namespace rfb {
     // set via the VNCServer's setPixelBuffer() method by the time this call
     // returns.
 
-    virtual void start(VNCServer* vs) {}
+    virtual void start(VNCServer* /* vs */) {}
 
     // stop() is called by the server when there are no longer any
     // authenticated clients, and therefore the desktop can cease any
@@ -71,8 +71,8 @@ namespace rfb {
 
     // setScreenLayout() requests to reconfigure the framebuffer and/or
     // the layout of screens.
-    virtual unsigned int setScreenLayout(int fb_width, int fb_height,
-                                         const ScreenSet& layout) {
+    virtual unsigned int setScreenLayout(int /* fb_width */, int /* fb_height */,
+                                         const ScreenSet& /* layout */) {
       return resultProhibited;
     }
 

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -32,7 +32,7 @@ namespace rdr { class OutStream; }
 namespace rfb {
 
   class ConnParams;
-  class ScreenSet;
+  struct ScreenSet;
 
   class SMsgWriter {
   public:

--- a/common/rfb/SSecurityPlain.h
+++ b/common/rfb/SSecurityPlain.h
@@ -38,6 +38,8 @@ namespace rfb {
       { return validUser(username) ? validateInternal(sc, username, password) : false; }
     static StringParameter plainUsers;
 
+    virtual ~PasswordValidator() { }
+
   protected:
     virtual bool validateInternal(SConnection* sc, const char *username, const char *password)=0;
     static bool validUser(const char* username);
@@ -49,6 +51,8 @@ namespace rfb {
     virtual bool processMsg(SConnection* sc);
     virtual int getType() const { return secTypePlain; };
     virtual const char* getUserName() const { return username.buf; }
+
+    virtual ~SSecurityPlain() { }
 
   private:
     PasswordValidator* valid;

--- a/common/rfb/SSecurityVncAuth.h
+++ b/common/rfb/SSecurityVncAuth.h
@@ -37,6 +37,8 @@ namespace rfb {
     // getVncAuthPasswd() fills buffer of given password and readOnlyPassword.
     // If there was no read only password in the file, readOnlyPassword buffer is null.
     virtual void getVncAuthPasswd(PlainPasswd *password, PlainPasswd *readOnlyPassword)=0;
+
+    virtual ~VncAuthPasswdGetter() { }
   };
 
   class VncAuthPasswdParameter : public VncAuthPasswdGetter, BinaryParameter {

--- a/common/rfb/Timer.h
+++ b/common/rfb/Timer.h
@@ -49,6 +49,8 @@ namespace rfb {
       //   appropriate interval.
       //   If the handler returns false then the Timer is cancelled.
       virtual bool handleTimeout(Timer* t) = 0;
+
+      virtual ~Callback() {}
     };
 
     // checkTimeouts()

--- a/common/rfb/UserPasswdGetter.h
+++ b/common/rfb/UserPasswdGetter.h
@@ -25,6 +25,8 @@ namespace rfb {
     // case no user name will be retrieved.  The caller MUST delete [] the
     // result(s).
     virtual void getUserPasswd(char** user, char** password)=0;
+
+    virtual ~UserPasswdGetter() {}
   };
 }
 #endif

--- a/common/rfb/util.cxx
+++ b/common/rfb/util.cxx
@@ -44,7 +44,7 @@ namespace rfb {
 
   void CharArray::format(const char *fmt, ...) {
     va_list ap;
-    size_t len;
+    int len;
 
     va_start(ap, fmt);
     len = vsnprintf(NULL, 0, fmt, ap);


### PR DESCRIPTION
First patch adds support for compilation of a static library for Android. The second patch cleans up most of the warnings emitted by Clang on Android Nougat. I've also written an server implementation which uses the virtual display feature of Surfaceflinger. Android doesn't permit input injection from normal apps, so it only works if bundled with the system image (or as part of a custom rom / rooted device). If it's something that makes sense as part of the TigerVNC codebase, I'd be happy to clean it up and submit it. The server code is currently here: https://github.com/cyanogen/vncflinger/tree/tigervnc