### PR TITLE
Accept a cfg as an argument as an alt way to start the viewer

### DIFF
--- a/java/com/tigervnc/vncviewer/VncViewer.java
+++ b/java/com/tigervnc/vncviewer/VncViewer.java
@@ -208,6 +208,8 @@ public class VncViewer extends javax.swing.JApplet
       vncServerName.put(argv[i].toCharArray()).flip();
     }
 
+    // Check if the server name in reality is a configuration file
+    potentiallyLoadConfigurationFile(vncServerName);
   }
 
   public static void usage() {
@@ -215,6 +217,7 @@ public class VncViewer extends javax.swing.JApplet
                     "[host:displayNum]\n"+
                     "       vncviewer [options/parameters] -listen [port] "+
                     "[options/parameters]\n"+
+                    "       vncviewer [options/parameters] [.tigervnc file]\n"+
                     "\n"+
                     "Options:\n"+
                     "  -log <level>    configure logging level\n"+
@@ -275,6 +278,27 @@ public class VncViewer extends javax.swing.JApplet
     // Technically, we shouldn't use System.exit here but if there is a parameter
     // error then the problem is in the index/html file anyway.
     System.exit(1);
+  }
+
+  public static void potentiallyLoadConfigurationFile(CharBuffer vncServerName) {
+    String serverName = vncServerName.toString();
+    boolean hasPathSeparator = (serverName.indexOf('/') != -1 ||
+                                (serverName.indexOf('\\')) != -1);
+
+    if (hasPathSeparator) {
+      try {
+        serverName = loadViewerParameters(vncServerName.toString());
+        if (serverName == "") {
+          vlog.info("Unable to load the server name from given file");
+          System.exit(1);
+        }
+        vncServerName.clear();
+        vncServerName.put(serverName).flip();
+      } catch (com.tigervnc.rfb.Exception e) {
+        vlog.info(e.getMessage());
+        System.exit(1);
+      }
+    }
   }
 
   public static void newViewer() {

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -14,6 +14,10 @@ vncviewer \- VNC viewer for X
 .RI [ options ] 
 .B \-listen
 .RI [ port ]
+.br
+.B vncviewer
+.RI [ options ]
+.RI [ .tigervnc file ]
 .SH DESCRIPTION
 .B vncviewer
 is a viewer (client) for Virtual Network Computing.  This manual page documents
@@ -30,6 +34,18 @@ where 'snoopy' is the name of the machine, and '2' is the display number of the
 VNC server on that machine.  Either the machine name or display number can be
 omitted.  So for example ":1" means display number 1 on the same machine, and
 "snoopy" means "snoopy:0" i.e. display 0 on machine "snoopy".
+
+As another quick way to start a connection to a VNC server, specify a .tigervnc
+configuration file as an argument to the viewer, e.g.:
+
+.RS
+vncviewer ./some.tigervnc
+.RE
+
+where './some.tigervnc' is an existing and valid TigerVNC configuration file.
+The file name needs to include a path separator.  Additional options may be
+given too, but the given configuration file will overwrite any conflicting
+parameters.
 
 If the VNC server is successfully contacted, you will be prompted for a
 password to authenticate you.  If the password is correct, a window will appear


### PR DESCRIPTION
The user can specify a tigervnc configuration file as an argument to the
viewer. Previously the viewer assumed this to be a server, but now we
will first check if there is any file matching the given argument. If
so, try to load the content of that file, like we normally do.

Fixes issue #38.