### PR TITLE
Fix all warnings emitted by Clang in common code

### DIFF
--- a/common/network/Socket.h
+++ b/common/network/Socket.h
@@ -82,6 +82,7 @@ namespace network {
   class ConnectionFilter {
   public:
     virtual bool verifyConnection(Socket* s) = 0;
+    virtual ~ConnectionFilter() {}
   };
 
   class SocketListener {

--- a/common/rdr/FdInStream.h
+++ b/common/rdr/FdInStream.h
@@ -30,6 +30,7 @@ namespace rdr {
   class FdInStreamBlockCallback {
   public:
     virtual void blockCallback() = 0;
+    virtual ~FdInStreamBlockCallback() {}
   };
 
   class FdInStream : public InStream {

--- a/common/rdr/FileInStream.cxx
+++ b/common/rdr/FileInStream.cxx
@@ -70,12 +70,12 @@ int FileInStream::overrun(int itemSize, int nItems, bool wait)
 
   while (end < b + itemSize) {
     size_t n = fread((U8 *)end, b + sizeof(b) - end, 1, file);
-    if (n < 1) {
-      if (n < 0 || ferror(file))
+    if (n == 0) {
+      if (ferror(file))
         throw SystemException("fread", errno);
       if (feof(file))
         throw EndOfStream();
-      if (n == 0) { return 0; }
+      return 0;
     }
     end += b + sizeof(b) - end;
   }

--- a/common/rfb/CMsgWriter.cxx
+++ b/common/rfb/CMsgWriter.cxx
@@ -239,7 +239,7 @@ void CMsgWriter::pointerEvent(const Point& pos, int buttonMask)
 }
 
 
-void CMsgWriter::clientCutText(const char* str, rdr::U32 len)
+void CMsgWriter::clientCutText(const char* str, int len)
 {
   startMsg(msgTypeClientCutText);
   os->pad(3);

--- a/common/rfb/CMsgWriter.h
+++ b/common/rfb/CMsgWriter.h
@@ -33,7 +33,7 @@ namespace rfb {
 
   class PixelFormat;
   class ConnParams;
-  class ScreenSet;
+  struct ScreenSet;
   struct Rect;
 
   class CMsgWriter : public InputHandler {

--- a/common/rfb/CMsgWriter.h
+++ b/common/rfb/CMsgWriter.h
@@ -57,7 +57,7 @@ namespace rfb {
 
     virtual void keyEvent(rdr::U32 key, bool down);
     virtual void pointerEvent(const Point& pos, int buttonMask);
-    virtual void clientCutText(const char* str, rdr::U32 len);
+    virtual void clientCutText(const char* str, int len);
 
   protected:
     void startMsg(int type);

--- a/common/rfb/Configuration.h
+++ b/common/rfb/Configuration.h
@@ -215,6 +215,7 @@ namespace rfb {
     IntParameter(const char* name_, const char* desc_, int v,
                  int minValue=INT_MIN, int maxValue=INT_MAX,
 		 ConfigurationObject co=ConfGlobal);
+    using VoidParameter::setParam;
     virtual bool setParam(const char* value);
     virtual bool setParam(int v);
     virtual char* getDefaultStr() const;
@@ -251,6 +252,7 @@ namespace rfb {
   public:
     BinaryParameter(const char* name_, const char* desc_, const void* v, int l,
 		    ConfigurationObject co=ConfGlobal);
+    using VoidParameter::setParam;
     virtual ~BinaryParameter();
     virtual bool setParam(const char* value);
     virtual void setParam(const void* v, int l);

--- a/common/rfb/DecodeManager.h
+++ b/common/rfb/DecodeManager.h
@@ -32,7 +32,7 @@ namespace os {
 }
 
 namespace rdr {
-  class Exception;
+  struct Exception;
   class MemOutStream;
 }
 
@@ -40,7 +40,7 @@ namespace rfb {
   class CConnection;
   class Decoder;
   class ModifiablePixelBuffer;
-  class Rect;
+  struct Rect;
 
   class DecodeManager {
   public:

--- a/common/rfb/Decoder.h
+++ b/common/rfb/Decoder.h
@@ -27,8 +27,9 @@ namespace rdr {
 namespace rfb {
   class ConnParams;
   class ModifiablePixelBuffer;
-  class Rect;
   class Region;
+
+  struct Rect;
 
   enum DecoderFlags {
     // A constant for decoders that don't need anything special

--- a/common/rfb/EncodeManager.h
+++ b/common/rfb/EncodeManager.h
@@ -32,7 +32,7 @@ namespace rfb {
   class PixelBuffer;
   class RenderedCursor;
   class Region;
-  class Rect;
+  struct Rect;
 
   struct RectInfo;
 

--- a/common/rfb/InputHandler.h
+++ b/common/rfb/InputHandler.h
@@ -25,15 +25,16 @@
 
 #include <rdr/types.h>
 #include <rfb/Rect.h>
+#include <rfb/util.h>
 
 namespace rfb {
 
   class InputHandler {
   public:
     virtual ~InputHandler() {}
-    virtual void keyEvent(rdr::U32 key, bool down) {}
-    virtual void pointerEvent(const Point& pos, int buttonMask) {}
-    virtual void clientCutText(const char* str, int len) {}
+    virtual void keyEvent(rdr::U32 __unused key, bool __unused down) { }
+    virtual void pointerEvent(const Point& __unused pos, int __unused buttonMask) { }
+    virtual void clientCutText(const char* __unused str, int __unused len) { }
   };
 
 }

--- a/common/rfb/LogWriter.h
+++ b/common/rfb/LogWriter.h
@@ -36,9 +36,9 @@
 // is assigned a particular log level.
 
 #define DEF_LOGFUNCTION(name, level) \
-  inline void v##name(const char* fmt, va_list ap) { \
-    if (m_log && (level <= m_level))       \
-      m_log->write(level, m_name, fmt, ap);\
+  inline void v##name(const char* fmt, va_list ap) __printf_attr(2, 0) { \
+    if (m_log && (level <= m_level))        \
+      m_log->write(level, m_name, fmt, ap); \
   } \
   inline void name(const char* fmt, ...) __printf_attr(2, 3) { \
     if (m_log && (level <= m_level)) {     \

--- a/common/rfb/Logger.h
+++ b/common/rfb/Logger.h
@@ -28,6 +28,12 @@
 // and is attached to a particular Logger instance and
 // is assigned a particular log level.
 
+#ifdef __GNUC__
+#  define __printf_attr(a, b) __attribute__((__format__ (__printf__, a, b)))
+#else
+#  define __printf_attr(a, b)
+#endif // __GNUC__
+
 namespace rfb {
 
   class Logger {
@@ -45,7 +51,7 @@ namespace rfb {
     // -=- Write data to a log
 
     virtual void write(int level, const char *logname, const char *text) = 0;
-    void write(int level, const char *logname, const char* format, va_list ap);
+    void write(int level, const char *logname, const char* format, va_list ap) __printf_attr(4, 0);
 
     // -=- Register a logger
 

--- a/common/rfb/PixelBuffer.h
+++ b/common/rfb/PixelBuffer.h
@@ -28,6 +28,7 @@
 #include <rfb/PixelFormat.h>
 #include <rfb/Rect.h>
 #include <rfb/Pixel.h>
+#include <rfb/util.h>
 
 namespace rfb {
 
@@ -85,7 +86,7 @@ namespace rfb {
     // Ensure that the specified rectangle of buffer is up to date.
     //   Overridden by derived classes implementing framebuffer access
     //   to copy the required display data into place.
-    virtual void grabRegion(const Region& region) {}
+    virtual void grabRegion(const Region& __unused region) {}
 
   protected:
     PixelBuffer();

--- a/common/rfb/SDesktop.h
+++ b/common/rfb/SDesktop.h
@@ -42,6 +42,7 @@
 #include <rfb/InputHandler.h>
 #include <rfb/Exception.h>
 #include <rfb/screenTypes.h>
+#include <rfb/util.h>
 
 namespace rfb {
 
@@ -55,7 +56,7 @@ namespace rfb {
     // set via the VNCServer's setPixelBuffer() method by the time this call
     // returns.
 
-    virtual void start(VNCServer* vs) {}
+    virtual void start(VNCServer* __unused vs) {}
 
     // stop() is called by the server when there are no longer any
     // authenticated clients, and therefore the desktop can cease any
@@ -71,8 +72,8 @@ namespace rfb {
 
     // setScreenLayout() requests to reconfigure the framebuffer and/or
     // the layout of screens.
-    virtual unsigned int setScreenLayout(int fb_width, int fb_height,
-                                         const ScreenSet& layout) {
+    virtual unsigned int setScreenLayout(int __unused fb_width, int __unused fb_height,
+                                         const ScreenSet& __unused layout) {
       return resultProhibited;
     }
 

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -32,7 +32,7 @@ namespace rdr { class OutStream; }
 namespace rfb {
 
   class ConnParams;
-  class ScreenSet;
+  struct ScreenSet;
 
   class SMsgWriter {
   public:

--- a/common/rfb/SSecurityPlain.h
+++ b/common/rfb/SSecurityPlain.h
@@ -38,6 +38,8 @@ namespace rfb {
       { return validUser(username) ? validateInternal(sc, username, password) : false; }
     static StringParameter plainUsers;
 
+    virtual ~PasswordValidator() { }
+
   protected:
     virtual bool validateInternal(SConnection* sc, const char *username, const char *password)=0;
     static bool validUser(const char* username);
@@ -49,6 +51,8 @@ namespace rfb {
     virtual bool processMsg(SConnection* sc);
     virtual int getType() const { return secTypePlain; };
     virtual const char* getUserName() const { return username.buf; }
+
+    virtual ~SSecurityPlain() { }
 
   private:
     PasswordValidator* valid;

--- a/common/rfb/SSecurityVncAuth.h
+++ b/common/rfb/SSecurityVncAuth.h
@@ -37,6 +37,8 @@ namespace rfb {
     // getVncAuthPasswd() fills buffer of given password and readOnlyPassword.
     // If there was no read only password in the file, readOnlyPassword buffer is null.
     virtual void getVncAuthPasswd(PlainPasswd *password, PlainPasswd *readOnlyPassword)=0;
+
+    virtual ~VncAuthPasswdGetter() { }
   };
 
   class VncAuthPasswdParameter : public VncAuthPasswdGetter, BinaryParameter {

--- a/common/rfb/Timer.h
+++ b/common/rfb/Timer.h
@@ -49,6 +49,8 @@ namespace rfb {
       //   appropriate interval.
       //   If the handler returns false then the Timer is cancelled.
       virtual bool handleTimeout(Timer* t) = 0;
+
+      virtual ~Callback() {}
     };
 
     // checkTimeouts()

--- a/common/rfb/UserPasswdGetter.h
+++ b/common/rfb/UserPasswdGetter.h
@@ -25,6 +25,8 @@ namespace rfb {
     // case no user name will be retrieved.  The caller MUST delete [] the
     // result(s).
     virtual void getUserPasswd(char** user, char** password)=0;
+
+    virtual ~UserPasswdGetter() {}
   };
 }
 #endif

--- a/common/rfb/util.cxx
+++ b/common/rfb/util.cxx
@@ -44,7 +44,7 @@ namespace rfb {
 
   void CharArray::format(const char *fmt, ...) {
     va_list ap;
-    size_t len;
+    int len;
 
     va_start(ap, fmt);
     len = vsnprintf(NULL, 0, fmt, ap);

--- a/common/rfb/util.h
+++ b/common/rfb/util.h
@@ -38,6 +38,10 @@ struct timeval;
 #  define __printf_attr(a, b)
 #endif // __GNUC__
 
+#ifndef __unused
+#  define __unused __attribute((__unused__))
+#endif
+
 namespace rfb {
 
   // -=- Class to handle cleanup of arrays of characters


### PR DESCRIPTION
Android uses Clang with relatively strict options as it's default compiler. This series of patches eliminates all warnings from the common core and allows building with Werror. Patches are split up by error/issue type.