### PR TITLE
Increase maximum vnc server name length, fix #699

### DIFF
--- a/java/com/tigervnc/vncviewer/VncViewer.java
+++ b/java/com/tigervnc/vncviewer/VncViewer.java
@@ -85,7 +85,7 @@ public class VncViewer extends javax.swing.JApplet
   private static VncViewer applet;
 
   private String defaultServerName;
-  int VNCSERVERNAMELEN = 64;
+  int VNCSERVERNAMELEN = 256;
   CharBuffer vncServerName = CharBuffer.allocate(VNCSERVERNAMELEN);
 
   public static void setLookAndFeel() {

--- a/vncviewer/vncviewer.h
+++ b/vncviewer/vncviewer.h
@@ -19,7 +19,7 @@
 #ifndef __VNCVIEWER_H__
 #define __VNCVIEWER_H__
 
-#define VNCSERVERNAMELEN 64
+#define VNCSERVERNAMELEN 256
 
 void exit_vncviewer(const char *error = NULL);
 bool should_exit();


### PR DESCRIPTION
Current maximum vnc server name length is too small as described in corresponding issue, thus increased it to 256 symbols.