### PR TITLE
change parameter name

### DIFF
--- a/java/com/tigervnc/vncviewer/Parameters.java
+++ b/java/com/tigervnc/vncviewer/Parameters.java
@@ -586,7 +586,7 @@ public class Parameters {
   }
 
   public static String loadAppletParameters(VncViewer applet) {
-    String servername = applet.getParameter("Server");
+    String servername = applet.getParameter("Host");
     String serverport = applet.getParameter("Port");
     String embedParam = applet.getParameter("Embed");
 


### PR DESCRIPTION
the "server" parameter should be named "Host" because the most vnc viewers recieves that parameter instead off "Server"