### PR TITLE
Avoid clipboard updates when not focused

### DIFF
--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -423,32 +423,7 @@ void CConn::bell()
 
 void CConn::serverCutText(const char* str, rdr::U32 len)
 {
-  char *buffer;
-  int size, ret;
-
-  if (!acceptClipboard)
-    return;
-
-  size = fl_utf8froma(NULL, 0, str, len);
-  if (size <= 0)
-    return;
-
-  size++;
-
-  buffer = new char[size];
-
-  ret = fl_utf8froma(buffer, size, str, len);
-  assert(ret < size);
-
-  vlog.debug("Got clipboard data (%d bytes)", (int)strlen(buffer));
-
-  // RFB doesn't have separate selection and clipboard concepts, so we
-  // dump the data into both variants.
-  if (setPrimary)
-    Fl::copy(buffer, ret, 0);
-  Fl::copy(buffer, ret, 1);
-
-  delete [] buffer;
+  desktop->serverCutText(str, len);
 }
 
 void CConn::dataRect(const Rect& r, int encoding)

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -276,6 +276,12 @@ void DesktopWindow::resizeFramebuffer(int new_w, int new_h)
 }
 
 
+void DesktopWindow::serverCutText(const char* str, rdr::U32 len)
+{
+  viewport->serverCutText(str, len);
+}
+
+
 void DesktopWindow::setCursor(int width, int height,
                               const rfb::Point& hotspot,
                               const rdr::U8* data)

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -694,10 +694,6 @@ int DesktopWindow::fltkHandle(int event, Fl_Window *win)
         if (dw->fullscreen_active())
           dw->grabKeyboard();
       }
-
-      // We may have gotten our lock keys out of sync with the server
-      // whilst we didn't have focus. Try to sort this out.
-      dw->viewport->pushLEDState();
       break;
 
     case FL_UNFOCUS:

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -62,6 +62,9 @@ public:
   // Resize the current framebuffer, but retain the contents
   void resizeFramebuffer(int new_w, int new_h);
 
+  // Incoming clipboard from server
+  void serverCutText(const char* str, rdr::U32 len);
+
   // New image for the locally rendered cursor
   void setCursor(int width, int height, const rfb::Point& hotspot,
                  const rdr::U8* data);

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -118,6 +118,7 @@ Viewport::Viewport(int w, int h, const rfb::PixelFormat& serverPF, CConn* cc_)
 #ifdef WIN32
     altGrArmed(false),
 #endif
+    pendingServerCutText(NULL), pendingClientCutText(NULL),
     menuCtrlKey(false), menuAltKey(false), cursor(NULL)
 {
 #if !defined(WIN32) && !defined(__APPLE__)
@@ -206,6 +207,8 @@ Viewport::~Viewport()
     delete cursor;
   }
 
+  clearPendingClipboard();
+
   // FLTK automatically deletes all child widgets, so we shouldn't touch
   // them ourselves here
 }
@@ -233,6 +236,8 @@ void Viewport::serverCutText(const char* str, rdr::U32 len)
   char *buffer;
   int size, ret;
 
+  clearPendingClipboard();
+
   if (!acceptClipboard)
     return;
 
@@ -248,6 +253,11 @@ void Viewport::serverCutText(const char* str, rdr::U32 len)
   assert(ret < size);
 
   vlog.debug("Got clipboard data (%d bytes)", (int)strlen(buffer));
+
+  if (!hasFocus()) {
+    pendingServerCutText = buffer;
+    return;
+  }
 
   // RFB doesn't have separate selection and clipboard concepts, so we
   // dump the data into both variants.
@@ -534,10 +544,17 @@ int Viewport::handle(int event)
   case FL_PASTE:
     buffer = new char[Fl::event_length() + 1];
 
+    clearPendingClipboard();
+
     // This is documented as to ASCII, but actually does to 8859-1
     ret = fl_utf8toa(Fl::event_text(), Fl::event_length(), buffer,
                      Fl::event_length() + 1);
     assert(ret < (Fl::event_length() + 1));
+
+    if (!hasFocus()) {
+      pendingClientCutText = buffer;
+      return 1;
+    }
 
     vlog.debug("Sending clipboard data (%d bytes)", (int)strlen(buffer));
 
@@ -598,6 +615,8 @@ int Viewport::handle(int event)
     Fl::disable_im();
 
     try {
+      flushPendingClipboard();
+
       // We may have gotten our lock keys out of sync with the server
       // whilst we didn't have focus. Try to sort this out.
       pushLEDState();
@@ -701,6 +720,33 @@ void Viewport::handleClipboardChange(int source, void *data)
 #endif
 
   Fl::paste(*self, source);
+}
+
+
+void Viewport::clearPendingClipboard()
+{
+  delete [] pendingServerCutText;
+  pendingServerCutText = NULL;
+  delete [] pendingClientCutText;
+  pendingClientCutText = NULL;
+}
+
+
+void Viewport::flushPendingClipboard()
+{
+  if (pendingServerCutText) {
+    size_t len = strlen(pendingServerCutText);
+    if (setPrimary)
+      Fl::copy(pendingServerCutText, len, 0);
+    Fl::copy(pendingServerCutText, len, 1);
+  }
+  if (pendingClientCutText) {
+    size_t len = strlen(pendingClientCutText);
+    vlog.debug("Sending pending clipboard data (%d bytes)", (int)len);
+    cc->writer()->clientCutText(pendingClientCutText, len);
+  }
+
+  clearPendingClipboard();
 }
 
 

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -604,6 +604,16 @@ int Viewport::handle(int event)
 
   case FL_FOCUS:
     Fl::disable_im();
+
+    try {
+      // We may have gotten our lock keys out of sync with the server
+      // whilst we didn't have focus. Try to sort this out.
+      pushLEDState();
+    } catch (rdr::Exception& e) {
+      vlog.error("%s", e.str());
+      exit_vncviewer(e.str());
+    }
+
     // Yes, we would like some focus please!
     return 1;
 
@@ -1167,7 +1177,12 @@ void Viewport::popupContextMenu()
   if (Fl::belowmouse() == this)
     window()->cursor(FL_CURSOR_DEFAULT);
 
+  // FLTK also doesn't switch focus properly for menus
+  handle(FL_UNFOCUS);
+
   m = contextMenu->popup();
+
+  handle(FL_FOCUS);
 
   // Back to our proper mouse pointer.
   if ((Fl::belowmouse() == this) && cursor)

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -228,6 +228,36 @@ void Viewport::updateWindow()
   damage(FL_DAMAGE_USER1, r.tl.x + x(), r.tl.y + y(), r.width(), r.height());
 }
 
+void Viewport::serverCutText(const char* str, rdr::U32 len)
+{
+  char *buffer;
+  int size, ret;
+
+  if (!acceptClipboard)
+    return;
+
+  size = fl_utf8froma(NULL, 0, str, len);
+  if (size <= 0)
+    return;
+
+  size++;
+
+  buffer = new char[size];
+
+  ret = fl_utf8froma(buffer, size, str, len);
+  assert(ret < size);
+
+  vlog.debug("Got clipboard data (%d bytes)", (int)strlen(buffer));
+
+  // RFB doesn't have separate selection and clipboard concepts, so we
+  // dump the data into both variants.
+  if (setPrimary)
+    Fl::copy(buffer, ret, 0);
+  Fl::copy(buffer, ret, 1);
+
+  delete [] buffer;
+}
+
 static const char * dotcursor_xpm[] = {
   "5 5 2 1",
   ".	c #000000",

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -309,17 +309,9 @@ void Viewport::setCursor(int width, int height, const Point& hotspot,
 
 void Viewport::setLEDState(unsigned int state)
 {
-  Fl_Widget *focus;
-
   vlog.debug("Got server LED state: 0x%08x", state);
 
-  focus = Fl::grab();
-  if (!focus)
-    focus = Fl::focus();
-  if (!focus)
-    return;
-
-  if (focus != this)
+  if (!hasFocus())
     return;
 
 #if defined(WIN32)
@@ -635,6 +627,17 @@ int Viewport::handle(int event)
 }
 
 
+bool Viewport::hasFocus()
+{
+  Fl_Widget* focus;
+
+  focus = Fl::grab();
+  if (!focus)
+    focus = Fl::focus();
+
+  return focus == this;
+}
+
 #if ! (defined(WIN32) || defined(__APPLE__))
 unsigned int Viewport::getModifierMask(unsigned int keysym)
 {
@@ -845,17 +848,10 @@ void Viewport::handleKeyRelease(int keyCode)
 int Viewport::handleSystemEvent(void *event, void *data)
 {
   Viewport *self = (Viewport *)data;
-  Fl_Widget *focus;
 
   assert(self);
 
-  focus = Fl::grab();
-  if (!focus)
-    focus = Fl::focus();
-  if (!focus)
-    return 0;
-
-  if (focus != self)
+  if (!self->hasFocus())
     return 0;
 
   assert(event);

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -52,8 +52,6 @@ public:
 
   // Change client LED state
   void setLEDState(unsigned int state);
-  // Change server LED state
-  void pushLEDState();
 
   void draw(Surface* dst);
 
@@ -82,6 +80,8 @@ private:
 #ifdef WIN32
   static void handleAltGrTimeout(void *data);
 #endif
+
+  void pushLEDState();
 
   void initContextMenu();
   void popupContextMenu();

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -70,6 +70,9 @@ private:
 
   static void handleClipboardChange(int source, void *data);
 
+  void clearPendingClipboard();
+  void flushPendingClipboard();
+
   void handlePointerEvent(const rfb::Point& pos, int buttonMask);
   static void handlePointerTimeout(void *data);
 
@@ -106,6 +109,9 @@ private:
   bool altGrArmed;
   unsigned int altGrCtrlTime;
 #endif
+
+  const char* pendingServerCutText;
+  const char* pendingClientCutText;
 
   rdr::U32 menuKeySym;
   int menuKeyCode, menuKeyFLTK;

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -64,6 +64,7 @@ public:
   int handle(int event);
 
 private:
+  bool hasFocus();
 
   unsigned int getModifierMask(unsigned int keysym);
 

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -43,6 +43,9 @@ public:
   // Flush updates to screen
   void updateWindow();
 
+  // Incoming clipboard from server
+  void serverCutText(const char* str, rdr::U32 len);
+
   // New image for the locally rendered cursor
   void setCursor(int width, int height, const rfb::Point& hotspot,
                  const rdr::U8* data);


### PR DESCRIPTION
We don't want to surprise the user with unexpected clipboard changes when vncviewer is in the background, and it is both wasteful and possibly insecure to inform the server of every clipboard update when the user isn't interacting with it.
