### PR TITLE
Add support for X server 1.20.0.

### DIFF
--- a/unix/xserver/hw/vnc/xorg-version.h
+++ b/unix/xserver/hw/vnc/xorg-version.h
@@ -52,8 +52,10 @@
 #define XORG 118
 #elif XORG_VERSION_CURRENT < ((1 * 10000000) + (19 * 100000) + (99 * 1000))
 #define XORG 119
+#elif XORG_VERSION_CURRENT < ((1 * 10000000) + (20 * 100000) + (99 * 1000))
+#define XORG 120
 #else
-#error "X.Org newer than 1.19 is not supported"
+#error "X.Org newer than 1.20 is not supported"
 #endif
 
 #endif

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -202,6 +202,7 @@ vfbBitsPerPixel(int depth)
 static void vfbFreeFramebufferMemory(vfbFramebufferInfoPtr pfb);
 
 #ifdef DPMSExtension
+#if XORG < 120
     /* Why support DPMS? Because stupid modern desktop environments
        such as Unity 2D on Ubuntu 11.10 crashes if DPMS is not
        available. (DPMSSet is called by dpms.c, but the return value
@@ -217,6 +218,7 @@ Bool DPMSSupported(void)
        capable */
     return FALSE;
 }
+#endif
 #endif
 
 #if XORG < 111
@@ -1738,6 +1740,10 @@ InitOutput(ScreenInfo *scrInfo, int argc, char **argv)
 
     vncPrintBanner();
 
+#if XORG >= 120
+    xorgGlxCreateVendor();
+#else
+
 #if XORG >= 113
 #ifdef GLXEXT
     if (serverGeneration == 1)
@@ -1747,6 +1753,8 @@ InitOutput(ScreenInfo *scrInfo, int argc, char **argv)
         LoadExtension(&glxExt, TRUE);
 #endif
 #endif
+#endif
+
 #endif
 
     /* initialize pixmap formats */

--- a/unix/xserver120.patch
+++ b/unix/xserver120.patch
@@ -1,0 +1,82 @@
+Index: xserver/configure.ac
+===================================================================
+--- xserver.orig/configure.ac
++++ xserver/configure.ac
+@@ -74,6 +74,7 @@ dnl forcing an entire recompile.x
+ AC_CONFIG_HEADERS(include/version-config.h)
+ 
+ AM_PROG_AS
++AC_PROG_CXX
+ AC_PROG_LN_S
+ LT_PREREQ([2.2])
+ LT_INIT([disable-static win32-dll])
+@@ -1777,6 +1778,10 @@ if test "x$XVFB" = xyes; then
+ 	AC_SUBST([XVFB_SYS_LIBS])
+ fi
+ 
++dnl Xvnc DDX
++AC_SUBST([XVNC_CPPFLAGS], ["-DHAVE_DIX_CONFIG_H $XSERVER_CFLAGS"])
++AC_SUBST([XVNC_LIBS], ["$FB_LIB $FIXES_LIB $XEXT_LIB $CONFIG_LIB $DBE_LIB $RECORD_LIB $GLX_LIBS $RANDR_LIB $RENDER_LIB $DAMAGE_LIB $DRI3_LIB $PRESENT_LIB $MIEXT_SYNC_LIB $MIEXT_DAMAGE_LIB $MIEXT_SHADOW_LIB $XI_LIB $XKB_LIB $XKB_STUB_LIB $COMPOSITE_LIB $MAIN_LIB"])
++AC_SUBST([XVNC_SYS_LIBS], ["$GLX_SYS_LIBS"])
+ 
+ dnl Xnest DDX
+ 
+@@ -1812,6 +1817,8 @@ if test "x$XORG" = xauto; then
+ fi
+ AC_MSG_RESULT([$XORG])
+ 
++AC_DEFINE_UNQUOTED(XORG_VERSION_CURRENT, [$VENDOR_RELEASE], [Current Xorg version])
++
+ if test "x$XORG" = xyes; then
+ 	XORG_DDXINCS='-I$(top_srcdir)/hw/xfree86 -I$(top_srcdir)/hw/xfree86/include -I$(top_srcdir)/hw/xfree86/common'
+ 	XORG_OSINCS='-I$(top_srcdir)/hw/xfree86/os-support -I$(top_srcdir)/hw/xfree86/os-support/bus -I$(top_srcdir)/os'
+@@ -2029,7 +2036,6 @@ if test "x$XORG" = xyes; then
+ 	AC_DEFINE(XORG_SERVER, 1, [Building Xorg server])
+ 	AC_DEFINE(XORGSERVER, 1, [Building Xorg server])
+ 	AC_DEFINE(XFree86Server, 1, [Building XFree86 server])
+-	AC_DEFINE_UNQUOTED(XORG_VERSION_CURRENT, [$VENDOR_RELEASE], [Current Xorg version])
+ 	AC_DEFINE(NEED_XF86_TYPES, 1, [Need XFree86 typedefs])
+ 	AC_DEFINE(NEED_XF86_PROTOTYPES, 1, [Need XFree86 helper functions])
+ 	AC_DEFINE(__XSERVERNAME__, "Xorg", [Name of X server])
+@@ -2565,6 +2571,7 @@ hw/dmx/Makefile
+ hw/dmx/man/Makefile
+ hw/vfb/Makefile
+ hw/vfb/man/Makefile
++hw/vnc/Makefile
+ hw/xnest/Makefile
+ hw/xnest/man/Makefile
+ hw/xwin/Makefile
+Index: xserver/hw/Makefile.am
+===================================================================
+--- xserver.orig/hw/Makefile.am
++++ xserver/hw/Makefile.am
+@@ -38,7 +38,8 @@ SUBDIRS =			\
+ 	$(DMX_SUBDIRS)		\
+ 	$(KDRIVE_SUBDIRS)	\
+ 	$(XQUARTZ_SUBDIRS)	\
+-	$(XWAYLAND_SUBDIRS)
++	$(XWAYLAND_SUBDIRS)	\
++	vnc
+ 
+ DIST_SUBDIRS = dmx xfree86 vfb xnest xwin xquartz kdrive xwayland
+ 
+Index: xserver/mi/miinitext.c
+===================================================================
+--- xserver.orig/mi/miinitext.c
++++ xserver/mi/miinitext.c
+@@ -107,8 +107,15 @@ SOFTWARE.
+ #include "os.h"
+ #include "globals.h"
+ 
++#ifdef TIGERVNC
++extern void vncExtensionInit(void);
++#endif
++
+ /* List of built-in (statically linked) extensions */
+ static const ExtensionModule staticExtensions[] = {
++#ifdef TIGERVNC
++    {vncExtensionInit, "VNC-EXTENSION", NULL},
++#endif
+     {GEExtensionInit, "Generic Event Extension", &noGEExtension},
+     {ShapeExtensionInit, "SHAPE", NULL},
+ #ifdef MITSHM


### PR DESCRIPTION
In-server GLVND requires xorgGlxCreateVendor call from InitOutput.
DPMS functions were moved to another location and no longer need to be faked.
xserver120.patch is a copy of xserver119.patch with refreshed contexts.