### PR TITLE
Avoid error/warning about implicit function declaration

### DIFF
--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -47,6 +47,7 @@ from the X Consortium.
 #include <X11/Xproto.h>
 #include <X11/Xos.h>
 #include "scrnintstr.h"
+#include "glx_extinit.h"
 #include "servermd.h"
 #include "fb.h"
 #include "mi.h"


### PR DESCRIPTION
Function xorgGlxCreateVendor() is defined in glx_extinit.h, if this header is not included, we might get either error or warning. This header also needs to be included after scrninststr.h header as it defines some structures used in glx_extinit.h