### PR TITLE
Automatic lossless refresh improvements

### DIFF
--- a/common/rfb/Congestion.cxx
+++ b/common/rfb/Congestion.cxx
@@ -291,11 +291,20 @@ int Congestion::getUncongestedETA()
 
 size_t Congestion::getBandwidth()
 {
+  size_t bandwidth;
+
   // No measurements yet? Guess RTT of 60 ms
   if (safeBaseRTT == (unsigned)-1)
-    return congWindow * 1000 / 60;
+    bandwidth = congWindow * 1000 / 60;
+  else
+    bandwidth = congWindow * 1000 / safeBaseRTT;
 
-  return congWindow * 1000 / safeBaseRTT;
+  // We're still probing so guess actual bandwidth is halfway between
+  // the current guess and the next one (slow start doubles each time)
+  if (inSlowStart)
+    bandwidth = bandwidth + bandwidth / 2;
+
+  return bandwidth;
 }
 
 void Congestion::debugTrace(const char* filename, int fd)

--- a/common/rfb/EncodeManager.cxx
+++ b/common/rfb/EncodeManager.cxx
@@ -476,6 +476,9 @@ Region EncodeManager::getLosslessRefresh(const Region& req,
   // We make a conservative guess at the compression ratio at 2:1
   maxUpdateSize *= 2;
 
+  // We will measure pixels, not bytes (assume 32 bpp)
+  maxUpdateSize /= 4;
+
   area = 0;
   pendingRefreshRegion.intersect(req).get_rects(&rects);
   while (!rects.empty()) {

--- a/common/rfb/Encoder.cxx
+++ b/common/rfb/Encoder.cxx
@@ -24,9 +24,11 @@
 using namespace rfb;
 
 Encoder::Encoder(SConnection *conn_, int encoding_,
-                 enum EncoderFlags flags_, unsigned int maxPaletteSize_) :
+                 enum EncoderFlags flags_,
+                 unsigned int maxPaletteSize_, int losslessQuality_) :
   encoding(encoding_), flags(flags_),
-  maxPaletteSize(maxPaletteSize_), conn(conn_)
+  maxPaletteSize(maxPaletteSize_), losslessQuality(losslessQuality_),
+  conn(conn_)
 {
 }
 

--- a/common/rfb/Encoder.h
+++ b/common/rfb/Encoder.h
@@ -42,7 +42,8 @@ namespace rfb {
   class Encoder {
   public:
     Encoder(SConnection* conn, int encoding,
-            enum EncoderFlags flags, unsigned int maxPaletteSize=-1);
+            enum EncoderFlags flags, unsigned int maxPaletteSize=-1,
+            int losslessQuality=-1);
     virtual ~Encoder();
 
     // isSupported() should return a boolean indicating if this encoder
@@ -94,6 +95,10 @@ namespace rfb {
 
     // Maximum size of the palette per rect
     const unsigned int maxPaletteSize;
+
+    // Minimum level where the quality loss will not be noticed by
+    // most users (only relevant with EncoderLossy flag)
+    const int losslessQuality;
 
   protected:
     SConnection* conn;

--- a/common/rfb/Encoder.h
+++ b/common/rfb/Encoder.h
@@ -54,6 +54,9 @@ namespace rfb {
     virtual void setQualityLevel(int level) {};
     virtual void setFineQualityLevel(int quality, int subsampling) {};
 
+    virtual int getCompressLevel() { return -1; };
+    virtual int getQualityLevel() { return -1; };
+
     // writeRect() is the main interface that encodes the given rectangle
     // with data from the PixelBuffer onto the SConnection given at
     // encoder creation.

--- a/common/rfb/Encoder.h
+++ b/common/rfb/Encoder.h
@@ -42,7 +42,7 @@ namespace rfb {
   class Encoder {
   public:
     Encoder(SConnection* conn, int encoding,
-            enum EncoderFlags flags, unsigned int maxPaletteSize);
+            enum EncoderFlags flags, unsigned int maxPaletteSize=-1);
     virtual ~Encoder();
 
     // isSupported() should return a boolean indicating if this encoder

--- a/common/rfb/HextileEncoder.cxx
+++ b/common/rfb/HextileEncoder.cxx
@@ -45,7 +45,7 @@ BoolParameter improvedHextile("ImprovedHextile",
 #undef BPP
 
 HextileEncoder::HextileEncoder(SConnection* conn) :
-  Encoder(conn, encodingHextile, EncoderPlain, -1)
+  Encoder(conn, encodingHextile, EncoderPlain)
 {
 }
 

--- a/common/rfb/RREEncoder.cxx
+++ b/common/rfb/RREEncoder.cxx
@@ -37,7 +37,7 @@ using namespace rfb;
 #undef BPP
 
 RREEncoder::RREEncoder(SConnection* conn) :
-  Encoder(conn, encodingRRE, EncoderPlain, -1)
+  Encoder(conn, encodingRRE, EncoderPlain)
 {
 }
 

--- a/common/rfb/RawEncoder.cxx
+++ b/common/rfb/RawEncoder.cxx
@@ -25,7 +25,7 @@
 using namespace rfb;
 
 RawEncoder::RawEncoder(SConnection* conn) :
-  Encoder(conn, encodingRaw, EncoderPlain, -1)
+  Encoder(conn, encodingRaw, EncoderPlain)
 {
 }
 

--- a/common/rfb/TightJPEGEncoder.cxx
+++ b/common/rfb/TightJPEGEncoder.cxx
@@ -64,7 +64,8 @@ static const struct TightJPEGConfiguration conf[10] = {
 
 
 TightJPEGEncoder::TightJPEGEncoder(SConnection* conn) :
-  Encoder(conn, encodingTight, (EncoderFlags)(EncoderUseNativePF | EncoderLossy)),
+  Encoder(conn, encodingTight,
+          (EncoderFlags)(EncoderUseNativePF | EncoderLossy), -1, 9),
   qualityLevel(-1), fineQuality(-1), fineSubsampling(subsampleUndefined)
 {
 }

--- a/common/rfb/TightJPEGEncoder.cxx
+++ b/common/rfb/TightJPEGEncoder.cxx
@@ -101,6 +101,11 @@ void TightJPEGEncoder::setFineQualityLevel(int quality, int subsampling)
   fineSubsampling = subsampling;
 }
 
+int TightJPEGEncoder::getQualityLevel()
+{
+  return qualityLevel;
+}
+
 void TightJPEGEncoder::writeRect(const PixelBuffer* pb, const Palette& palette)
 {
   const rdr::U8* buffer;

--- a/common/rfb/TightJPEGEncoder.cxx
+++ b/common/rfb/TightJPEGEncoder.cxx
@@ -64,7 +64,7 @@ static const struct TightJPEGConfiguration conf[10] = {
 
 
 TightJPEGEncoder::TightJPEGEncoder(SConnection* conn) :
-  Encoder(conn, encodingTight, (EncoderFlags)(EncoderUseNativePF | EncoderLossy), -1),
+  Encoder(conn, encodingTight, (EncoderFlags)(EncoderUseNativePF | EncoderLossy)),
   qualityLevel(-1), fineQuality(-1), fineSubsampling(subsampleUndefined)
 {
 }

--- a/common/rfb/TightJPEGEncoder.h
+++ b/common/rfb/TightJPEGEncoder.h
@@ -35,6 +35,8 @@ namespace rfb {
     virtual void setQualityLevel(int level);
     virtual void setFineQualityLevel(int quality, int subsampling);
 
+    virtual int getQualityLevel();
+
     virtual void writeRect(const PixelBuffer* pb, const Palette& palette);
     virtual void writeSolidRect(int width, int height,
                                 const PixelFormat& pf,

--- a/common/rfb/Timer.cxx
+++ b/common/rfb/Timer.cxx
@@ -151,7 +151,7 @@ int Timer::getTimeoutMs() {
 int Timer::getRemainingMs() {
   timeval now;
   gettimeofday(&now, 0);
-  return __rfbmax(0, diffTimeMillis(pending.front()->dueTime, now));
+  return __rfbmax(0, diffTimeMillis(dueTime, now));
 }
 
 bool Timer::isBefore(timeval other) {

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -1094,11 +1094,16 @@ void VNCSConnectionST::writeDataUpdate()
     //        afford a larger update size
     nextUpdate = server->msToNextUpdate();
     if (nextUpdate > 0) {
-      size_t maxUpdateSize;
+      size_t bandwidth, maxUpdateSize;
 
       // FIXME: Bandwidth estimation without congestion control
-      maxUpdateSize = congestion.getBandwidth() * nextUpdate / 1000;
+      bandwidth = congestion.getBandwidth();
 
+      // FIXME: Hard coded value for maximum CPU throughput
+      if (bandwidth > 5000000)
+        bandwidth = 5000000;
+
+      maxUpdateSize = bandwidth * nextUpdate / 1000;
       encodeManager.writeLosslessRefresh(req, server->getPixelBuffer(),
                                          cursor, maxUpdateSize);
     }

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -1087,18 +1087,21 @@ void VNCSConnectionST::writeDataUpdate()
   if (!ui.is_empty())
     encodeManager.writeUpdate(ui, server->getPixelBuffer(), cursor);
   else {
-    size_t maxUpdateSize;
+    int nextUpdate;
 
     // FIXME: If continuous updates aren't used then the client might
     //        be slower than frameRate in its requests and we could
     //        afford a larger update size
+    nextUpdate = server->msToNextUpdate();
+    if (nextUpdate > 0) {
+      size_t maxUpdateSize;
 
-    // FIXME: Bandwidth estimation without congestion control
-    maxUpdateSize = congestion.getBandwidth() *
-                    server->msToNextUpdate() / 1000;
+      // FIXME: Bandwidth estimation without congestion control
+      maxUpdateSize = congestion.getBandwidth() * nextUpdate / 1000;
 
-    encodeManager.writeLosslessRefresh(req, server->getPixelBuffer(),
-                                       cursor, maxUpdateSize);
+      encodeManager.writeLosslessRefresh(req, server->getPixelBuffer(),
+                                         cursor, maxUpdateSize);
+    }
   }
 
   writeRTTPing();

--- a/common/rfb/VNCSConnectionST.h
+++ b/common/rfb/VNCSConnectionST.h
@@ -191,6 +191,7 @@ namespace rfb {
 
     Congestion congestion;
     Timer congestionTimer;
+    Timer losslessTimer;
 
     VNCServerST* server;
     SimpleUpdateTracker updates;


### PR DESCRIPTION
Various improvements to the lossless refresh mechanism:

 * Bug fix where the refresh size was mis-estimated
 * Limit on size to avoid overshooting the target because of CPU usage
 * Fix corner case of trying to send a refresh even though we're out of time
 * Avoid refreshing areas that keep getting overwritten
 * Allow high quality JPEG to be considered "lossless" as users will not be able to tell the difference