### PR TITLE
Make sure auth argument is escaped

### DIFF
--- a/unix/vncserver
+++ b/unix/vncserver
@@ -207,7 +207,7 @@ my %config;
 # override these where present.
 $default_opts{desktop} = &quotedString($desktopName);
 $default_opts{httpd} = $vncJavaFiles if ($vncJavaFiles);
-$default_opts{auth} = $xauthorityFile;
+$default_opts{auth} = &quotedString($xauthorityFile);
 $default_opts{geometry} = $geometry if ($geometry);
 $default_opts{depth} = $depth if ($depth);
 $default_opts{pixelformat} = $pixelformat if ($pixelformat);


### PR DESCRIPTION
Some options are already escaped, some are validated to be sure they do not have to but these are  still not.

I discovered this while running with `XAUTHORITY` file in directory containing `&&` that caused broken xvnc was launched as only the pre-`&&` portion was passed through `sh -c`.