### PR TITLE
Define "TigerVNC Viewer" in header, to get a consistent spelling

### DIFF
--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -38,6 +38,7 @@
 #include "i18n.h"
 #include "menukey.h"
 #include "parameters.h"
+#include "vncviewer.h"
 
 #include <FL/Fl_Tabs.H>
 #include <FL/Fl_Button.H>
@@ -54,7 +55,7 @@ using namespace rfb;
 std::map<OptionsCallback*, void*> OptionsDialog::callbacks;
 
 OptionsDialog::OptionsDialog()
-  : Fl_Window(450, 450, _("VNC Viewer: Connection Options"))
+  : Fl_Window(450, 450, _(PROGNAME_LONG ": Connection Options"))
 {
   int x, y;
   Fl_Button *button;

--- a/vncviewer/ServerDialog.cxx
+++ b/vncviewer/ServerDialog.cxx
@@ -39,7 +39,7 @@
 #include "rfb/Exception.h"
 
 ServerDialog::ServerDialog()
-  : Fl_Window(450, 160, _("VNC Viewer: Connection Details"))
+  : Fl_Window(450, 160, _(PROGNAME_LONG ": Connection Details"))
 {
   int x, y;
   Fl_Button *button;

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -1214,7 +1214,7 @@ void Viewport::initContextMenu()
                 0, NULL, (void*)ID_OPTIONS, 0);
   fltk_menu_add(contextMenu, p_("ContextMenu|", "Connection &info..."),
                 0, NULL, (void*)ID_INFO, 0);
-  fltk_menu_add(contextMenu, p_("ContextMenu|", "About &TigerVNC viewer..."),
+  fltk_menu_add(contextMenu, p_("ContextMenu|", "About &" PROGNAME_LONG "..."),
                 0, NULL, (void*)ID_ABOUT, FL_MENU_DIVIDER);
 
   fltk_menu_add(contextMenu, p_("ContextMenu|", "Dismiss &menu"),

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -31,6 +31,7 @@
 #include <tchar.h>
 #endif
 
+#include "vncviewer.h"
 #include "parameters.h"
 
 #include <os/os.h>
@@ -135,7 +136,7 @@ BoolParameter sendPrimary("SendPrimary",
                           "server as well as the clipboard selection",
                           true);
 StringParameter display("display",
-			"Specifies the X display on which the VNC viewer window should appear.",
+			"Specifies the X display on which the " PROGNAME_LONG " window should appear.",
 			"");
 #endif
 
@@ -395,7 +396,7 @@ static void saveToReg(const char* servername) {
   HKEY hKey;
     
   LONG res = RegCreateKeyExW(HKEY_CURRENT_USER,
-                             L"Software\\TigerVNC\\vncviewer", 0, NULL,
+                             L"Software\\TigerVNC\\" PROGNAME_SHORT, 0, NULL,
                              REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL,
                              &hKey, NULL);
   if (res != ERROR_SUCCESS) {

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -97,7 +97,7 @@ static const char *about_text()
   // encodings, so we need to make sure we get a fresh string every
   // time.
   snprintf(buffer, sizeof(buffer),
-           _("TigerVNC Viewer %d-bit v%s\n"
+           _(PROGNAME_LONG " %d-bit v%s\n"
              "Built on: %s\n"
              "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
              "See http://www.tigervnc.org for information on TigerVNC."),
@@ -124,7 +124,7 @@ bool should_exit()
 
 void about_vncviewer()
 {
-  fl_message_title(_("About TigerVNC Viewer"));
+  fl_message_title(_("About " PROGNAME_LONG));
   fl_message("%s", about_text());
 }
 
@@ -155,7 +155,7 @@ static void new_connection_cb(Fl_Widget *widget, void *data)
 
   pid = fork();
   if (pid == -1) {
-    vlog.error(_("Error starting new TigerVNC Viewer: %s"), strerror(errno));
+    vlog.error(_("Error starting new " PROGNAME_LONG ": %s"), strerror(errno));
     return;
   }
 
@@ -167,7 +167,7 @@ static void new_connection_cb(Fl_Widget *widget, void *data)
 
   execvp(argv[0], (char * const *)argv);
 
-  vlog.error(_("Error starting new TigerVNC Viewer: %s"), strerror(errno));
+  vlog.error(_("Error starting new " PROGNAME_LONG ": %s"), strerror(errno));
   _exit(1);
 }
 #endif
@@ -176,7 +176,7 @@ static void CleanupSignalHandler(int sig)
 {
   // CleanupSignalHandler allows C++ object cleanup to happen because it calls
   // exit() rather than the default which is to abort.
-  vlog.info(_("Termination signal %d has been received. TigerVNC Viewer will now exit."), sig);
+  vlog.info(_("Termination signal %d has been received. " PROGNAME_LONG " will now exit."), sig);
   exit(1);
 }
 
@@ -197,7 +197,7 @@ static void init_fltk()
 
   // Proper Gnome Shell integration requires that we set a sensible
   // WM_CLASS for the window.
-  Fl_Window::default_xclass("vncviewer");
+  Fl_Window::default_xclass(PROGNAME_SHORT);
 
   // Set the default icon for all windows.
 #ifdef WIN32
@@ -268,7 +268,7 @@ static void init_fltk()
   fl_message_hotspot(false);
 
   // Avoid empty titles for popups
-  fl_message_title_default(_("TigerVNC Viewer"));
+  fl_message_title_default(_(PROGNAME_LONG));
 
 #ifdef WIN32
   // Most "normal" Windows apps use this font for UI elements.
@@ -511,9 +511,9 @@ int main(int argc, char** argv)
 
   rfb::initStdIOLoggers();
 #ifdef WIN32
-  rfb::initFileLogger("C:\\temp\\vncviewer.log");
+  rfb::initFileLogger("C:\\temp\\" PROGNAME_SHORT ".log");
 #else
-  rfb::initFileLogger("/tmp/vncviewer.log");
+  rfb::initFileLogger("/tmp/" PROGNAME_SHORT ".log");
 #endif
   rfb::LogWriter::setLogParams("*:stderr:30");
 

--- a/vncviewer/vncviewer.h
+++ b/vncviewer/vncviewer.h
@@ -19,7 +19,12 @@
 #ifndef __VNCVIEWER_H__
 #define __VNCVIEWER_H__
 
+#include <stddef.h>
+
 #define VNCSERVERNAMELEN 256
+
+#define PROGNAME_SHORT "vncviewer"
+#define PROGNAME_LONG "TigerVNC Viewer"
 
 void exit_vncviewer(const char *error = NULL);
 bool should_exit();


### PR DESCRIPTION
It turns out that we were using all four variants:

VNC Viewer
VNC viewer
TigerVNC viewer
TigerVNC Viewer

Also define "vncviewer" in the same way.