### PR TITLE
x0vncserver: Use Xfixes to display cursors if available

### DIFF
--- a/unix/x0vncserver/CMakeLists.txt
+++ b/unix/x0vncserver/CMakeLists.txt
@@ -31,6 +31,13 @@ else()
   message(WARNING "No DAMAGE extension.  x0vncserver will have to use the slower polling method.")
 endif()
 
+if(X11_FOUND AND X11_Xfixes_LIB)
+  add_definitions(-DHAVE_XFIXES)
+  target_link_libraries(x0vncserver ${X11_Xfixes_LIB})
+else()
+  message(WARNING "No XFIXES extension.  x0vncserver will not be able to show cursors.")
+endif()
+
 target_link_libraries(x0vncserver ${X11_LIBRARIES})
 
 install(TARGETS x0vncserver DESTINATION ${BIN_DIR})


### PR DESCRIPTION
https://github.com/TigerVNC/tigervnc/issues/361

This is a simple implementation that refetches and transforms the cursor
image every time it changes, and doesn't use the cursor naming functions
of the XFixes extension to save & cache cursor images.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>