### PR TITLE
Fixes for Pause, PrintScreen and NumLock keys on Windows

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -922,6 +922,11 @@ int Viewport::handleSystemEvent(void *event, void *data)
         vlog.error(_("No symbol for virtual key 0x%02x"), (int)vKey);
     }
 
+    // Windows sends the same vKey for both shifts, so we need to look
+    // at the scan code to tell them apart
+    if ((keySym == XK_Shift_L) && (keyCode == 0x36))
+      keySym = XK_Shift_R;
+
     self->handleKeyPress(keyCode, keySym);
 
     return 1;
@@ -952,6 +957,15 @@ int Viewport::handleSystemEvent(void *event, void *data)
       keyCode = 0x54;
 
     self->handleKeyRelease(keyCode);
+
+    // Windows has a rather nasty bug where it won't send key release
+    // events for a Shift button if the other Shift is still pressed
+    if ((keyCode == 0x2a) || (keyCode == 0x36)) {
+      if (self->downKeySym.count(0x2a))
+        self->handleKeyRelease(0x2a);
+      if (self->downKeySym.count(0x36))
+        self->handleKeyRelease(0x36);
+    }
 
     return 1;
   }

--- a/vncviewer/win32.c
+++ b/vncviewer/win32.c
@@ -129,6 +129,7 @@ void win32_disable_lowlevel_keyboard(HWND hwnd)
 }
 
 static const int vkey_map[][3] = {
+  { VK_CANCEL,              NoSymbol,       XK_Break },
   { VK_BACK,                XK_BackSpace,   NoSymbol },
   { VK_TAB,                 XK_Tab,         NoSymbol },
   { VK_CLEAR,               XK_Clear,       NoSymbol },

--- a/win/rfb_win32/SInput.cxx
+++ b/win/rfb_win32/SInput.cxx
@@ -377,6 +377,14 @@ void win32::SKeyboard::keyEvent(rdr::U32 keysym, rdr::U32 keycode, bool down)
     if ((keycode == 0x54) && !(GetAsyncKeyState(VK_MENU) & 0x8000))
       keycode = 0xb7;
 
+    if (down && (keycode == 0xd3) &&
+        ((GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0) &&
+        ((GetAsyncKeyState(VK_MENU) & 0x8000) != 0))
+    {
+      rfb::win32::emulateCtrlAltDel();
+      return;
+    }
+
     doScanCodeEvent(keycode, down);
     return;
   }


### PR DESCRIPTION
These keys don't behave quite like other keys, so they needed some special care.

(Also improved the situation with Shift keys on Windows a bit)