### PR TITLE
Add NoReminder parameter to disable menuOverlay

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -184,7 +184,9 @@ DesktopWindow::DesktopWindow(int w, int h, const char *name,
   }
 
   // Show hint about menu key
-  Fl::add_timeout(0.5, menuOverlay, this);
+  if (!noReminder) {
+    Fl::add_timeout(0.5, menuOverlay, this);
+  }
 }
 
 

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -142,6 +142,10 @@ StringParameter display("display",
 StringParameter menuKey("MenuKey", "The key which brings up the popup menu",
                         "F8");
 
+BoolParameter noReminder("NoReminder",
+                         "Disable the floating MenuKey reminder at startup",
+                         false);
+
 BoolParameter fullscreenSystemKeys("FullscreenSystemKeys",
                                    "Pass special keys (like Alt+Tab) directly "
                                    "to the server when in full screen mode.",
@@ -181,6 +185,7 @@ static VoidParameter* parameterArray[] = {
   &sendPrimary,
 #endif
   &menuKey,
+  &noReminder,
   &fullscreenSystemKeys,
   &alertOnFatalError
 };

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -59,6 +59,7 @@ extern rfb::StringParameter display;
 #endif
 
 extern rfb::StringParameter menuKey;
+extern rfb::BoolParameter noReminder;
 
 extern rfb::BoolParameter fullscreenSystemKeys;
 extern rfb::BoolParameter alertOnFatalError;

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -276,6 +276,11 @@ supported list is: F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, Pause,
 Scroll_Lock, Escape, Insert, Delete, Home, Page_Up, Page_Down). Default is F8.
 .
 .TP
+.B \-NoReminder
+Disable the floating reminder popop displaying the current \fBMenuKey\fR,
+which is otherwise shown at start. Default is off (reminder will be shown).
+.
+.TP
 \fB\-via\fR \fIgateway\fR
 Automatically create encrypted TCP tunnel to the \fIgateway\fR machine
 before connection, connect to the \fIhost\fR through that tunnel


### PR DESCRIPTION
If `vncviewer` is passed a `-NoReminder` argument, the `menuOverlay` message will not be displayed at start.

Fixes #678.