### PR TITLE
Unset pixel buffer when x0vncserver client disconnects.

### DIFF
--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -313,6 +313,8 @@ void VNCServerST::setPixelBuffer(PixelBuffer* pb_, const ScreenSet& layout)
   screenLayout = layout;
 
   if (!pb) {
+    stopFrameClock();
+
     if (desktopStarted)
       throw Exception("setPixelBuffer: null PixelBuffer when desktopStarted?");
     return;
@@ -337,18 +339,10 @@ void VNCServerST::setPixelBuffer(PixelBuffer* pb_, const ScreenSet& layout)
 
 void VNCServerST::setPixelBuffer(PixelBuffer* pb_)
 {
-  ScreenSet layout;
-
-  if (!pb_) {
-    if (desktopStarted)
-      throw Exception("setPixelBuffer: null PixelBuffer when desktopStarted?");
-    return;
-  }
-
-  layout = screenLayout;
+  ScreenSet layout = screenLayout;
 
   // Check that the screen layout is still valid
-  if (!layout.validate(pb_->width(), pb_->height())) {
+  if (pb_ && !layout.validate(pb_->width(), pb_->height())) {
     Rect fbRect;
     ScreenSet::iterator iter, iter_next;
 

--- a/unix/x0vncserver/x0vncserver.cxx
+++ b/unix/x0vncserver/x0vncserver.cxx
@@ -270,7 +270,8 @@ public:
     TXWindow::setGlobalEventHandler(this);
   }
   virtual ~XDesktop() {
-    stop();
+    if (running)
+      stop();
   }
 
   inline void poll() {
@@ -326,6 +327,9 @@ public:
     if (haveDamage)
       XDamageDestroy(dpy, damage);
 #endif
+
+    server->setPixelBuffer(0);
+    server = 0;
 
     delete pb;
     pb = 0;


### PR DESCRIPTION
In XDesktop::start() we allocate pixel buffer and set it as the backend to the given VNCServer.
In XDesktop::stop() we deallocate the buffer, so we must unset it from the VNCServer as well.
Otherwise the VNCServer could try to access it and crash, for example in deferred update.

This prevents crashes after client disconnects from x0vncserver. Backtrace of such crash looks like this:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000000100574c50 in ?? ()
(gdb) bt
#0  0x0000000100574c50 in ?? ()
#1  0x00000001000385de in rfb::VNCServerST::writeUpdate (this=this@entry=0x7fffffffdfc0) at /usr/src/debug/tigervnc-1.8.0/common/rfb/VNCServerST.cxx:595
#2  0x00000001000386c6 in rfb::VNCServerST::handleTimeout (this=0x7fffffffdfc0, t=<optimized out>) at /usr/src/debug/tigervnc-1.8.0/common/rfb/VNCServerST.cxx:514
#3  0x00000001000360cd in rfb::Timer::checkTimeouts () at /usr/src/debug/tigervnc-1.8.0/common/rfb/Timer.cxx:76
#4  0x0000000100036ae7 in rfb::VNCServerST::checkTimeouts (this=0x7fffffffdfc0) at /usr/src/debug/tigervnc-1.8.0/common/rfb/VNCServerST.cxx:203
#5  0x000000010002733f in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/tigervnc-1.8.0/unix/x0vncserver/x0vncserver.cxx:555
```