### PR TITLE
Better handling of Meta keysym

### DIFF
--- a/unix/xserver/hw/vnc/Input.c
+++ b/unix/xserver/hw/vnc/Input.c
@@ -537,9 +537,9 @@ static void vncKeysymKeyboardEvent(KeySym keysym, int down)
 	 * get confused when we do a fake shift to get the same effect
 	 * that having NumLock active would produce.
 	 *
-	 * Until we have proper NumLock synchronisation (so we can
-	 * avoid faking shift), we try to avoid the fake shifts if we
-	 * can use an alternative keysym.
+	 * Not all clients have proper NumLock synchronisation (so we
+	 * can avoid faking shift) so we try to avoid the fake shifts
+	 * if we can use an alternative keysym.
 	 */
 	if (((state & ShiftMask) != (new_state & ShiftMask)) &&
 	    vncGetAvoidShiftNumLock() && vncIsAffectedByNumLock(keycode)) {

--- a/win/rfb_win32/keymap.h
+++ b/win/rfb_win32/keymap.h
@@ -134,6 +134,8 @@ static keymap_t keymap[] = {
   { XK_Control_R,        VK_CONTROL, 1 },
   { XK_Alt_L,            VK_MENU, 0 },
   { XK_Alt_R,            VK_MENU, 1 },
+  { XK_Meta_L,           VK_MENU, 0 },
+  { XK_Meta_R,           VK_MENU, 1 },
 
   // Left & Right Windows keys & Windows Menu Key
 


### PR DESCRIPTION
Shift+Alt sometimes sends Shift+Alt and sometimes Shift+Meta which can cause some confusion. Adjust things to be a bit more compatible.