### PR TITLE
Avoid potential crash when replacing buffer in PlainPasswd

### DIFF
--- a/common/rfb/util.h
+++ b/common/rfb/util.h
@@ -50,7 +50,7 @@ namespace rfb {
     CharArray() : buf(0) {}
     CharArray(char* str) : buf(str) {} // note: assumes ownership
     CharArray(int len) {
-      buf = new char[len];
+      buf = new char[len]();
     }
     ~CharArray() {
       delete [] buf;


### PR DESCRIPTION
This is reproducible when using `export MALLOC_CHECK_=2 MALLOC_PERTURB_=204` and running vncpasswd `echo "123456" | vncpasswd -f >/tmp/out`. In vncpassd we use fgets() to set buffer in CharArray, but using vncpasswd as mentioned before, second run of fgets won't read anything, setting some unknown string to the buffer and then when PlainPasswd destructor is called, we attempt to replace the buffer with zeros, which might fail on getting buffer length. In this case we can use length we get from the contructor. Also add some additional checks to avoid deleting empty buffer.