### PR TITLE
Use RawKeyboard by default

### DIFF
--- a/unix/x0vncserver/XDesktop.cxx
+++ b/unix/x0vncserver/XDesktop.cxx
@@ -52,7 +52,7 @@ BoolParameter useShm("UseSHM", "Use MIT-SHM extension if available", true);
 BoolParameter rawKeyboard("RawKeyboard",
                           "Send keyboard events straight through and "
                           "avoid mapping them to the current keyboard "
-                          "layout", false);
+                          "layout", true);
 
 static rfb::LogWriter vlog("XDesktop");
 


### PR DESCRIPTION
The keyboard implementation in x0vncserver is very basic and has many
issues, for example #528.