### PR TITLE
WIP: Fix Numlock turning off while starting tigervnc-client.

### DIFF
--- a/common/rfb/ConnParams.cxx
+++ b/common/rfb/ConnParams.cxx
@@ -40,7 +40,7 @@ ConnParams::ConnParams()
     supportsContinuousUpdates(false),
     compressLevel(2), qualityLevel(-1), fineQualityLevel(-1),
     subsampling(subsampleUndefined), name_(0), verStrPos(0),
-    ledState_(ledUnknown)
+    ledState_(0)
 {
   setName("");
   cursor_ = new Cursor(0, 0, Point(), NULL);


### PR DESCRIPTION
The latest linux tigervnc-client (built from latest source 816baa35) switches Numlock off after starting session. I think this also happens on Windows. I guess the bug was introduced (isn't anybody else having the issue too?) with the introduction of the ledState logic due to changes in the X server.

This is not really a fix. It's more of an ugly work-around. I am not really proposing it as a solution but as kind bug report/question. If you prefer, I can gladfully open an issue for this. I thought showing the work-around might help though.

I think the problem is that the first time that the client (Viewport) tries sync the current local led state to the server and runs Viewport::pushLEDState(), it returns here:
``` C++
void Viewport::pushLEDState()                                                                                                                                                                                      
{                                                                                                                                                                                                                  
  unsigned int state;                                                                                                                                                                                              
                                                                                                                                                                                                                   
  // Server support?                                                                                                                                                                                               
  if (cc->cp.ledState() == ledUnknown)                                                                                                                                                                             
    return;
```
not allowing pushLEDState to do its magic.

I haven't yet managed to understand why, but at some point after this, the client Numlock is switched off.

Shortly after that, CMsgReader does in fact receive the server led state, which is 0, and can sync without a problem after that. Subsequent switching on and off of Numlock (and Capslock) work flawlessly.

Assuming ledState is 0 on server instead of ledUnkown (-1) seems to do the trick. That is, pushLEDState doesn't return immediately and performs its magic (virtually pressing the buttons) wonderfully.

Has anybody seen this? Can you think of a nicer solution for this?