### PR TITLE
viewer: reset ctrl / alt to menu state on focus

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -635,6 +635,12 @@ int Viewport::handle(int event)
       exit_vncviewer(e.str());
     }
 
+    // Resend Ctrl/Alt if needed
+    if (menuCtrlKey)
+      handleKeyPress(0x1d, XK_Control_L);
+    if (menuAltKey)
+      handleKeyPress(0x38, XK_Alt_L);
+
     // Yes, we would like some focus please!
     return 1;
 


### PR DESCRIPTION
Setting Ctrl or Alt key on menu only sends the key press, and the
state is lost when focus is lost and recovered.
This checks the menu variable and sends the keys again if needed.

PS: thanks for tigervnc! Feel free to ask me to change anything, this is a very small patch and I tried to respect style but I'll admit to not having read any contributing rules.