### PR TITLE
Run listener destructors before terminating

### DIFF
--- a/unix/x0vncserver/x0vncserver.cxx
+++ b/unix/x0vncserver/x0vncserver.cxx
@@ -439,6 +439,13 @@ int main(int argc, char** argv)
 
   TXWindow::handleXEvents(dpy);
 
+  // Run listener destructors; remove UNIX sockets etc
+  for (std::list<SocketListener*>::iterator i = listeners.begin();
+       i != listeners.end();
+       i++) {
+    delete *i;
+  }
+
   vlog.info("Terminated");
   return 0;
 }


### PR DESCRIPTION
Must be done in order to remove UNIX sockets etc.