### PR TITLE
Fix build failure other than utf-8

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Java)
 
 set(DATA_DIR "${CMAKE_INSTALL_PREFIX}/share")
 
-set(DEFAULT_JAVACFLAGS "-source 1.6 -target 1.6 -Xlint:all,-serial,-cast,-unchecked,-fallthrough,-dep-ann,-deprecation,-rawtypes")
+set(DEFAULT_JAVACFLAGS "-source 1.6 -target 1.6 -encoding UTF-8 -Xlint:all,-serial,-cast,-unchecked,-fallthrough,-dep-ann,-deprecation,-rawtypes")
 set(JAVACFLAGS ${DEFAULT_JAVACFLAGS} CACHE STRING
   "Java compiler flags (Default: ${DEFAULT_JAVACFLAGS})")
 message(STATUS "Java compiler flags = ${JAVACFLAGS}")


### PR DESCRIPTION
This PR avoid build failures in environments other than utf-8.

This bug reported on gentoo bugzilla.
https://bugs.gentoo.org/610738
https://bugs.gentoo.org/634918

