### PR TITLE
Add support for dynamic JPEG quality adjustment

### DIFF
--- a/common/rfb/Configuration.cxx
+++ b/common/rfb/Configuration.cxx
@@ -325,6 +325,39 @@ BoolParameter::operator bool() const {
   return value;
 }
 
+// -=- PresetParameter
+
+PresetParameter::PresetParameter(const char* name_, const char* desc_, bool v,
+				 void (*onSet)(void),
+				 ConfigurationObject co)
+: BoolParameter(name_, desc_, v, co), onSetCB(onSet) {
+}
+
+bool PresetParameter::setParam(const char* value_) {
+  const bool ret = BoolParameter::setParam(value_);
+
+  if (ret && onSetCB && value)
+    onSetCB();
+
+  return ret;
+}
+
+bool PresetParameter::setParam() {
+  const bool ret = BoolParameter::setParam();
+
+  if (ret && onSetCB && value)
+    onSetCB();
+
+  return ret;
+}
+
+void PresetParameter::setParam(bool b) {
+  BoolParameter::setParam(b);
+
+  if (onSetCB && value)
+    onSetCB();
+}
+
 // -=- IntParameter
 
 IntParameter::IntParameter(const char* name_, const char* desc_, int v,

--- a/common/rfb/Configuration.h
+++ b/common/rfb/Configuration.h
@@ -216,6 +216,18 @@ namespace rfb {
     bool def_value;
   };
 
+  class PresetParameter : public BoolParameter {
+  public:
+    PresetParameter(const char* name_, const char* desc_, bool v,
+		    void (*onSet)(void),
+		    ConfigurationObject co=ConfGlobal);
+    virtual bool setParam(const char* value);
+    virtual bool setParam();
+    virtual void setParam(bool b);
+  protected:
+    void (*onSetCB)(void);
+  };
+
   class IntParameter : public VoidParameter {
   public:
     IntParameter(const char* name_, const char* desc_, int v,

--- a/common/rfb/EncodeManager.cxx
+++ b/common/rfb/EncodeManager.cxx
@@ -550,7 +550,7 @@ Encoder *EncodeManager::startRect(const Rect& rect, int type)
   encoder = encoders[klass];
   conn->writer()->startRect(rect, encoder->encoding);
 
-  if (encoder->flags & EncoderLossy)
+  if (encoder->flags & EncoderLossy && !encoder->treatLossless())
     lossyRegion.assign_union(Region(rect));
   else
     lossyRegion.assign_subtract(Region(rect));

--- a/common/rfb/EncodeManager.cxx
+++ b/common/rfb/EncodeManager.cxx
@@ -1,6 +1,7 @@
 /* Copyright (C) 2000-2003 Constantin Kaplinsky.  All Rights Reserved.
  * Copyright (C) 2011 D. R. Commander.  All Rights Reserved.
  * Copyright 2014-2018 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 Lauri Kasanen
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +25,7 @@
 #include <rfb/Encoder.h>
 #include <rfb/Palette.h>
 #include <rfb/SConnection.h>
+#include <rfb/ServerCore.h>
 #include <rfb/SMsgWriter.h>
 #include <rfb/UpdateTracker.h>
 #include <rfb/LogWriter.h>
@@ -38,6 +40,9 @@
 using namespace rfb;
 
 static LogWriter vlog("EncodeManager");
+
+// If this rect was touched this update, add this to its quality score
+#define SCORE_INCREMENT 8
 
 // Split each rectangle into smaller ones no larger than this area,
 // and no wider than this width.
@@ -75,6 +80,12 @@ enum EncoderType {
 struct RectInfo {
   int rleRuns;
   Palette palette;
+};
+
+struct QualityInfo {
+  struct timeval lastUpdate;
+  Rect rect;
+  unsigned score;
 };
 
 };
@@ -123,7 +134,8 @@ static const char *encoderTypeName(EncoderType type)
   return "Unknown Encoder Type";
 }
 
-EncodeManager::EncodeManager(SConnection* conn_) : conn(conn_)
+EncodeManager::EncodeManager(SConnection* conn_) : conn(conn_),
+  dynamicQualityMin(-1), dynamicQualityOff(-1)
 {
   StatsVector::iterator iter;
 
@@ -146,6 +158,12 @@ EncodeManager::EncodeManager(SConnection* conn_) : conn(conn_)
     for (iter2 = iter->begin();iter2 != iter->end();++iter2)
       memset(&*iter2, 0, sizeof(EncoderStats));
   }
+
+  if (Server::dynamicQualityMax && Server::dynamicQualityMax <= 9 &&
+      Server::dynamicQualityMax > Server::dynamicQualityMin) {
+    dynamicQualityMin = Server::dynamicQualityMin;
+    dynamicQualityOff = Server::dynamicQualityMax - Server::dynamicQualityMin;
+  }
 }
 
 EncodeManager::~EncodeManager()
@@ -156,6 +174,9 @@ EncodeManager::~EncodeManager()
 
   for (iter = encoders.begin();iter != encoders.end();iter++)
     delete *iter;
+
+  for (std::list<QualityInfo*>::iterator it = qualityList.begin(); it != qualityList.end(); it++)
+    delete *it;
 }
 
 void EncodeManager::logStats()
@@ -259,8 +280,10 @@ void EncodeManager::pruneLosslessRefresh(const Region& limits)
 }
 
 void EncodeManager::writeUpdate(const UpdateInfo& ui, const PixelBuffer* pb,
-                                const RenderedCursor* renderedCursor)
+                                const RenderedCursor* renderedCursor,
+                                size_t maxUpdateSize)
 {
+    curMaxUpdateSize = maxUpdateSize;
     doUpdate(true, ui.changed, ui.copied, ui.copy_delta, pb, renderedCursor);
 }
 
@@ -316,6 +339,8 @@ void EncodeManager::doUpdate(bool allowLossy, const Region& changed_,
 
     writeRects(changed, pb);
     writeRects(cursorRegion, renderedCursor);
+
+    updateQualities();
 
     conn->writer()->writeFramebufferUpdateEnd();
 }
@@ -804,6 +829,14 @@ void EncodeManager::writeSubRect(const Rect& rect, const PixelBuffer *pb)
   if (encoder->flags & EncoderUseNativePF)
     ppb = preparePixelBuffer(rect, pb, false);
 
+  if (type == encoderFullColour && dynamicQualityMin > -1) {
+    trackRectQuality(rect);
+
+    // Set the dynamic quality here. Unset fine quality, as it would overrule us
+    encoder->setQualityLevel(scaledQuality(rect));
+    encoder->setFineQualityLevel(-1, subsampleUndefined);
+  }
+
   encoder->writeRect(ppb, info.palette);
 
   endRect();
@@ -997,3 +1030,125 @@ void EncodeManager::OffsetPixelBuffer::update(const PixelFormat& pf,
 #define BPP 32
 #include "EncodeManagerBPP.cxx"
 #undef BPP
+
+// Dynamic quality tracking
+void EncodeManager::updateQualities() {
+  struct timeval now;
+  gettimeofday(&now, NULL);
+
+  // Remove elements that haven't been touched in 5s. Update the scores.
+  for (std::list<QualityInfo*>::iterator it = qualityList.begin(); it != qualityList.end(); ) {
+    QualityInfo * const cur = *it;
+    const unsigned since = msBetween(&cur->lastUpdate, &now);
+    if (since > 5000) {
+      delete cur;
+      it = qualityList.erase(it);
+    } else {
+      cur->score -= cur->score / 16;
+      it++;
+    }
+  }
+}
+
+static bool closeEnough(const Rect& unioned, const int& unionArea,
+                        const Rect& check, const int& checkArea) {
+  const Point p = unioned.tl.subtract(check.tl);
+  if (abs(p.x) > 32 ||
+      abs(p.y) > 32)
+      return false;
+
+  if (abs(unionArea - checkArea) > 4096)
+    return false;
+
+  return true;
+}
+
+void EncodeManager::trackRectQuality(const Rect& rect) {
+
+  const int searchArea = rect.area();
+  struct timeval now;
+  gettimeofday(&now, NULL);
+
+  for (std::list<QualityInfo*>::iterator it = qualityList.begin(); it != qualityList.end(); it++) {
+    QualityInfo * const cur = *it;
+    const int curArea = cur->rect.area();
+    const Rect unioned = cur->rect.union_boundary(rect);
+    const int unionArea = unioned.area();
+    // Is this close enough to match?
+    // e.g. ads that change parts in one frame and more in others
+    if (rect.enclosed_by(cur->rect) ||
+        cur->rect.enclosed_by(rect) ||
+        closeEnough(unioned, unionArea, cur->rect, curArea) ||
+        closeEnough(unioned, unionArea, rect, searchArea)) {
+
+        // This existing rect matched. Set it to the larger of the two,
+        // and add to its score.
+        if (searchArea > curArea)
+          cur->rect = rect;
+
+        cur->score += SCORE_INCREMENT;
+        cur->lastUpdate = now;
+        return;
+    }
+  }
+
+  // It wasn't found, add it
+  QualityInfo *info = new QualityInfo;
+  info->rect = rect;
+  info->score = 0;
+  info->lastUpdate = now;
+  qualityList.push_back(info);
+}
+
+// Returns the change-tracked quality, 0-128, where 128 is max quality
+unsigned EncodeManager::getQuality(const Rect& rect) const {
+
+  const int searchArea = rect.area();
+
+  for (std::list<QualityInfo*>::const_iterator it = qualityList.begin(); it != qualityList.end(); it++) {
+    const QualityInfo * const cur = *it;
+    const int curArea = cur->rect.area();
+    const Rect unioned = cur->rect.union_boundary(rect);
+    const int unionArea = unioned.area();
+    // Is this close enough to match?
+    // e.g. ads that change parts in one frame and more in others
+    if (rect.enclosed_by(cur->rect) ||
+        cur->rect.enclosed_by(rect) ||
+        closeEnough(unioned, unionArea, cur->rect, curArea) ||
+        closeEnough(unioned, unionArea, rect, searchArea)) {
+
+        unsigned score = cur->score;
+        if (score > 128)
+          score = 128;
+        score = 128 - score;
+
+        return score;
+    }
+  }
+
+  return 128; // Not found, this shouldn't happen - return max quality then
+}
+
+// Returns the scaled quality, 0-9, where 9 is max
+// Optionally takes bandwidth into account
+unsigned EncodeManager::scaledQuality(const Rect& rect) const {
+
+  unsigned dynamic;
+
+  dynamic = getQuality(rect);
+
+  // The tracker gives quality as 0-128. Convert to our desired range
+  dynamic *= dynamicQualityOff;
+  dynamic += 64; // Rounding
+  dynamic /= 128;
+  dynamic += dynamicQualityMin;
+
+  // Bandwidth adjustment
+  if (!Server::preferBandwidth) {
+    // Prefer quality, if there's bandwidth available, don't go below 7
+    if (curMaxUpdateSize > 2000 && dynamic < 7)
+      dynamic = 7;
+  }
+
+  return dynamic;
+}

--- a/common/rfb/EncodeManager.h
+++ b/common/rfb/EncodeManager.h
@@ -57,7 +57,7 @@ namespace rfb {
 
     void writeUpdate(const UpdateInfo& ui, const PixelBuffer* pb,
                      const RenderedCursor* renderedCursor,
-                     size_t maxUpdateSize);
+                     size_t maxUpdateSize = 2000);
 
     void writeLosslessRefresh(const Region& req, const PixelBuffer* pb,
                               const RenderedCursor* renderedCursor,

--- a/common/rfb/EncodeManager.h
+++ b/common/rfb/EncodeManager.h
@@ -1,6 +1,7 @@
 /* Copyright (C) 2000-2003 Constantin Kaplinsky.  All Rights Reserved.
  * Copyright (C) 2011 D. R. Commander.  All Rights Reserved.
  * Copyright 2014-2018 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 Lauri Kasanen
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,10 +22,14 @@
 #define __RFB_ENCODEMANAGER_H__
 
 #include <vector>
+#include <list>
 
 #include <rdr/types.h>
 #include <rfb/PixelBuffer.h>
 #include <rfb/Region.h>
+#include <rfb/util.h>
+
+#include <sys/time.h>
 
 namespace rfb {
   class SConnection;
@@ -35,6 +40,7 @@ namespace rfb {
   struct Rect;
 
   struct RectInfo;
+  struct QualityInfo;
 
   class EncodeManager {
   public:
@@ -50,7 +56,8 @@ namespace rfb {
     void pruneLosslessRefresh(const Region& limits);
 
     void writeUpdate(const UpdateInfo& ui, const PixelBuffer* pb,
-                     const RenderedCursor* renderedCursor);
+                     const RenderedCursor* renderedCursor,
+                     size_t maxUpdateSize);
 
     void writeLosslessRefresh(const Region& req, const PixelBuffer* pb,
                               const RenderedCursor* renderedCursor,
@@ -91,6 +98,11 @@ namespace rfb {
     bool analyseRect(const PixelBuffer *pb,
                      struct RectInfo *info, int maxColours);
 
+    void updateQualities();
+    void trackRectQuality(const Rect& rect);
+    unsigned getQuality(const Rect& rect) const;
+    unsigned scaledQuality(const Rect& rect) const;
+
   protected:
     // Preprocessor generated, optimised methods
     inline bool checkSolidTile(const Rect& r, rdr::U8 colourValue,
@@ -126,11 +138,16 @@ namespace rfb {
     };
     typedef std::vector< std::vector<struct EncoderStats> > StatsVector;
 
+    std::list<QualityInfo*> qualityList;
+    int dynamicQualityMin;
+    int dynamicQualityOff;
+
     unsigned updates;
     EncoderStats copyStats;
     StatsVector stats;
     int activeType;
     int beforeLength;
+    size_t curMaxUpdateSize;
 
     class OffsetPixelBuffer : public FullFramePixelBuffer {
     public:

--- a/common/rfb/Encoder.h
+++ b/common/rfb/Encoder.h
@@ -54,6 +54,8 @@ namespace rfb {
     virtual void setQualityLevel(int level) {};
     virtual void setFineQualityLevel(int quality, int subsampling) {};
 
+    virtual bool treatLossless() { return !(flags & EncoderLossy); }
+
     // writeRect() is the main interface that encodes the given rectangle
     // with data from the PixelBuffer onto the SConnection given at
     // encoder creation.

--- a/common/rfb/ServerCore.cxx
+++ b/common/rfb/ServerCore.cxx
@@ -109,10 +109,15 @@ rfb::IntParameter rfb::Server::dynamicQualityMax
 ("DynamicQualityMax",
  "The maximum dynamic JPEG quality, 0 = low, 9 = high",
  8, 0, 9);
+rfb::IntParameter rfb::Server::treatLossless
+("TreatLossless",
+ "Treat lossy quality levels above and including this as lossless, 0-9. 10 = off",
+ 10, 0, 10);
 
 static void bandwidthPreset() {
   rfb::Server::dynamicQualityMin.setParam(2);
   rfb::Server::dynamicQualityMax.setParam(9);
+  rfb::Server::treatLossless.setParam(8);
 }
 
 rfb::PresetParameter rfb::Server::preferBandwidth

--- a/common/rfb/ServerCore.cxx
+++ b/common/rfb/ServerCore.cxx
@@ -101,3 +101,21 @@ rfb::BoolParameter rfb::Server::queryConnect
 ("QueryConnect",
  "Prompt the local user to accept or reject incoming connections.",
  false);
+rfb::IntParameter rfb::Server::dynamicQualityMin
+("DynamicQualityMin",
+ "The minimum dynamic JPEG quality, 0 = low, 9 = high",
+ 7, 0, 9);
+rfb::IntParameter rfb::Server::dynamicQualityMax
+("DynamicQualityMax",
+ "The maximum dynamic JPEG quality, 0 = low, 9 = high",
+ 8, 0, 9);
+
+static void bandwidthPreset() {
+  rfb::Server::dynamicQualityMin.setParam(2);
+  rfb::Server::dynamicQualityMax.setParam(9);
+}
+
+rfb::PresetParameter rfb::Server::preferBandwidth
+("PreferBandwidth",
+ "Set various options for lower bandwidth use. The default is off, aka to prefer quality.",
+ false, bandwidthPreset);

--- a/common/rfb/ServerCore.h
+++ b/common/rfb/ServerCore.h
@@ -39,6 +39,8 @@ namespace rfb {
     static IntParameter clientWaitTimeMillis;
     static IntParameter compareFB;
     static IntParameter frameRate;
+    static IntParameter dynamicQualityMin;
+    static IntParameter dynamicQualityMax;
     static BoolParameter protocol3_3;
     static BoolParameter alwaysShared;
     static BoolParameter neverShared;
@@ -49,6 +51,7 @@ namespace rfb {
     static BoolParameter sendCutText;
     static BoolParameter acceptSetDesktopSize;
     static BoolParameter queryConnect;
+    static PresetParameter preferBandwidth;
 
   };
 

--- a/common/rfb/ServerCore.h
+++ b/common/rfb/ServerCore.h
@@ -41,6 +41,7 @@ namespace rfb {
     static IntParameter frameRate;
     static IntParameter dynamicQualityMin;
     static IntParameter dynamicQualityMax;
+    static IntParameter treatLossless;
     static BoolParameter protocol3_3;
     static BoolParameter alwaysShared;
     static BoolParameter neverShared;

--- a/common/rfb/TightJPEGEncoder.cxx
+++ b/common/rfb/TightJPEGEncoder.cxx
@@ -20,6 +20,7 @@
 #include <rdr/OutStream.h>
 #include <rfb/encodings.h>
 #include <rfb/SConnection.h>
+#include <rfb/ServerCore.h>
 #include <rfb/PixelBuffer.h>
 #include <rfb/TightJPEGEncoder.h>
 #include <rfb/TightConstants.h>
@@ -99,6 +100,11 @@ void TightJPEGEncoder::setFineQualityLevel(int quality, int subsampling)
 {
   fineQuality = quality;
   fineSubsampling = subsampling;
+}
+
+bool TightJPEGEncoder::treatLossless()
+{
+  return qualityLevel >= rfb::Server::treatLossless;
 }
 
 void TightJPEGEncoder::writeRect(const PixelBuffer* pb, const Palette& palette)

--- a/common/rfb/TightJPEGEncoder.h
+++ b/common/rfb/TightJPEGEncoder.h
@@ -35,6 +35,8 @@ namespace rfb {
     virtual void setQualityLevel(int level);
     virtual void setFineQualityLevel(int quality, int subsampling);
 
+    virtual bool treatLossless();
+
     virtual void writeRect(const PixelBuffer* pb, const Palette& palette);
     virtual void writeSolidRect(int width, int height,
                                 const PixelFormat& pf,

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -186,6 +186,28 @@ update to the client. Note that this only controls the maximum rate and a
 client may get a lower rate when resources are limited. Default is \fB60\fP.
 .
 .TP
+.B \-DynamicQualityMin \fImin\fP
+The minimum quality to with dynamic JPEG quality scaling. The accepted values
+are 0-9 where 0 is low and 9 is high, with the same meaning as the client-side
+-quality parameter. Default is \fB7\fP.
+.
+.TP
+.B \-DynamicQualityMax \fImax\fP
+The maximum quality to use with dynamic JPEG quality scaling. Setting this to
+zero disables dynamic JPEG quality scaling. The accepted values are 0-9 where 0
+is low and 9 is high, with the same meaning as the client-side -quality parameter.
+Default is \fB8\fP.
+.
+.TP
+.B \-PreferBandwidth
+Prefer bandwidth over quality, and set various options for lower bandwidth use.
+The default is off, aka to prefer quality. You can override individual values
+by setting them after this switch on the command line. This switch sets the
+following:
+.br
+- dynamic JPEG quality range 2-9
+.
+.TP
 .B \-CompareFB \fImode\fP
 Perform pixel comparison on framebuffer to reduce unnecessary updates. Can
 be either \fB0\fP (off), \fB1\fP (always) or \fB2\fP (auto). Default is

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -199,6 +199,12 @@ is low and 9 is high, with the same meaning as the client-side -quality paramete
 Default is \fB8\fP.
 .
 .TP
+.B \-TreatLossless \fIquality\fP
+Treat lossy quality levels above and including this as lossless, without
+sending lossless updates for them. 0-9, 10 disables this.
+Default is \fB10\fP.
+.
+.TP
 .B \-PreferBandwidth
 Prefer bandwidth over quality, and set various options for lower bandwidth use.
 The default is off, aka to prefer quality. You can override individual values
@@ -206,6 +212,8 @@ by setting them after this switch on the command line. This switch sets the
 following:
 .br
 - dynamic JPEG quality range 2-9
+.br
+- TreatLossless 8
 .
 .TP
 .B \-CompareFB \fImode\fP


### PR DESCRIPTION
These commits add support for dynamic JPEG quality adjustment, requested in #672.

It's added as a server-side option, where if enabled, all clients supporting the Tight
encoding with jpeg images get it. It can be configured with the min and max parameters,
giving a range of quality values, using the same 0-9 scale as the client-side quality
option.

I ran some tests compared to the defaults (jpeg at constant level 8). First was a web
page with text and two animated banners. Using the full dynamic range, 0-9, the numbers
reported by Xvnc for Tight (JPEG) improved by 12%. Range 2-8 improved by 21%.

Then I tried playing video, a 10-sec clip from a movie. Range 0-9 improved over the
baseline by 25%, and range 2-8 by 29%.

I couldn't notice visual degradation, so setting the maximum even lower may work, depending
on workload. Fully compatible with existing VNC viewers, I tested two old binaries from
2010 and 2008.