### PR TITLE
Check endianness when constructing PlatformPixelBuffer()

### DIFF
--- a/vncviewer/PlatformPixelBuffer.cxx
+++ b/vncviewer/PlatformPixelBuffer.cxx
@@ -34,8 +34,8 @@
 static rfb::LogWriter vlog("PlatformPixelBuffer");
 
 PlatformPixelBuffer::PlatformPixelBuffer(int width, int height) :
-  FullFramePixelBuffer(rfb::PixelFormat(32, 24, false, true,
-                                       255, 255, 255, 16, 8, 0),
+  FullFramePixelBuffer(rfb::PixelFormat(32, 24, ImageByteOrder(fl_display) == MSBFirst,
+                                        true, 255, 255, 255, 16, 8, 0),
                        width, height, 0, stride),
   Surface(width, height)
 #if !defined(WIN32) && !defined(__APPLE__)

--- a/vncviewer/PlatformPixelBuffer.cxx
+++ b/vncviewer/PlatformPixelBuffer.cxx
@@ -34,7 +34,12 @@
 static rfb::LogWriter vlog("PlatformPixelBuffer");
 
 PlatformPixelBuffer::PlatformPixelBuffer(int width, int height) :
-  FullFramePixelBuffer(rfb::PixelFormat(32, 24, ImageByteOrder(fl_display) == MSBFirst,
+  FullFramePixelBuffer(rfb::PixelFormat(32, 24,
+#if !defined(WIN32) && !defined(__APPLE__)
+                                        ImageByteOrder(fl_display) == MSBFirst,
+#else
+                                        false,
+#endif
                                         true, 255, 255, 255, 16, 8, 0),
                        width, height, 0, stride),
   Surface(width, height)


### PR DESCRIPTION
This fixes wrong colors when using vncviewer on ppc64 or s390x (big endian). We shouldn't assume we use little-endian all the time.