### PR TITLE
Split ConnParams and clean up connection objects

### DIFF
--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -595,37 +595,9 @@ void CConnection::updateEncodings()
 
   encodings.push_back(encodingCopyRect);
 
-  /*
-   * Prefer encodings in this order:
-   *
-   *   Tight, ZRLE, Hextile, *
-   */
-
-  if ((preferredEncoding != encodingTight) &&
-      Decoder::supported(encodingTight))
-    encodings.push_back(encodingTight);
-
-  if ((preferredEncoding != encodingZRLE) &&
-      Decoder::supported(encodingZRLE))
-    encodings.push_back(encodingZRLE);
-
-  if ((preferredEncoding != encodingHextile) &&
-      Decoder::supported(encodingHextile))
-    encodings.push_back(encodingHextile);
-
-  // Remaining encodings
   for (int i = encodingMax; i >= 0; i--) {
-    switch (i) {
-    case encodingCopyRect:
-    case encodingTight:
-    case encodingZRLE:
-    case encodingHextile:
-      /* These have already been sent earlier */
-      break;
-    default:
-      if ((i != preferredEncoding) && Decoder::supported(i))
-        encodings.push_back(i);
-    }
+    if ((i != preferredEncoding) && Decoder::supported(i))
+      encodings.push_back(i);
   }
 
   if (server.compressLevel >= 0 && server.compressLevel <= 9)

--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -335,6 +335,14 @@ void CConnection::setExtendedDesktopSize(unsigned reason,
   CMsgHandler::setExtendedDesktopSize(reason, result, w, h, layout);
 }
 
+void CConnection::serverInit()
+{
+  state_ = RFBSTATE_NORMAL;
+  vlog.debug("initialisation done");
+
+  initDone();
+}
+
 void CConnection::readAndDecodeRect(const Rect& r, int encoding,
                                     ModifiablePixelBuffer* pb)
 {
@@ -363,10 +371,8 @@ void CConnection::authSuccess()
 {
 }
 
-void CConnection::serverInit()
+void CConnection::initDone()
 {
-  state_ = RFBSTATE_NORMAL;
-  vlog.debug("initialisation done");
 }
 
 void CConnection::fence(rdr::U32 flags, unsigned len, const char data[])

--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -16,6 +16,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
  * USA.
  */
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -335,12 +336,19 @@ void CConnection::setExtendedDesktopSize(unsigned reason,
   CMsgHandler::setExtendedDesktopSize(reason, result, w, h, layout);
 }
 
-void CConnection::serverInit()
+void CConnection::serverInit(int width, int height,
+                             const PixelFormat& pf,
+                             const char* name)
 {
+  CMsgHandler::serverInit(width, height, pf, name);
+
   state_ = RFBSTATE_NORMAL;
   vlog.debug("initialisation done");
 
   initDone();
+  assert(framebuffer != NULL);
+  assert(framebuffer->width() == server.width());
+  assert(framebuffer->height() == server.height());
 }
 
 void CConnection::readAndDecodeRect(const Rect& r, int encoding,

--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -41,10 +41,14 @@ using namespace rfb;
 static LogWriter vlog("CConnection");
 
 CConnection::CConnection()
-  : csecurity(0), is(0), os(0), reader_(0), writer_(0),
+  : csecurity(0),
+    supportsLocalCursor(false), supportsDesktopResize(false),
+    supportsLEDState(false),
+    is(0), os(0), reader_(0), writer_(0),
     shared(false),
     state_(RFBSTATE_UNINITIALISED), useProtocol3_3(false),
     pendingPFChange(false), preferredEncoding(encodingTight),
+    compressLevel(2), qualityLevel(-1),
     formatChange(false), encodingChange(false),
     firstUpdate(true), pendingUpdate(false), continuousUpdates(false),
     forceNonincremental(true),
@@ -498,19 +502,19 @@ int CConnection::getPreferredEncoding()
 
 void CConnection::setCompressLevel(int level)
 {
-  if (server.compressLevel == level)
+  if (compressLevel == level)
     return;
 
-  server.compressLevel = level;
+  compressLevel = level;
   encodingChange = true;
 }
 
 void CConnection::setQualityLevel(int level)
 {
-  if (server.qualityLevel == level)
+  if (qualityLevel == level)
     return;
 
-  server.qualityLevel = level;
+  qualityLevel = level;
   encodingChange = true;
 }
 
@@ -590,16 +594,16 @@ void CConnection::updateEncodings()
 {
   std::list<rdr::U32> encodings;
 
-  if (server.supportsLocalCursor) {
+  if (supportsLocalCursor) {
     encodings.push_back(pseudoEncodingCursorWithAlpha);
     encodings.push_back(pseudoEncodingCursor);
     encodings.push_back(pseudoEncodingXCursor);
   }
-  if (server.supportsDesktopResize) {
+  if (supportsDesktopResize) {
     encodings.push_back(pseudoEncodingDesktopSize);
     encodings.push_back(pseudoEncodingExtendedDesktopSize);
   }
-  if (server.supportsLEDState)
+  if (supportsLEDState)
     encodings.push_back(pseudoEncodingLEDState);
 
   encodings.push_back(pseudoEncodingDesktopName);
@@ -619,10 +623,10 @@ void CConnection::updateEncodings()
       encodings.push_back(i);
   }
 
-  if (server.compressLevel >= 0 && server.compressLevel <= 9)
-      encodings.push_back(pseudoEncodingCompressLevel0 + server.compressLevel);
-  if (server.qualityLevel >= 0 && server.qualityLevel <= 9)
-      encodings.push_back(pseudoEncodingQualityLevel0 + server.qualityLevel);
+  if (compressLevel >= 0 && compressLevel <= 9)
+      encodings.push_back(pseudoEncodingCompressLevel0 + compressLevel);
+  if (qualityLevel >= 0 && qualityLevel <= 9)
+      encodings.push_back(pseudoEncodingQualityLevel0 + qualityLevel);
 
   writer()->writeSetEncodings(encodings);
 }

--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -73,6 +73,11 @@ void CConnection::setFramebuffer(ModifiablePixelBuffer* fb)
 {
   decoder.flush();
 
+  if (fb) {
+    assert(fb->width() == server.width());
+    assert(fb->height() == server.height());
+  }
+
   if ((framebuffer != NULL) && (fb != NULL)) {
     Rect rect;
 
@@ -334,6 +339,11 @@ void CConnection::setDesktopSize(int w, int h)
     writer()->writeEnableContinuousUpdates(true, 0, 0,
                                            server.width(),
                                            server.height());
+
+  resizeFramebuffer();
+  assert(framebuffer != NULL);
+  assert(framebuffer->width() == server.width());
+  assert(framebuffer->height() == server.height());
 }
 
 void CConnection::setExtendedDesktopSize(unsigned reason,
@@ -349,6 +359,11 @@ void CConnection::setExtendedDesktopSize(unsigned reason,
     writer()->writeEnableContinuousUpdates(true, 0, 0,
                                            server.width(),
                                            server.height());
+
+  resizeFramebuffer();
+  assert(framebuffer != NULL);
+  assert(framebuffer->width() == server.width());
+  assert(framebuffer->height() == server.height());
 }
 
 void CConnection::endOfContinuousUpdates()
@@ -450,6 +465,11 @@ void CConnection::authSuccess()
 
 void CConnection::initDone()
 {
+}
+
+void CConnection::resizeFramebuffer()
+{
+  assert(false);
 }
 
 void CConnection::refreshFramebuffer()
@@ -575,10 +595,10 @@ void CConnection::updateEncodings()
     encodings.push_back(pseudoEncodingCursor);
     encodings.push_back(pseudoEncodingXCursor);
   }
-  if (server.supportsDesktopResize)
+  if (server.supportsDesktopResize) {
     encodings.push_back(pseudoEncodingDesktopSize);
-  if (server.supportsExtendedDesktopSize)
     encodings.push_back(pseudoEncodingExtendedDesktopSize);
+  }
   if (server.supportsLEDState)
     encodings.push_back(pseudoEncodingLEDState);
 

--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -568,33 +568,32 @@ void CConnection::requestNewUpdate()
 
 void CConnection::updateEncodings()
 {
-  int nEncodings = 0;
-  rdr::U32 encodings[encodingMax+3];
+  std::list<rdr::U32> encodings;
 
   if (server.supportsLocalCursor) {
-    encodings[nEncodings++] = pseudoEncodingCursorWithAlpha;
-    encodings[nEncodings++] = pseudoEncodingCursor;
-    encodings[nEncodings++] = pseudoEncodingXCursor;
+    encodings.push_back(pseudoEncodingCursorWithAlpha);
+    encodings.push_back(pseudoEncodingCursor);
+    encodings.push_back(pseudoEncodingXCursor);
   }
   if (server.supportsDesktopResize)
-    encodings[nEncodings++] = pseudoEncodingDesktopSize;
+    encodings.push_back(pseudoEncodingDesktopSize);
   if (server.supportsExtendedDesktopSize)
-    encodings[nEncodings++] = pseudoEncodingExtendedDesktopSize;
+    encodings.push_back(pseudoEncodingExtendedDesktopSize);
   if (server.supportsDesktopRename)
-    encodings[nEncodings++] = pseudoEncodingDesktopName;
+    encodings.push_back(pseudoEncodingDesktopName);
   if (server.supportsLEDState)
-    encodings[nEncodings++] = pseudoEncodingLEDState;
+    encodings.push_back(pseudoEncodingLEDState);
 
-  encodings[nEncodings++] = pseudoEncodingLastRect;
-  encodings[nEncodings++] = pseudoEncodingContinuousUpdates;
-  encodings[nEncodings++] = pseudoEncodingFence;
-  encodings[nEncodings++] = pseudoEncodingQEMUKeyEvent;
+  encodings.push_back(pseudoEncodingLastRect);
+  encodings.push_back(pseudoEncodingContinuousUpdates);
+  encodings.push_back(pseudoEncodingFence);
+  encodings.push_back(pseudoEncodingQEMUKeyEvent);
 
   if (Decoder::supported(preferredEncoding)) {
-    encodings[nEncodings++] = preferredEncoding;
+    encodings.push_back(preferredEncoding);
   }
 
-  encodings[nEncodings++] = encodingCopyRect;
+  encodings.push_back(encodingCopyRect);
 
   /*
    * Prefer encodings in this order:
@@ -604,15 +603,15 @@ void CConnection::updateEncodings()
 
   if ((preferredEncoding != encodingTight) &&
       Decoder::supported(encodingTight))
-    encodings[nEncodings++] = encodingTight;
+    encodings.push_back(encodingTight);
 
   if ((preferredEncoding != encodingZRLE) &&
       Decoder::supported(encodingZRLE))
-    encodings[nEncodings++] = encodingZRLE;
+    encodings.push_back(encodingZRLE);
 
   if ((preferredEncoding != encodingHextile) &&
       Decoder::supported(encodingHextile))
-    encodings[nEncodings++] = encodingHextile;
+    encodings.push_back(encodingHextile);
 
   // Remaining encodings
   for (int i = encodingMax; i >= 0; i--) {
@@ -625,14 +624,14 @@ void CConnection::updateEncodings()
       break;
     default:
       if ((i != preferredEncoding) && Decoder::supported(i))
-        encodings[nEncodings++] = i;
+        encodings.push_back(i);
     }
   }
 
   if (server.compressLevel >= 0 && server.compressLevel <= 9)
-      encodings[nEncodings++] = pseudoEncodingCompressLevel0 + server.compressLevel;
+      encodings.push_back(pseudoEncodingCompressLevel0 + server.compressLevel);
   if (server.qualityLevel >= 0 && server.qualityLevel <= 9)
-      encodings[nEncodings++] = pseudoEncodingQualityLevel0 + server.qualityLevel;
+      encodings.push_back(pseudoEncodingQualityLevel0 + server.qualityLevel);
 
-  writer()->writeSetEncodings(nEncodings, encodings);
+  writer()->writeSetEncodings(encodings);
 }

--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -579,11 +579,10 @@ void CConnection::updateEncodings()
     encodings.push_back(pseudoEncodingDesktopSize);
   if (server.supportsExtendedDesktopSize)
     encodings.push_back(pseudoEncodingExtendedDesktopSize);
-  if (server.supportsDesktopRename)
-    encodings.push_back(pseudoEncodingDesktopName);
   if (server.supportsLEDState)
     encodings.push_back(pseudoEncodingLEDState);
 
+  encodings.push_back(pseudoEncodingDesktopName);
   encodings.push_back(pseudoEncodingLastRect);
   encodings.push_back(pseudoEncodingContinuousUpdates);
   encodings.push_back(pseudoEncodingFence);

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -127,6 +127,11 @@ namespace rfb {
     // returning.
     virtual void initDone() = 0;
 
+    // resizeFramebuffer() is called whenever the framebuffer
+    // dimensions or the screen layout changes. A subclass must make
+    // sure the pixel buffer has been updated once this call returns.
+    virtual void resizeFramebuffer();
+
 
     // Other methods
 

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -100,7 +100,9 @@ namespace rfb {
                                         int w, int h,
                                         const ScreenSet& layout);
 
-    virtual void serverInit();
+    virtual void serverInit(int width, int height,
+                            const PixelFormat& pf,
+                            const char* name);
 
     virtual void readAndDecodeRect(const Rect& r, int encoding,
                                    ModifiablePixelBuffer* pb);
@@ -118,8 +120,10 @@ namespace rfb {
     // initDone() is called when the connection is fully established
     // and standard messages can be sent. This is called before the
     // initial FramebufferUpdateRequest giving a derived class the
-    // chance to modify pixel format and settings.
-    virtual void initDone();
+    // chance to modify pixel format and settings. The derived class
+    // must also make sure it has provided a valid framebuffer before
+    // returning.
+    virtual void initDone() = 0;
 
 
     // Other methods

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -100,6 +100,8 @@ namespace rfb {
                                         int w, int h,
                                         const ScreenSet& layout);
 
+    virtual void serverInit();
+
     virtual void readAndDecodeRect(const Rect& r, int encoding,
                                    ModifiablePixelBuffer* pb);
 
@@ -113,9 +115,11 @@ namespace rfb {
     // authSuccess() is called when authentication has succeeded.
     virtual void authSuccess();
 
-    // serverInit() is called when the ServerInit message is received.  The
-    // derived class must call on to CConnection::serverInit().
-    virtual void serverInit();
+    // initDone() is called when the connection is fully established
+    // and standard messages can be sent. This is called before the
+    // initial FramebufferUpdateRequest giving a derived class the
+    // chance to modify pixel format and settings.
+    virtual void initDone();
 
 
     // Other methods

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -201,6 +201,7 @@ namespace rfb {
     void securityCompleted();
 
     void requestNewUpdate();
+    void updateEncodings();
 
     rdr::InStream* is;
     rdr::OutStream* os;

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -110,10 +110,6 @@ namespace rfb {
 
     // Methods to be overridden in a derived class
 
-    // getIdVerifier() returns the identity verifier associated with the connection.
-    // Ownership of the IdentityVerifier is retained by the CConnection instance.
-    virtual IdentityVerifier* getIdentityVerifier() {return 0;}
-
     // authSuccess() is called when authentication has succeeded.
     virtual void authSuccess();
 

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -188,6 +188,13 @@ namespace rfb {
 
     ModifiablePixelBuffer* getFramebuffer() { return framebuffer; }
 
+  protected:
+    // Optional capabilities that a subclass is expected to set to true
+    // if supported
+    bool supportsLocalCursor;
+    bool supportsDesktopResize;
+    bool supportsLEDState;
+
   private:
     // This is a default implementation of fences that automatically
     // responds to requests, stating no support for synchronisation.
@@ -224,6 +231,8 @@ namespace rfb {
     rfb::PixelFormat pendingPF;
 
     int preferredEncoding;
+    int compressLevel;
+    int qualityLevel;
 
     bool formatChange;
     rfb::PixelFormat nextPF;

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -100,6 +100,8 @@ namespace rfb {
                                         int w, int h,
                                         const ScreenSet& layout);
 
+    virtual void endOfContinuousUpdates();
+
     virtual void serverInit(int width, int height,
                             const PixelFormat& pf,
                             const char* name);
@@ -127,6 +129,24 @@ namespace rfb {
 
 
     // Other methods
+
+    // refreshFramebuffer() forces a complete refresh of the entire
+    // framebuffer
+    void refreshFramebuffer();
+
+    // setPreferredEncoding()/getPreferredEncoding() adjusts which
+    // encoding is listed first as a hint to the server that it is the
+    // preferred one
+    void setPreferredEncoding(int encoding);
+    int getPreferredEncoding();
+    // setCompressLevel()/setQualityLevel() controls the encoding hints
+    // sent to the server
+    void setCompressLevel(int level);
+    void setQualityLevel(int level);
+    // setPF() controls the pixel format requested from the server.
+    // server.pf() will automatically be adjusted once the new format
+    // is active.
+    void setPF(const PixelFormat& pf);
 
     CMsgReader* reader() { return reader_; }
     CMsgWriter* writer() { return writer_; }
@@ -180,6 +200,8 @@ namespace rfb {
     void throwConnFailedException();
     void securityCompleted();
 
+    void requestNewUpdate();
+
     rdr::InStream* is;
     rdr::OutStream* os;
     CMsgReader* reader_;
@@ -191,6 +213,21 @@ namespace rfb {
     CharArray serverName;
 
     bool useProtocol3_3;
+
+    bool pendingPFChange;
+    rfb::PixelFormat pendingPF;
+
+    int preferredEncoding;
+
+    bool formatChange;
+    rfb::PixelFormat nextPF;
+    bool encodingChange;
+
+    bool firstUpdate;
+    bool pendingUpdate;
+    bool continuousUpdates;
+
+    bool forceNonincremental;
 
     ModifiablePixelBuffer* framebuffer;
     DecodeManager decoder;

--- a/common/rfb/CMakeLists.txt
+++ b/common/rfb/CMakeLists.txt
@@ -43,6 +43,7 @@ set(RFB_SOURCES
   SMsgReader.cxx
   SMsgWriter.cxx
   ServerCore.cxx
+  ServerParams.cxx
   Security.cxx
   SecurityServer.cxx
   SecurityClient.cxx

--- a/common/rfb/CMakeLists.txt
+++ b/common/rfb/CMakeLists.txt
@@ -11,9 +11,9 @@ set(RFB_SOURCES
   CSecurityStack.cxx
   CSecurityVeNCrypt.cxx
   CSecurityVncAuth.cxx
+  ClientParams.cxx
   ComparingUpdateTracker.cxx
   Configuration.cxx
-  ConnParams.cxx
   CopyRectDecoder.cxx
   Cursor.cxx
   DecodeManager.cxx

--- a/common/rfb/CMsgHandler.cxx
+++ b/common/rfb/CMsgHandler.cxx
@@ -34,44 +34,44 @@ CMsgHandler::~CMsgHandler()
 
 void CMsgHandler::setDesktopSize(int width, int height)
 {
-  cp.setDimensions(width, height);
+  server.setDimensions(width, height);
 }
 
 void CMsgHandler::setExtendedDesktopSize(unsigned reason, unsigned result,
                                          int width, int height,
                                          const ScreenSet& layout)
 {
-  cp.supportsSetDesktopSize = true;
+  server.supportsSetDesktopSize = true;
 
   if ((reason == reasonClient) && (result != resultSuccess))
     return;
 
-  cp.setDimensions(width, height, layout);
+  server.setDimensions(width, height, layout);
 }
 
 void CMsgHandler::setPixelFormat(const PixelFormat& pf)
 {
-  cp.setPF(pf);
+  server.setPF(pf);
 }
 
 void CMsgHandler::setName(const char* name)
 {
-  cp.setName(name);
+  server.setName(name);
 }
 
 void CMsgHandler::fence(rdr::U32 flags, unsigned len, const char data[])
 {
-  cp.supportsFence = true;
+  server.supportsFence = true;
 }
 
 void CMsgHandler::endOfContinuousUpdates()
 {
-  cp.supportsContinuousUpdates = true;
+  server.supportsContinuousUpdates = true;
 }
 
 void CMsgHandler::supportsQEMUKeyEvent()
 {
-  cp.supportsQEMUKeyEvent = true;
+  server.supportsQEMUKeyEvent = true;
 }
 
 void CMsgHandler::framebufferUpdateStart()
@@ -84,5 +84,5 @@ void CMsgHandler::framebufferUpdateEnd()
 
 void CMsgHandler::setLEDState(unsigned int state)
 {
-  cp.setLEDState(state);
+  server.setLEDState(state);
 }

--- a/common/rfb/CMsgHandler.cxx
+++ b/common/rfb/CMsgHandler.cxx
@@ -34,8 +34,7 @@ CMsgHandler::~CMsgHandler()
 
 void CMsgHandler::setDesktopSize(int width, int height)
 {
-  cp.width = width;
-  cp.height = height;
+  cp.setDimensions(width, height);
 }
 
 void CMsgHandler::setExtendedDesktopSize(unsigned reason, unsigned result,
@@ -47,12 +46,7 @@ void CMsgHandler::setExtendedDesktopSize(unsigned reason, unsigned result,
   if ((reason == reasonClient) && (result != resultSuccess))
     return;
 
-  if (!layout.validate(width, height))
-    fprintf(stderr, "Server sent us an invalid screen layout\n");
-
-  cp.width = width;
-  cp.height = height;
-  cp.screenLayout = layout;
+  cp.setDimensions(width, height, layout);
 }
 
 void CMsgHandler::setPixelFormat(const PixelFormat& pf)

--- a/common/rfb/CMsgHandler.cxx
+++ b/common/rfb/CMsgHandler.cxx
@@ -74,6 +74,15 @@ void CMsgHandler::supportsQEMUKeyEvent()
   server.supportsQEMUKeyEvent = true;
 }
 
+void CMsgHandler::serverInit(int width, int height,
+                             const PixelFormat& pf,
+                             const char* name)
+{
+  server.setDimensions(width, height);
+  server.setPF(pf);
+  server.setName(name);
+}
+
 void CMsgHandler::framebufferUpdateStart()
 {
 }

--- a/common/rfb/CMsgHandler.h
+++ b/common/rfb/CMsgHandler.h
@@ -41,9 +41,9 @@ namespace rfb {
 
     // The following methods are called as corresponding messages are read.  A
     // derived class should override these methods as desired.  Note that for
-    // the setDesktopSize(), setExtendedDesktopSize(), setPixelFormat() and
-    // setName() methods, a derived class should call on to CMsgHandler's
-    // methods to set the members of "server" appropriately.
+    // the setDesktopSize(), setExtendedDesktopSize(), setPixelFormat(),
+    // setName() and serverInit() methods, a derived class should call on to
+    // CMsgHandler's methods to set the members of "server" appropriately.
 
     virtual void setDesktopSize(int w, int h);
     virtual void setExtendedDesktopSize(unsigned reason, unsigned result,
@@ -56,7 +56,9 @@ namespace rfb {
     virtual void fence(rdr::U32 flags, unsigned len, const char data[]);
     virtual void endOfContinuousUpdates();
     virtual void supportsQEMUKeyEvent();
-    virtual void serverInit() = 0;
+    virtual void serverInit(int width, int height,
+                            const PixelFormat& pf,
+                            const char* name) = 0;
 
     virtual void readAndDecodeRect(const Rect& r, int encoding,
                                    ModifiablePixelBuffer* pb) = 0;

--- a/common/rfb/CMsgHandler.h
+++ b/common/rfb/CMsgHandler.h
@@ -26,7 +26,7 @@
 
 #include <rdr/types.h>
 #include <rfb/Pixel.h>
-#include <rfb/ConnParams.h>
+#include <rfb/ServerParams.h>
 #include <rfb/Rect.h>
 #include <rfb/ScreenSet.h>
 
@@ -43,7 +43,7 @@ namespace rfb {
     // derived class should override these methods as desired.  Note that for
     // the setDesktopSize(), setExtendedDesktopSize(), setPixelFormat() and
     // setName() methods, a derived class should call on to CMsgHandler's
-    // methods to set the members of cp appropriately.
+    // methods to set the members of "server" appropriately.
 
     virtual void setDesktopSize(int w, int h);
     virtual void setExtendedDesktopSize(unsigned reason, unsigned result,
@@ -72,7 +72,7 @@ namespace rfb {
 
     virtual void setLEDState(unsigned int state);
 
-    ConnParams cp;
+    ServerParams server;
   };
 }
 #endif

--- a/common/rfb/CMsgReader.cxx
+++ b/common/rfb/CMsgReader.cxx
@@ -192,10 +192,10 @@ void CMsgReader::readFramebufferUpdate()
 
 void CMsgReader::readRect(const Rect& r, int encoding)
 {
-  if ((r.br.x > handler->cp.width) || (r.br.y > handler->cp.height)) {
+  if ((r.br.x > handler->cp.width()) || (r.br.y > handler->cp.height())) {
     fprintf(stderr, "Rect too big: %dx%d at %d,%d exceeds %dx%d\n",
 	    r.width(), r.height(), r.tl.x, r.tl.y,
-            handler->cp.width, handler->cp.height);
+            handler->cp.width(), handler->cp.height());
     throw Exception("Rect too big");
   }
 

--- a/common/rfb/CMsgReader.cxx
+++ b/common/rfb/CMsgReader.cxx
@@ -43,13 +43,10 @@ void CMsgReader::readServerInit()
 {
   int width = is->readU16();
   int height = is->readU16();
-  handler->setDesktopSize(width, height);
   PixelFormat pf;
   pf.read(is);
-  handler->setPixelFormat(pf);
   CharArray name(is->readString());
-  handler->setName(name.buf);
-  handler->serverInit();
+  handler->serverInit(width, height, pf, name.buf);
 }
 
 void CMsgReader::readMsg()

--- a/common/rfb/CMsgReader.cxx
+++ b/common/rfb/CMsgReader.cxx
@@ -192,10 +192,11 @@ void CMsgReader::readFramebufferUpdate()
 
 void CMsgReader::readRect(const Rect& r, int encoding)
 {
-  if ((r.br.x > handler->cp.width()) || (r.br.y > handler->cp.height())) {
+  if ((r.br.x > handler->server.width()) ||
+      (r.br.y > handler->server.height())) {
     fprintf(stderr, "Rect too big: %dx%d at %d,%d exceeds %dx%d\n",
 	    r.width(), r.height(), r.tl.x, r.tl.y,
-            handler->cp.width(), handler->cp.height());
+            handler->server.width(), handler->server.height());
     throw Exception("Rect too big");
   }
 
@@ -269,7 +270,7 @@ void CMsgReader::readSetCursor(int width, int height, const Point& hotspot)
   if (width > maxCursorSize || height > maxCursorSize)
     throw Exception("Too big cursor");
 
-  int data_len = width * height * (handler->cp.pf().bpp/8);
+  int data_len = width * height * (handler->server.pf().bpp/8);
   int mask_len = ((width+7)/8) * height;
   rdr::U8Array data(data_len);
   rdr::U8Array mask(mask_len);
@@ -290,14 +291,14 @@ void CMsgReader::readSetCursor(int width, int height, const Point& hotspot)
       int byte = y * maskBytesPerRow + x / 8;
       int bit = 7 - x % 8;
 
-      handler->cp.pf().rgbFromBuffer(out, in, 1);
+      handler->server.pf().rgbFromBuffer(out, in, 1);
 
       if (mask.buf[byte] & (1 << bit))
         out[3] = 255;
       else
         out[3] = 0;
 
-      in += handler->cp.pf().bpp/8;
+      in += handler->server.pf().bpp/8;
       out += 4;
     }
   }
@@ -321,10 +322,10 @@ void CMsgReader::readSetCursorWithAlpha(int width, int height, const Point& hots
 
   encoding = is->readS32();
 
-  origPF = handler->cp.pf();
-  handler->cp.setPF(rgbaPF);
+  origPF = handler->server.pf();
+  handler->server.setPF(rgbaPF);
   handler->readAndDecodeRect(pb.getRect(), encoding, &pb);
-  handler->cp.setPF(origPF);
+  handler->server.setPF(origPF);
 
   // On-wire data has pre-multiplied alpha, but we store it
   // non-pre-multiplied

--- a/common/rfb/CMsgWriter.cxx
+++ b/common/rfb/CMsgWriter.cxx
@@ -52,13 +52,14 @@ void CMsgWriter::writeSetPixelFormat(const PixelFormat& pf)
   endMsg();
 }
 
-void CMsgWriter::writeSetEncodings(int nEncodings, rdr::U32* encodings)
+void CMsgWriter::writeSetEncodings(const std::list<rdr::U32> encodings)
 {
+  std::list<rdr::U32>::const_iterator iter;
   startMsg(msgTypeSetEncodings);
   os->skip(1);
-  os->writeU16(nEncodings);
-  for (int i = 0; i < nEncodings; i++)
-    os->writeU32(encodings[i]);
+  os->writeU16(encodings.size());
+  for (iter = encodings.begin(); iter != encodings.end(); ++iter)
+    os->writeU32(*iter);
   endMsg();
 }
 

--- a/common/rfb/CMsgWriter.cxx
+++ b/common/rfb/CMsgWriter.cxx
@@ -245,8 +245,8 @@ void CMsgWriter::writePointerEvent(const Point& pos, int buttonMask)
   Point p(pos);
   if (p.x < 0) p.x = 0;
   if (p.y < 0) p.y = 0;
-  if (p.x >= cp->width) p.x = cp->width - 1;
-  if (p.y >= cp->height) p.y = cp->height - 1;
+  if (p.x >= cp->width()) p.x = cp->width() - 1;
+  if (p.y >= cp->height()) p.y = cp->height() - 1;
 
   startMsg(msgTypePointerEvent);
   os->writeU8(buttonMask);

--- a/common/rfb/CMsgWriter.h
+++ b/common/rfb/CMsgWriter.h
@@ -44,7 +44,6 @@ namespace rfb {
 
     void writeSetPixelFormat(const PixelFormat& pf);
     void writeSetEncodings(int nEncodings, rdr::U32* encodings);
-    void writeSetEncodings(int preferredEncoding, bool useCopyRect);
     void writeSetDesktopSize(int width, int height, const ScreenSet& layout);
 
     void writeFramebufferUpdateRequest(const Rect& r,bool incremental);

--- a/common/rfb/CMsgWriter.h
+++ b/common/rfb/CMsgWriter.h
@@ -23,6 +23,8 @@
 #ifndef __RFB_CMSGWRITER_H__
 #define __RFB_CMSGWRITER_H__
 
+#include <list>
+
 #include <rdr/types.h>
 
 namespace rdr { class OutStream; }
@@ -43,7 +45,7 @@ namespace rfb {
     void writeClientInit(bool shared);
 
     void writeSetPixelFormat(const PixelFormat& pf);
-    void writeSetEncodings(int nEncodings, rdr::U32* encodings);
+    void writeSetEncodings(const std::list<rdr::U32> encodings);
     void writeSetDesktopSize(int width, int height, const ScreenSet& layout);
 
     void writeFramebufferUpdateRequest(const Rect& r,bool incremental);

--- a/common/rfb/CMsgWriter.h
+++ b/common/rfb/CMsgWriter.h
@@ -30,14 +30,14 @@ namespace rdr { class OutStream; }
 namespace rfb {
 
   class PixelFormat;
-  class ConnParams;
+  class ServerParams;
   struct ScreenSet;
   struct Point;
   struct Rect;
 
   class CMsgWriter {
   public:
-    CMsgWriter(ConnParams* cp, rdr::OutStream* os);
+    CMsgWriter(ServerParams* server, rdr::OutStream* os);
     virtual ~CMsgWriter();
 
     void writeClientInit(bool shared);
@@ -60,7 +60,7 @@ namespace rfb {
     void startMsg(int type);
     void endMsg();
 
-    ConnParams* cp;
+    ServerParams* server;
     rdr::OutStream* os;
   };
 }

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -34,7 +34,6 @@
 #endif
 
 #include <rfb/CSecurityTLS.h>
-#include <rfb/SSecurityVeNCrypt.h> 
 #include <rfb/CConnection.h>
 #include <rfb/LogWriter.h>
 #include <rfb/Exception.h>

--- a/common/rfb/CSecurityTLS.h
+++ b/common/rfb/CSecurityTLS.h
@@ -31,7 +31,6 @@
 #endif
 
 #include <rfb/CSecurity.h>
-#include <rfb/SSecurityVeNCrypt.h>
 #include <rfb/Security.h>
 #include <rfb/UserMsgBox.h>
 #include <rdr/InStream.h>

--- a/common/rfb/ClientParams.cxx
+++ b/common/rfb/ClientParams.cxx
@@ -147,6 +147,15 @@ bool ClientParams::supportsLocalCursor() const
   return false;
 }
 
+bool ClientParams::supportsDesktopSize() const
+{
+  if (supportsEncoding(pseudoEncodingExtendedDesktopSize))
+    return true;
+  if (supportsEncoding(pseudoEncodingDesktopSize))
+    return true;
+  return false;
+}
+
 bool ClientParams::supportsLEDState() const
 {
   if (supportsEncoding(pseudoEncodingLEDState))

--- a/common/rfb/ClientParams.cxx
+++ b/common/rfb/ClientParams.cxx
@@ -26,14 +26,6 @@ using namespace rfb;
 
 ClientParams::ClientParams()
   : majorVersion(0), minorVersion(0),
-    useCopyRect(false),
-    supportsLocalCursor(false), supportsLocalXCursor(false),
-    supportsLocalCursorWithAlpha(false),
-    supportsDesktopResize(false), supportsExtendedDesktopSize(false),
-    supportsDesktopRename(false), supportsLastRect(false),
-    supportsLEDState(false), supportsQEMUKeyEvent(false),
-    supportsSetDesktopSize(false), supportsFence(false),
-    supportsContinuousUpdates(false),
     compressLevel(2), qualityLevel(-1), fineQualityLevel(-1),
     subsampling(subsampleUndefined),
     width_(0), height_(0), name_(0),
@@ -93,14 +85,6 @@ bool ClientParams::supportsEncoding(rdr::S32 encoding) const
 
 void ClientParams::setEncodings(int nEncodings, const rdr::S32* encodings)
 {
-  useCopyRect = false;
-  supportsLocalCursor = false;
-  supportsLocalCursorWithAlpha = false;
-  supportsDesktopResize = false;
-  supportsExtendedDesktopSize = false;
-  supportsLocalXCursor = false;
-  supportsLastRect = false;
-  supportsQEMUKeyEvent = false;
   compressLevel = -1;
   qualityLevel = -1;
   fineQualityLevel = -1;
@@ -111,42 +95,6 @@ void ClientParams::setEncodings(int nEncodings, const rdr::S32* encodings)
 
   for (int i = nEncodings-1; i >= 0; i--) {
     switch (encodings[i]) {
-    case encodingCopyRect:
-      useCopyRect = true;
-      break;
-    case pseudoEncodingCursor:
-      supportsLocalCursor = true;
-      break;
-    case pseudoEncodingXCursor:
-      supportsLocalXCursor = true;
-      break;
-    case pseudoEncodingCursorWithAlpha:
-      supportsLocalCursorWithAlpha = true;
-      break;
-    case pseudoEncodingDesktopSize:
-      supportsDesktopResize = true;
-      break;
-    case pseudoEncodingExtendedDesktopSize:
-      supportsExtendedDesktopSize = true;
-      break;
-    case pseudoEncodingDesktopName:
-      supportsDesktopRename = true;
-      break;
-    case pseudoEncodingLastRect:
-      supportsLastRect = true;
-      break;
-    case pseudoEncodingLEDState:
-      supportsLEDState = true;
-      break;
-    case pseudoEncodingQEMUKeyEvent:
-      supportsQEMUKeyEvent = true;
-      break;
-    case pseudoEncodingFence:
-      supportsFence = true;
-      break;
-    case pseudoEncodingContinuousUpdates:
-      supportsContinuousUpdates = true;
-      break;
     case pseudoEncodingSubsamp1X:
       subsampling = subsampleNone;
       break;
@@ -179,12 +127,43 @@ void ClientParams::setEncodings(int nEncodings, const rdr::S32* encodings)
         encodings[i] <= pseudoEncodingFineQualityLevel100)
       fineQualityLevel = encodings[i] - pseudoEncodingFineQualityLevel0;
 
-    if (encodings[i] > 0)
-      encodings_.insert(encodings[i]);
+    encodings_.insert(encodings[i]);
   }
 }
 
 void ClientParams::setLEDState(unsigned int state)
 {
   ledState_ = state;
+}
+
+bool ClientParams::supportsLocalCursor() const
+{
+  if (supportsEncoding(pseudoEncodingCursorWithAlpha))
+    return true;
+  if (supportsEncoding(pseudoEncodingCursor))
+    return true;
+  if (supportsEncoding(pseudoEncodingXCursor))
+    return true;
+  return false;
+}
+
+bool ClientParams::supportsLEDState() const
+{
+  if (supportsEncoding(pseudoEncodingLEDState))
+    return true;
+  return false;
+}
+
+bool ClientParams::supportsFence() const
+{
+  if (supportsEncoding(pseudoEncodingFence))
+    return true;
+  return false;
+}
+
+bool ClientParams::supportsContinuousUpdates() const
+{
+  if (supportsEncoding(pseudoEncodingContinuousUpdates))
+    return true;
+  return false;
 }

--- a/common/rfb/ClientParams.cxx
+++ b/common/rfb/ClientParams.cxx
@@ -1,6 +1,6 @@
 /* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
  * Copyright (C) 2011 D. R. Commander.  All Rights Reserved.
- * Copyright 2014 Pierre Ossman for Cendio AB
+ * Copyright 2014-2018 Pierre Ossman for Cendio AB
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,16 +17,14 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
  * USA.
  */
-#include <stdio.h>
 #include <rfb/Exception.h>
 #include <rfb/encodings.h>
 #include <rfb/ledStates.h>
-#include <rfb/ConnParams.h>
-#include <rfb/util.h>
+#include <rfb/ClientParams.h>
 
 using namespace rfb;
 
-ConnParams::ConnParams()
+ClientParams::ClientParams()
   : majorVersion(0), minorVersion(0),
     useCopyRect(false),
     supportsLocalCursor(false), supportsLocalXCursor(false),
@@ -45,20 +43,20 @@ ConnParams::ConnParams()
   cursor_ = new Cursor(0, 0, Point(), NULL);
 }
 
-ConnParams::~ConnParams()
+ClientParams::~ClientParams()
 {
   delete [] name_;
   delete cursor_;
 }
 
-void ConnParams::setDimensions(int width, int height)
+void ClientParams::setDimensions(int width, int height)
 {
   ScreenSet layout;
   layout.add_screen(rfb::Screen(0, 0, 0, width, height, 0));
   setDimensions(width, height, layout);
 }
 
-void ConnParams::setDimensions(int width, int height, const ScreenSet& layout)
+void ClientParams::setDimensions(int width, int height, const ScreenSet& layout)
 {
   if (!layout.validate(width, height))
     throw Exception("Attempted to configure an invalid screen layout");
@@ -68,7 +66,7 @@ void ConnParams::setDimensions(int width, int height, const ScreenSet& layout)
   screenLayout_ = layout;
 }
 
-void ConnParams::setPF(const PixelFormat& pf)
+void ClientParams::setPF(const PixelFormat& pf)
 {
   pf_ = pf;
 
@@ -76,24 +74,24 @@ void ConnParams::setPF(const PixelFormat& pf)
     throw Exception("setPF: not 8, 16 or 32 bpp?");
 }
 
-void ConnParams::setName(const char* name)
+void ClientParams::setName(const char* name)
 {
   delete [] name_;
   name_ = strDup(name);
 }
 
-void ConnParams::setCursor(const Cursor& other)
+void ClientParams::setCursor(const Cursor& other)
 {
   delete cursor_;
   cursor_ = new Cursor(other);
 }
 
-bool ConnParams::supportsEncoding(rdr::S32 encoding) const
+bool ClientParams::supportsEncoding(rdr::S32 encoding) const
 {
   return encodings_.count(encoding) != 0;
 }
 
-void ConnParams::setEncodings(int nEncodings, const rdr::S32* encodings)
+void ClientParams::setEncodings(int nEncodings, const rdr::S32* encodings)
 {
   useCopyRect = false;
   supportsLocalCursor = false;
@@ -186,7 +184,7 @@ void ConnParams::setEncodings(int nEncodings, const rdr::S32* encodings)
   }
 }
 
-void ConnParams::setLEDState(unsigned int state)
+void ClientParams::setLEDState(unsigned int state)
 {
   ledState_ = state;
 }

--- a/common/rfb/ClientParams.h
+++ b/common/rfb/ClientParams.h
@@ -1,5 +1,5 @@
 /* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
- * Copyright 2014 Pierre Ossman for Cendio AB
+ * Copyright 2014-2018 Pierre Ossman for Cendio AB
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,11 +17,11 @@
  * USA.
  */
 //
-// ConnParams - structure containing the connection parameters.
+// ClientParams - structure describing the current state of the remote client
 //
 
-#ifndef __RFB_CONNPARAMS_H__
-#define __RFB_CONNPARAMS_H__
+#ifndef __RFB_CLIENTPARAMS_H__
+#define __RFB_CLIENTPARAMS_H__
 
 #include <set>
 
@@ -40,10 +40,10 @@ namespace rfb {
   const int subsample8X = 4;
   const int subsample16X = 5;
 
-  class ConnParams {
+  class ClientParams {
   public:
-    ConnParams();
-    ~ConnParams();
+    ClientParams();
+    ~ClientParams();
 
     int majorVersion;
     int minorVersion;

--- a/common/rfb/ClientParams.h
+++ b/common/rfb/ClientParams.h
@@ -87,6 +87,7 @@ namespace rfb {
     // Wrappers to check for functionality rather than specific
     // encodings
     bool supportsLocalCursor() const;
+    bool supportsDesktopSize() const;
     bool supportsLEDState() const;
     bool supportsFence() const;
     bool supportsContinuousUpdates() const;

--- a/common/rfb/ClientParams.h
+++ b/common/rfb/ClientParams.h
@@ -84,21 +84,12 @@ namespace rfb {
     unsigned int ledState() { return ledState_; }
     void setLEDState(unsigned int state);
 
-    bool useCopyRect;
-
-    bool supportsLocalCursor;
-    bool supportsLocalXCursor;
-    bool supportsLocalCursorWithAlpha;
-    bool supportsDesktopResize;
-    bool supportsExtendedDesktopSize;
-    bool supportsDesktopRename;
-    bool supportsLastRect;
-    bool supportsLEDState;
-    bool supportsQEMUKeyEvent;
-
-    bool supportsSetDesktopSize;
-    bool supportsFence;
-    bool supportsContinuousUpdates;
+    // Wrappers to check for functionality rather than specific
+    // encodings
+    bool supportsLocalCursor() const;
+    bool supportsLEDState() const;
+    bool supportsFence() const;
+    bool supportsContinuousUpdates() const;
 
     int compressLevel;
     int qualityLevel;

--- a/common/rfb/ConnParams.cxx
+++ b/common/rfb/ConnParams.cxx
@@ -28,7 +28,7 @@ using namespace rfb;
 
 ConnParams::ConnParams()
   : majorVersion(0), minorVersion(0),
-    width(0), height(0), useCopyRect(false),
+    useCopyRect(false),
     supportsLocalCursor(false), supportsLocalXCursor(false),
     supportsLocalCursorWithAlpha(false),
     supportsDesktopResize(false), supportsExtendedDesktopSize(false),
@@ -37,7 +37,8 @@ ConnParams::ConnParams()
     supportsSetDesktopSize(false), supportsFence(false),
     supportsContinuousUpdates(false),
     compressLevel(2), qualityLevel(-1), fineQualityLevel(-1),
-    subsampling(subsampleUndefined), name_(0),
+    subsampling(subsampleUndefined),
+    width_(0), height_(0), name_(0),
     ledState_(ledUnknown)
 {
   setName("");
@@ -48,6 +49,23 @@ ConnParams::~ConnParams()
 {
   delete [] name_;
   delete cursor_;
+}
+
+void ConnParams::setDimensions(int width, int height)
+{
+  ScreenSet layout;
+  layout.add_screen(rfb::Screen(0, 0, 0, width, height, 0));
+  setDimensions(width, height, layout);
+}
+
+void ConnParams::setDimensions(int width, int height, const ScreenSet& layout)
+{
+  if (!layout.validate(width, height))
+    throw Exception("Attempted to configure an invalid screen layout");
+
+  width_ = width;
+  height_ = height;
+  screenLayout_ = layout;
 }
 
 void ConnParams::setPF(const PixelFormat& pf)

--- a/common/rfb/ConnParams.cxx
+++ b/common/rfb/ConnParams.cxx
@@ -18,8 +18,6 @@
  * USA.
  */
 #include <stdio.h>
-#include <rdr/InStream.h>
-#include <rdr/OutStream.h>
 #include <rfb/Exception.h>
 #include <rfb/encodings.h>
 #include <rfb/ledStates.h>
@@ -39,7 +37,7 @@ ConnParams::ConnParams()
     supportsSetDesktopSize(false), supportsFence(false),
     supportsContinuousUpdates(false),
     compressLevel(2), qualityLevel(-1), fineQualityLevel(-1),
-    subsampling(subsampleUndefined), name_(0), verStrPos(0),
+    subsampling(subsampleUndefined), name_(0),
     ledState_(ledUnknown)
 {
   setName("");
@@ -50,30 +48,6 @@ ConnParams::~ConnParams()
 {
   delete [] name_;
   delete cursor_;
-}
-
-bool ConnParams::readVersion(rdr::InStream* is, bool* done)
-{
-  if (verStrPos >= 12) return false;
-  while (is->checkNoWait(1) && verStrPos < 12) {
-    verStr[verStrPos++] = is->readU8();
-  }
-
-  if (verStrPos < 12) {
-    *done = false;
-    return true;
-  }
-  *done = true;
-  verStr[12] = 0;
-  return (sscanf(verStr, "RFB %03d.%03d\n", &majorVersion,&minorVersion) == 2);
-}
-
-void ConnParams::writeVersion(rdr::OutStream* os)
-{
-  char str[13];
-  sprintf(str, "RFB %03d.%03d\n", majorVersion, minorVersion);
-  os->writeBytes(str, 12);
-  os->flush();
 }
 
 void ConnParams::setPF(const PixelFormat& pf)

--- a/common/rfb/ConnParams.h
+++ b/common/rfb/ConnParams.h
@@ -30,8 +30,6 @@
 #include <rfb/PixelFormat.h>
 #include <rfb/ScreenSet.h>
 
-namespace rdr { class InStream; }
-
 namespace rfb {
 
   const int subsampleUndefined = -1;
@@ -46,9 +44,6 @@ namespace rfb {
   public:
     ConnParams();
     ~ConnParams();
-
-    bool readVersion(rdr::InStream* is, bool* done);
-    void writeVersion(rdr::OutStream* os);
 
     int majorVersion;
     int minorVersion;
@@ -114,8 +109,6 @@ namespace rfb {
     char* name_;
     Cursor* cursor_;
     std::set<rdr::S32> encodings_;
-    char verStr[13];
-    int verStrPos;
     unsigned int ledState_;
   };
 }

--- a/common/rfb/ConnParams.h
+++ b/common/rfb/ConnParams.h
@@ -62,9 +62,11 @@ namespace rfb {
       return !beforeVersion(major,minor+1);
     }
 
-    int width;
-    int height;
-    ScreenSet screenLayout;
+    const int width() const { return width_; }
+    const int height() const { return height_; }
+    const ScreenSet& screenLayout() const { return screenLayout_; }
+    void setDimensions(int width, int height);
+    void setDimensions(int width, int height, const ScreenSet& layout);
 
     const PixelFormat& pf() const { return pf_; }
     void setPF(const PixelFormat& pf);
@@ -104,6 +106,10 @@ namespace rfb {
     int subsampling;
 
   private:
+
+    int width_;
+    int height_;
+    ScreenSet screenLayout_;
 
     PixelFormat pf_;
     char* name_;

--- a/common/rfb/CopyRectDecoder.cxx
+++ b/common/rfb/CopyRectDecoder.cxx
@@ -32,7 +32,7 @@ CopyRectDecoder::~CopyRectDecoder()
 }
 
 void CopyRectDecoder::readRect(const Rect& r, rdr::InStream* is,
-                               const ConnParams& cp, rdr::OutStream* os)
+                               const ServerParams& server, rdr::OutStream* os)
 {
   os->copyBytes(is, 4);
 }
@@ -41,21 +41,21 @@ void CopyRectDecoder::readRect(const Rect& r, rdr::InStream* is,
 void CopyRectDecoder::getAffectedRegion(const Rect& rect,
                                         const void* buffer,
                                         size_t buflen,
-                                        const ConnParams& cp,
+                                        const ServerParams& server,
                                         Region* region)
 {
   rdr::MemInStream is(buffer, buflen);
   int srcX = is.readU16();
   int srcY = is.readU16();
 
-  Decoder::getAffectedRegion(rect, buffer, buflen, cp, region);
+  Decoder::getAffectedRegion(rect, buffer, buflen, server, region);
 
   region->assign_union(Region(rect.translate(Point(srcX-rect.tl.x,
                                                    srcY-rect.tl.y))));
 }
 
 void CopyRectDecoder::decodeRect(const Rect& r, const void* buffer,
-                                 size_t buflen, const ConnParams& cp,
+                                 size_t buflen, const ServerParams& server,
                                  ModifiablePixelBuffer* pb)
 {
   rdr::MemInStream is(buffer, buflen);

--- a/common/rfb/CopyRectDecoder.h
+++ b/common/rfb/CopyRectDecoder.h
@@ -27,12 +27,12 @@ namespace rfb {
     CopyRectDecoder();
     virtual ~CopyRectDecoder();
     virtual void readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os);
+                          const ServerParams& server, rdr::OutStream* os);
     virtual void getAffectedRegion(const Rect& rect, const void* buffer,
-                                   size_t buflen, const ConnParams& cp,
+                                   size_t buflen, const ServerParams& server,
                                    Region* region);
     virtual void decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb);
   };
 }

--- a/common/rfb/DecodeManager.cxx
+++ b/common/rfb/DecodeManager.cxx
@@ -132,9 +132,9 @@ void DecodeManager::decodeRect(const Rect& r, int encoding,
   if (threads.empty()) {
     bufferStream = freeBuffers.front();
     bufferStream->clear();
-    decoder->readRect(r, conn->getInStream(), conn->cp, bufferStream);
+    decoder->readRect(r, conn->getInStream(), conn->server, bufferStream);
     decoder->decodeRect(r, bufferStream->data(), bufferStream->length(),
-                        conn->cp, pb);
+                        conn->server, pb);
     return;
   }
 
@@ -155,7 +155,7 @@ void DecodeManager::decodeRect(const Rect& r, int encoding,
 
   // Read the rect
   bufferStream->clear();
-  decoder->readRect(r, conn->getInStream(), conn->cp, bufferStream);
+  decoder->readRect(r, conn->getInStream(), conn->server, bufferStream);
 
   // Then try to put it on the queue
   entry = new QueueEntry;
@@ -164,12 +164,12 @@ void DecodeManager::decodeRect(const Rect& r, int encoding,
   entry->rect = r;
   entry->encoding = encoding;
   entry->decoder = decoder;
-  entry->cp = &conn->cp;
+  entry->server = &conn->server;
   entry->pb = pb;
   entry->bufferStream = bufferStream;
 
   decoder->getAffectedRegion(r, bufferStream->data(),
-                             bufferStream->length(), conn->cp,
+                             bufferStream->length(), conn->server,
                              &entry->affectedRegion);
 
   queueMutex->lock();
@@ -276,7 +276,7 @@ void DecodeManager::DecodeThread::worker()
     try {
       entry->decoder->decodeRect(entry->rect, entry->bufferStream->data(),
                                  entry->bufferStream->length(),
-                                 *entry->cp, entry->pb);
+                                 *entry->server, entry->pb);
     } catch (rdr::Exception& e) {
       manager->setThreadException(e);
     } catch(...) {
@@ -346,7 +346,7 @@ DecodeManager::QueueEntry* DecodeManager::DecodeThread::findEntry()
                                             (*iter2)->rect,
                                             (*iter2)->bufferStream->data(),
                                             (*iter2)->bufferStream->length(),
-                                            *entry->cp))
+                                            *entry->server))
           goto next;
       }
     }

--- a/common/rfb/DecodeManager.h
+++ b/common/rfb/DecodeManager.h
@@ -65,7 +65,7 @@ namespace rfb {
       Rect rect;
       int encoding;
       Decoder* decoder;
-      const ConnParams* cp;
+      const ServerParams* server;
       ModifiablePixelBuffer* pb;
       rdr::MemOutStream* bufferStream;
       Region affectedRegion;

--- a/common/rfb/Decoder.cxx
+++ b/common/rfb/Decoder.cxx
@@ -38,7 +38,7 @@ Decoder::~Decoder()
 }
 
 void Decoder::getAffectedRegion(const Rect& rect, const void* buffer,
-                                size_t buflen, const ConnParams& cp,
+                                size_t buflen, const ServerParams& server,
                                 Region* region)
 {
   region->reset(rect);
@@ -47,7 +47,7 @@ void Decoder::getAffectedRegion(const Rect& rect, const void* buffer,
 bool Decoder::doRectsConflict(const Rect& rectA, const void* bufferA,
                               size_t buflenA, const Rect& rectB,
                               const void* bufferB, size_t buflenB,
-                              const ConnParams& cp)
+                              const ServerParams& server)
 {
   return false;
 }

--- a/common/rfb/Decoder.h
+++ b/common/rfb/Decoder.h
@@ -25,7 +25,7 @@ namespace rdr {
 }
 
 namespace rfb {
-  class ConnParams;
+  class ServerParams;
   class ModifiablePixelBuffer;
   class Region;
 
@@ -53,7 +53,7 @@ namespace rfb {
     // make it easier to decode. This function will always be called in
     // a serial manner on the main thread.
     virtual void readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os)=0;
+                          const ServerParams& server, rdr::OutStream* os)=0;
 
     // These functions will be called from any of the worker threads.
     // A lock will be held whilst these are called so it is safe to
@@ -63,7 +63,7 @@ namespace rfb {
     // be either read from or written do when decoding this rect. The
     // default implementation simply returns the given rectangle.
     virtual void getAffectedRegion(const Rect& rect, const void* buffer,
-                                   size_t buflen, const ConnParams& cp,
+                                   size_t buflen, const ServerParams& server,
                                    Region* region);
 
     // doesRectsConflict() determines if two rectangles must be decoded
@@ -75,14 +75,14 @@ namespace rfb {
                                  const Rect& rectB,
                                  const void* bufferB,
                                  size_t buflenB,
-                                 const ConnParams& cp);
+                                 const ServerParams& server);
 
     // decodeRect() decodes the given rectangle with data from the
     // given buffer, onto the ModifiablePixelBuffer. The PixelFormat of
     // the PixelBuffer might not match the ConnParams and it is up to
     // the decoder to do any necessary conversion.
     virtual void decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb)=0;
 
   public:

--- a/common/rfb/EncodeManager.cxx
+++ b/common/rfb/EncodeManager.cxx
@@ -325,6 +325,9 @@ void EncodeManager::doUpdate(bool allowLossy, const Region& changed_,
 
     changed = changed_;
 
+    if (!conn->client.useCopyRect)
+      changed.assign_union(copied);
+
     /*
      * We need to render the cursor seperately as it has its own
      * magical pixel buffer, so split it out from the changed region.
@@ -344,7 +347,8 @@ void EncodeManager::doUpdate(bool allowLossy, const Region& changed_,
 
     conn->writer()->writeFramebufferUpdateStart(nRects);
 
-    writeCopyRects(copied, copyDelta);
+    if (conn->client.useCopyRect)
+      writeCopyRects(copied, copyDelta);
 
     /*
      * We start by searching for solid rects, which are then removed

--- a/common/rfb/EncodeManager.cxx
+++ b/common/rfb/EncodeManager.cxx
@@ -325,7 +325,7 @@ void EncodeManager::doUpdate(bool allowLossy, const Region& changed_,
 
     changed = changed_;
 
-    if (!conn->client.useCopyRect)
+    if (!conn->client.supportsEncoding(encodingCopyRect))
       changed.assign_union(copied);
 
     /*
@@ -337,7 +337,7 @@ void EncodeManager::doUpdate(bool allowLossy, const Region& changed_,
       changed.assign_subtract(renderedCursor->getEffectiveRect());
     }
 
-    if (conn->client.supportsLastRect)
+    if (conn->client.supportsEncoding(pseudoEncodingLastRect))
       nRects = 0xFFFF;
     else {
       nRects = copied.numRects();
@@ -347,14 +347,14 @@ void EncodeManager::doUpdate(bool allowLossy, const Region& changed_,
 
     conn->writer()->writeFramebufferUpdateStart(nRects);
 
-    if (conn->client.useCopyRect)
+    if (conn->client.supportsEncoding(encodingCopyRect))
       writeCopyRects(copied, copyDelta);
 
     /*
      * We start by searching for solid rects, which are then removed
      * from the changed region.
      */
-    if (conn->client.supportsLastRect)
+    if (conn->client.supportsEncoding(pseudoEncodingLastRect))
       writeSolidRects(&changed, pb);
 
     writeRects(changed, pb);

--- a/common/rfb/HextileDecoder.cxx
+++ b/common/rfb/HextileDecoder.cxx
@@ -20,7 +20,7 @@
 #include <rdr/MemInStream.h>
 #include <rdr/OutStream.h>
 
-#include <rfb/ConnParams.h>
+#include <rfb/ServerParams.h>
 #include <rfb/PixelBuffer.h>
 #include <rfb/HextileDecoder.h>
 
@@ -45,12 +45,12 @@ HextileDecoder::~HextileDecoder()
 }
 
 void HextileDecoder::readRect(const Rect& r, rdr::InStream* is,
-                              const ConnParams& cp, rdr::OutStream* os)
+                              const ServerParams& server, rdr::OutStream* os)
 {
   Rect t;
   size_t bytesPerPixel;
 
-  bytesPerPixel = cp.pf().bpp/8;
+  bytesPerPixel = server.pf().bpp/8;
 
   for (t.tl.y = r.tl.y; t.tl.y < r.br.y; t.tl.y += 16) {
 
@@ -91,11 +91,11 @@ void HextileDecoder::readRect(const Rect& r, rdr::InStream* is,
 }
 
 void HextileDecoder::decodeRect(const Rect& r, const void* buffer,
-                                size_t buflen, const ConnParams& cp,
+                                size_t buflen, const ServerParams& server,
                                 ModifiablePixelBuffer* pb)
 {
   rdr::MemInStream is(buffer, buflen);
-  const PixelFormat& pf = cp.pf();
+  const PixelFormat& pf = server.pf();
   switch (pf.bpp) {
   case 8:  hextileDecode8 (r, &is, pf, pb); break;
   case 16: hextileDecode16(r, &is, pf, pb); break;

--- a/common/rfb/HextileDecoder.h
+++ b/common/rfb/HextileDecoder.h
@@ -27,9 +27,9 @@ namespace rfb {
     HextileDecoder();
     virtual ~HextileDecoder();
     virtual void readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os);
+                          const ServerParams& server, rdr::OutStream* os);
     virtual void decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb);
   };
 }

--- a/common/rfb/HextileEncoder.cxx
+++ b/common/rfb/HextileEncoder.cxx
@@ -55,7 +55,7 @@ HextileEncoder::~HextileEncoder()
 
 bool HextileEncoder::isSupported()
 {
-  return conn->cp.supportsEncoding(encodingHextile);
+  return conn->client.supportsEncoding(encodingHextile);
 }
 
 void HextileEncoder::writeRect(const PixelBuffer* pb, const Palette& palette)

--- a/common/rfb/JpegCompressor.cxx
+++ b/common/rfb/JpegCompressor.cxx
@@ -22,7 +22,7 @@
 #include <rdr/Exception.h>
 #include <rfb/Rect.h>
 #include <rfb/PixelFormat.h>
-#include <rfb/ConnParams.h>
+#include <rfb/ClientParams.h>
 
 #include <stdio.h>
 extern "C" {

--- a/common/rfb/Logger.cxx
+++ b/common/rfb/Logger.cxx
@@ -47,7 +47,16 @@ void Logger::write(int level, const char *logname, const char* format,
   char buf1[4096];
   vsnprintf(buf1, sizeof(buf1)-1, format, ap);
   buf1[sizeof(buf1)-1] = 0;
-  write(level, logname, buf1);
+  char *buf = buf1;
+  while (true) {
+    char *end = strchr(buf, '\n');
+    if (end)
+      *end = '\0';
+    write(level, logname, buf);
+    if (!end)
+      break;
+    buf = end + 1;
+  }
 }
 
 void

--- a/common/rfb/RREDecoder.cxx
+++ b/common/rfb/RREDecoder.cxx
@@ -20,7 +20,7 @@
 #include <rdr/MemInStream.h>
 #include <rdr/OutStream.h>
 
-#include <rfb/ConnParams.h>
+#include <rfb/ServerParams.h>
 #include <rfb/PixelBuffer.h>
 #include <rfb/RREDecoder.h>
 
@@ -45,22 +45,22 @@ RREDecoder::~RREDecoder()
 }
 
 void RREDecoder::readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os)
+                          const ServerParams& server, rdr::OutStream* os)
 {
   rdr::U32 numRects;
 
   numRects = is->readU32();
   os->writeU32(numRects);
 
-  os->copyBytes(is, cp.pf().bpp/8 + numRects * (cp.pf().bpp/8 + 8));
+  os->copyBytes(is, server.pf().bpp/8 + numRects * (server.pf().bpp/8 + 8));
 }
 
 void RREDecoder::decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb)
 {
   rdr::MemInStream is(buffer, buflen);
-  const PixelFormat& pf = cp.pf();
+  const PixelFormat& pf = server.pf();
   switch (pf.bpp) {
   case 8:  rreDecode8 (r, &is, pf, pb); break;
   case 16: rreDecode16(r, &is, pf, pb); break;

--- a/common/rfb/RREDecoder.h
+++ b/common/rfb/RREDecoder.h
@@ -27,9 +27,9 @@ namespace rfb {
     RREDecoder();
     virtual ~RREDecoder();
     virtual void readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os);
+                          const ServerParams& server, rdr::OutStream* os);
     virtual void decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb);
   };
 }

--- a/common/rfb/RREEncoder.cxx
+++ b/common/rfb/RREEncoder.cxx
@@ -47,7 +47,7 @@ RREEncoder::~RREEncoder()
 
 bool RREEncoder::isSupported()
 {
-  return conn->cp.supportsEncoding(encodingRRE);
+  return conn->client.supportsEncoding(encodingRRE);
 }
 
 void RREEncoder::writeRect(const PixelBuffer* pb, const Palette& palette)

--- a/common/rfb/RawDecoder.cxx
+++ b/common/rfb/RawDecoder.cxx
@@ -19,7 +19,7 @@
 #include <assert.h>
 
 #include <rdr/OutStream.h>
-#include <rfb/ConnParams.h>
+#include <rfb/ServerParams.h>
 #include <rfb/PixelBuffer.h>
 #include <rfb/RawDecoder.h>
 
@@ -34,15 +34,15 @@ RawDecoder::~RawDecoder()
 }
 
 void RawDecoder::readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os)
+                          const ServerParams& server, rdr::OutStream* os)
 {
-  os->copyBytes(is, r.area() * (cp.pf().bpp/8));
+  os->copyBytes(is, r.area() * (server.pf().bpp/8));
 }
 
 void RawDecoder::decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb)
 {
-  assert(buflen >= (size_t)r.area() * (cp.pf().bpp/8));
-  pb->imageRect(cp.pf(), r, buffer);
+  assert(buflen >= (size_t)r.area() * (server.pf().bpp/8));
+  pb->imageRect(server.pf(), r, buffer);
 }

--- a/common/rfb/RawDecoder.h
+++ b/common/rfb/RawDecoder.h
@@ -26,9 +26,9 @@ namespace rfb {
     RawDecoder();
     virtual ~RawDecoder();
     virtual void readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os);
+                          const ServerParams& server, rdr::OutStream* os);
     virtual void decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb);
   };
 }

--- a/common/rfb/SConnection.cxx
+++ b/common/rfb/SConnection.cxx
@@ -59,7 +59,7 @@ SConnection::SConnection()
   if (rfb::Server::protocol3_3)
     defaultMinorVersion = 3;
 
-  cp.setVersion(defaultMajorVersion, defaultMinorVersion);
+  client.setVersion(defaultMajorVersion, defaultMinorVersion);
 }
 
 SConnection::~SConnection()
@@ -127,29 +127,29 @@ void SConnection::processVersionMsg()
     throw Exception("reading version failed: not an RFB client?");
   }
 
-  cp.setVersion(majorVersion, minorVersion);
+  client.setVersion(majorVersion, minorVersion);
 
   vlog.info("Client needs protocol version %d.%d",
-            cp.majorVersion, cp.minorVersion);
+            client.majorVersion, client.minorVersion);
 
-  if (cp.majorVersion != 3) {
+  if (client.majorVersion != 3) {
     // unknown protocol version
     throwConnFailedException("Client needs protocol version %d.%d, server has %d.%d",
-                             cp.majorVersion, cp.minorVersion,
+                             client.majorVersion, client.minorVersion,
                              defaultMajorVersion, defaultMinorVersion);
   }
 
-  if (cp.minorVersion != 3 && cp.minorVersion != 7 && cp.minorVersion != 8) {
+  if (client.minorVersion != 3 && client.minorVersion != 7 && client.minorVersion != 8) {
     vlog.error("Client uses unofficial protocol version %d.%d",
-               cp.majorVersion,cp.minorVersion);
-    if (cp.minorVersion >= 8)
-      cp.minorVersion = 8;
-    else if (cp.minorVersion == 7)
-      cp.minorVersion = 7;
+               client.majorVersion,client.minorVersion);
+    if (client.minorVersion >= 8)
+      client.minorVersion = 8;
+    else if (client.minorVersion == 7)
+      client.minorVersion = 7;
     else
-      cp.minorVersion = 3;
+      client.minorVersion = 3;
     vlog.error("Assuming compatibility with version %d.%d",
-               cp.majorVersion,cp.minorVersion);
+               client.majorVersion,client.minorVersion);
   }
 
   versionReceived();
@@ -158,7 +158,7 @@ void SConnection::processVersionMsg()
   std::list<rdr::U8>::iterator i;
   secTypes = security.GetEnabledSecTypes();
 
-  if (cp.isVersion(3,3)) {
+  if (client.isVersion(3,3)) {
 
     // cope with legacy 3.3 client only if "no authentication" or "vnc
     // authentication" is supported.
@@ -167,7 +167,7 @@ void SConnection::processVersionMsg()
     }
     if (i == secTypes.end()) {
       throwConnFailedException("No supported security type for %d.%d client",
-                               cp.majorVersion, cp.minorVersion);
+                               client.majorVersion, client.minorVersion);
     }
 
     os->writeU32(*i);
@@ -237,7 +237,7 @@ void SConnection::processSecurityMsg()
   } catch (AuthFailureException& e) {
     vlog.error("AuthFailureException: %s", e.str());
     os->writeU32(secResultFailed);
-    if (!cp.beforeVersion(3,8)) // 3.8 onwards have failure message
+    if (!client.beforeVersion(3,8)) // 3.8 onwards have failure message
       os->writeString(e.str());
     os->flush();
     throw;
@@ -262,7 +262,7 @@ void SConnection::throwConnFailedException(const char* format, ...)
   vlog.info("Connection failed: %s", str);
 
   if (state_ == RFBSTATE_PROTOCOL_VERSION) {
-    if (cp.majorVersion == 3 && cp.minorVersion == 3) {
+    if (client.majorVersion == 3 && client.minorVersion == 3) {
       os->writeU32(0);
       os->writeString(str);
       os->flush();
@@ -324,12 +324,12 @@ void SConnection::approveConnection(bool accept, const char* reason)
   if (state_ != RFBSTATE_QUERYING)
     throw Exception("SConnection::approveConnection: invalid state");
 
-  if (!cp.beforeVersion(3,8) || ssecurity->getType() != secTypeNone) {
+  if (!client.beforeVersion(3,8) || ssecurity->getType() != secTypeNone) {
     if (accept) {
       os->writeU32(secResultOK);
     } else {
       os->writeU32(secResultFailed);
-      if (!cp.beforeVersion(3,8)) { // 3.8 onwards have failure message
+      if (!client.beforeVersion(3,8)) { // 3.8 onwards have failure message
         if (reason)
           os->writeString(reason);
         else
@@ -342,7 +342,7 @@ void SConnection::approveConnection(bool accept, const char* reason)
   if (accept) {
     state_ = RFBSTATE_INITIALISATION;
     reader_ = new SMsgReader(this, is);
-    writer_ = new SMsgWriter(&cp, os);
+    writer_ = new SMsgWriter(&client, os);
     authSuccess();
   } else {
     state_ = RFBSTATE_INVALID;
@@ -371,7 +371,7 @@ void SConnection::framebufferUpdateRequest(const Rect& r, bool incremental)
 {
   if (!readyForSetColourMapEntries) {
     readyForSetColourMapEntries = true;
-    if (!cp.pf().trueColour) {
+    if (!client.pf().trueColour) {
       writeFakeColourMap();
     }
   }
@@ -399,7 +399,7 @@ void SConnection::writeFakeColourMap(void)
   rdr::U16 red[256], green[256], blue[256];
 
   for (i = 0;i < 256;i++)
-    cp.pf().rgbFromPixel(i, &red[i], &green[i], &blue[i]);
+    client.pf().rgbFromPixel(i, &red[i], &green[i], &blue[i]);
 
   writer()->writeSetColourMapEntries(0, 256, red, green, blue);
 }

--- a/common/rfb/SConnection.cxx
+++ b/common/rfb/SConnection.cxx
@@ -355,7 +355,8 @@ void SConnection::approveConnection(bool accept, const char* reason)
 
 void SConnection::clientInit(bool shared)
 {
-  writer_->writeServerInit();
+  writer_->writeServerInit(client.width(), client.height(),
+                           client.pf(), client.name());
   state_ = RFBSTATE_NORMAL;
 }
 

--- a/common/rfb/SMsgHandler.cxx
+++ b/common/rfb/SMsgHandler.cxx
@@ -36,7 +36,7 @@ void SMsgHandler::clientInit(bool shared)
 
 void SMsgHandler::setPixelFormat(const PixelFormat& pf)
 {
-  cp.setPF(pf);
+  client.setPF(pf);
 }
 
 void SMsgHandler::setEncodings(int nEncodings, const rdr::S32* encodings)
@@ -44,22 +44,22 @@ void SMsgHandler::setEncodings(int nEncodings, const rdr::S32* encodings)
   bool firstFence, firstContinuousUpdates, firstLEDState,
        firstQEMUKeyEvent;
 
-  firstFence = !cp.supportsFence;
-  firstContinuousUpdates = !cp.supportsContinuousUpdates;
-  firstLEDState = !cp.supportsLEDState;
-  firstQEMUKeyEvent = !cp.supportsQEMUKeyEvent;
+  firstFence = !client.supportsFence;
+  firstContinuousUpdates = !client.supportsContinuousUpdates;
+  firstLEDState = !client.supportsLEDState;
+  firstQEMUKeyEvent = !client.supportsQEMUKeyEvent;
 
-  cp.setEncodings(nEncodings, encodings);
+  client.setEncodings(nEncodings, encodings);
 
   supportsLocalCursor();
 
-  if (cp.supportsFence && firstFence)
+  if (client.supportsFence && firstFence)
     supportsFence();
-  if (cp.supportsContinuousUpdates && firstContinuousUpdates)
+  if (client.supportsContinuousUpdates && firstContinuousUpdates)
     supportsContinuousUpdates();
-  if (cp.supportsLEDState && firstLEDState)
+  if (client.supportsLEDState && firstLEDState)
     supportsLEDState();
-  if (cp.supportsQEMUKeyEvent && firstQEMUKeyEvent)
+  if (client.supportsQEMUKeyEvent && firstQEMUKeyEvent)
     supportsQEMUKeyEvent();
 }
 
@@ -86,6 +86,6 @@ void SMsgHandler::supportsQEMUKeyEvent()
 void SMsgHandler::setDesktopSize(int fb_width, int fb_height,
                                  const ScreenSet& layout)
 {
-  cp.setDimensions(fb_width, fb_height, layout);
+  client.setDimensions(fb_width, fb_height, layout);
 }
 

--- a/common/rfb/SMsgHandler.cxx
+++ b/common/rfb/SMsgHandler.cxx
@@ -86,8 +86,6 @@ void SMsgHandler::supportsQEMUKeyEvent()
 void SMsgHandler::setDesktopSize(int fb_width, int fb_height,
                                  const ScreenSet& layout)
 {
-  cp.width = fb_width;
-  cp.height = fb_height;
-  cp.screenLayout = layout;
+  cp.setDimensions(fb_width, fb_height, layout);
 }
 

--- a/common/rfb/SMsgHandler.cxx
+++ b/common/rfb/SMsgHandler.cxx
@@ -19,6 +19,7 @@
 #include <rfb/Exception.h>
 #include <rfb/SMsgHandler.h>
 #include <rfb/ScreenSet.h>
+#include <rfb/encodings.h>
 
 using namespace rfb;
 
@@ -44,22 +45,22 @@ void SMsgHandler::setEncodings(int nEncodings, const rdr::S32* encodings)
   bool firstFence, firstContinuousUpdates, firstLEDState,
        firstQEMUKeyEvent;
 
-  firstFence = !client.supportsFence;
-  firstContinuousUpdates = !client.supportsContinuousUpdates;
-  firstLEDState = !client.supportsLEDState;
-  firstQEMUKeyEvent = !client.supportsQEMUKeyEvent;
+  firstFence = !client.supportsFence();
+  firstContinuousUpdates = !client.supportsContinuousUpdates();
+  firstLEDState = !client.supportsLEDState();
+  firstQEMUKeyEvent = !client.supportsEncoding(pseudoEncodingQEMUKeyEvent);
 
   client.setEncodings(nEncodings, encodings);
 
   supportsLocalCursor();
 
-  if (client.supportsFence && firstFence)
+  if (client.supportsFence() && firstFence)
     supportsFence();
-  if (client.supportsContinuousUpdates && firstContinuousUpdates)
+  if (client.supportsContinuousUpdates() && firstContinuousUpdates)
     supportsContinuousUpdates();
-  if (client.supportsLEDState && firstLEDState)
+  if (client.supportsLEDState() && firstLEDState)
     supportsLEDState();
-  if (client.supportsQEMUKeyEvent && firstQEMUKeyEvent)
+  if (client.supportsEncoding(pseudoEncodingQEMUKeyEvent) && firstQEMUKeyEvent)
     supportsQEMUKeyEvent();
 }
 

--- a/common/rfb/SMsgHandler.cxx
+++ b/common/rfb/SMsgHandler.cxx
@@ -83,10 +83,3 @@ void SMsgHandler::supportsLEDState()
 void SMsgHandler::supportsQEMUKeyEvent()
 {
 }
-
-void SMsgHandler::setDesktopSize(int fb_width, int fb_height,
-                                 const ScreenSet& layout)
-{
-  client.setDimensions(fb_width, fb_height, layout);
-}
-

--- a/common/rfb/SMsgHandler.h
+++ b/common/rfb/SMsgHandler.h
@@ -25,7 +25,7 @@
 
 #include <rdr/types.h>
 #include <rfb/PixelFormat.h>
-#include <rfb/ConnParams.h>
+#include <rfb/ClientParams.h>
 #include <rfb/InputHandler.h>
 #include <rfb/ScreenSet.h>
 
@@ -85,7 +85,7 @@ namespace rfb {
     // handler will send a pseudo-rect back, signalling server support.
     virtual void supportsQEMUKeyEvent();
 
-    ConnParams cp;
+    ClientParams client;
   };
 }
 #endif

--- a/common/rfb/SMsgHandler.h
+++ b/common/rfb/SMsgHandler.h
@@ -40,8 +40,8 @@ namespace rfb {
 
     // The following methods are called as corresponding messages are read.  A
     // derived class should override these methods as desired.  Note that for
-    // the setPixelFormat(), setEncodings() and setDesktopSize() methods, a
-    // derived class must call on to SMsgHandler's methods.
+    // the setPixelFormat(), and setEncodings() methods, a derived class must
+    // call on to SMsgHandler's methods.
 
     virtual void clientInit(bool shared);
 

--- a/common/rfb/SMsgWriter.cxx
+++ b/common/rfb/SMsgWriter.cxx
@@ -47,12 +47,13 @@ SMsgWriter::~SMsgWriter()
 {
 }
 
-void SMsgWriter::writeServerInit()
+void SMsgWriter::writeServerInit(rdr::U16 width, rdr::U16 height,
+                                 const PixelFormat& pf, const char* name)
 {
-  os->writeU16(client->width());
-  os->writeU16(client->height());
-  client->pf().write(os);
-  os->writeString(client->name());
+  os->writeU16(width);
+  os->writeU16(height);
+  pf.write(os);
+  os->writeString(name);
   endMsg();
 }
 

--- a/common/rfb/SMsgWriter.cxx
+++ b/common/rfb/SMsgWriter.cxx
@@ -90,7 +90,7 @@ void SMsgWriter::writeServerCutText(const char* str, int len)
 
 void SMsgWriter::writeFence(rdr::U32 flags, unsigned len, const char data[])
 {
-  if (!client->supportsFence)
+  if (!client->supportsEncoding(pseudoEncodingFence))
     throw Exception("Client does not support fences");
   if (len > 64)
     throw Exception("Too large fence payload");
@@ -112,7 +112,7 @@ void SMsgWriter::writeFence(rdr::U32 flags, unsigned len, const char data[])
 
 void SMsgWriter::writeEndOfContinuousUpdates()
 {
-  if (!client->supportsContinuousUpdates)
+  if (!client->supportsEncoding(pseudoEncodingContinuousUpdates))
     throw Exception("Client does not support continuous updates");
 
   startMsg(msgTypeEndOfContinuousUpdates);
@@ -120,7 +120,7 @@ void SMsgWriter::writeEndOfContinuousUpdates()
 }
 
 bool SMsgWriter::writeSetDesktopSize() {
-  if (!client->supportsDesktopResize)
+  if (!client->supportsEncoding(pseudoEncodingDesktopSize))
     return false;
 
   needSetDesktopSize = true;
@@ -129,7 +129,7 @@ bool SMsgWriter::writeSetDesktopSize() {
 }
 
 bool SMsgWriter::writeExtendedDesktopSize() {
-  if (!client->supportsExtendedDesktopSize)
+  if (!client->supportsEncoding(pseudoEncodingExtendedDesktopSize))
     return false;
 
   needExtendedDesktopSize = true;
@@ -142,7 +142,7 @@ bool SMsgWriter::writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result,
                                           const ScreenSet& layout) {
   ExtendedDesktopSizeMsg msg;
 
-  if (!client->supportsExtendedDesktopSize)
+  if (!client->supportsEncoding(pseudoEncodingExtendedDesktopSize))
     return false;
 
   msg.reason = reason;
@@ -157,7 +157,7 @@ bool SMsgWriter::writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result,
 }
 
 bool SMsgWriter::writeSetDesktopName() {
-  if (!client->supportsDesktopRename)
+  if (!client->supportsEncoding(pseudoEncodingDesktopName))
     return false;
 
   needSetDesktopName = true;
@@ -167,7 +167,7 @@ bool SMsgWriter::writeSetDesktopName() {
 
 bool SMsgWriter::writeSetCursor()
 {
-  if (!client->supportsLocalCursor)
+  if (!client->supportsEncoding(pseudoEncodingCursor))
     return false;
 
   needSetCursor = true;
@@ -177,7 +177,7 @@ bool SMsgWriter::writeSetCursor()
 
 bool SMsgWriter::writeSetXCursor()
 {
-  if (!client->supportsLocalXCursor)
+  if (!client->supportsEncoding(pseudoEncodingXCursor))
     return false;
 
   needSetXCursor = true;
@@ -187,7 +187,7 @@ bool SMsgWriter::writeSetXCursor()
 
 bool SMsgWriter::writeSetCursorWithAlpha()
 {
-  if (!client->supportsLocalCursorWithAlpha)
+  if (!client->supportsEncoding(pseudoEncodingCursorWithAlpha))
     return false;
 
   needSetCursorWithAlpha = true;
@@ -197,7 +197,7 @@ bool SMsgWriter::writeSetCursorWithAlpha()
 
 bool SMsgWriter::writeLEDState()
 {
-  if (!client->supportsLEDState)
+  if (!client->supportsEncoding(pseudoEncodingLEDState))
     return false;
   if (client->ledState() == ledUnknown)
     return false;
@@ -209,7 +209,7 @@ bool SMsgWriter::writeLEDState()
 
 bool SMsgWriter::writeQEMUKeyEvent()
 {
-  if (!client->supportsQEMUKeyEvent)
+  if (!client->supportsEncoding(pseudoEncodingQEMUKeyEvent))
     return false;
 
   needQEMUKeyEvent = true;
@@ -437,7 +437,7 @@ void SMsgWriter::writeNoDataRects()
 
 void SMsgWriter::writeSetDesktopSizeRect(int width, int height)
 {
-  if (!client->supportsDesktopResize)
+  if (!client->supportsEncoding(pseudoEncodingDesktopSize))
     throw Exception("Client does not support desktop resize");
   if (++nRectsInUpdate > nRectsInHeader && nRectsInHeader)
     throw Exception("SMsgWriter::writeSetDesktopSizeRect: nRects out of sync");
@@ -457,7 +457,7 @@ void SMsgWriter::writeExtendedDesktopSizeRect(rdr::U16 reason,
 {
   ScreenSet::const_iterator si;
 
-  if (!client->supportsExtendedDesktopSize)
+  if (!client->supportsEncoding(pseudoEncodingExtendedDesktopSize))
     throw Exception("Client does not support extended desktop resize");
   if (++nRectsInUpdate > nRectsInHeader && nRectsInHeader)
     throw Exception("SMsgWriter::writeExtendedDesktopSizeRect: nRects out of sync");
@@ -483,7 +483,7 @@ void SMsgWriter::writeExtendedDesktopSizeRect(rdr::U16 reason,
 
 void SMsgWriter::writeSetDesktopNameRect(const char *name)
 {
-  if (!client->supportsDesktopRename)
+  if (!client->supportsEncoding(pseudoEncodingDesktopName))
     throw Exception("Client does not support desktop rename");
   if (++nRectsInUpdate > nRectsInHeader && nRectsInHeader)
     throw Exception("SMsgWriter::writeSetDesktopNameRect: nRects out of sync");
@@ -500,7 +500,7 @@ void SMsgWriter::writeSetCursorRect(int width, int height,
                                     int hotspotX, int hotspotY,
                                     const void* data, const void* mask)
 {
-  if (!client->supportsLocalCursor)
+  if (!client->supportsEncoding(pseudoEncodingCursor))
     throw Exception("Client does not support local cursors");
   if (++nRectsInUpdate > nRectsInHeader && nRectsInHeader)
     throw Exception("SMsgWriter::writeSetCursorRect: nRects out of sync");
@@ -518,7 +518,7 @@ void SMsgWriter::writeSetXCursorRect(int width, int height,
                                      int hotspotX, int hotspotY,
                                      const void* data, const void* mask)
 {
-  if (!client->supportsLocalXCursor)
+  if (!client->supportsEncoding(pseudoEncodingXCursor))
     throw Exception("Client does not support local cursors");
   if (++nRectsInUpdate > nRectsInHeader && nRectsInHeader)
     throw Exception("SMsgWriter::writeSetXCursorRect: nRects out of sync");
@@ -544,7 +544,7 @@ void SMsgWriter::writeSetCursorWithAlphaRect(int width, int height,
                                              int hotspotX, int hotspotY,
                                              const rdr::U8* data)
 {
-  if (!client->supportsLocalCursorWithAlpha)
+  if (!client->supportsEncoding(pseudoEncodingCursorWithAlpha))
     throw Exception("Client does not support local cursors");
   if (++nRectsInUpdate > nRectsInHeader && nRectsInHeader)
     throw Exception("SMsgWriter::writeSetCursorWithAlphaRect: nRects out of sync");
@@ -570,7 +570,7 @@ void SMsgWriter::writeSetCursorWithAlphaRect(int width, int height,
 
 void SMsgWriter::writeLEDStateRect(rdr::U8 state)
 {
-  if (!client->supportsLEDState)
+  if (!client->supportsEncoding(pseudoEncodingLEDState))
     throw Exception("Client does not support LED state updates");
   if (client->ledState() == ledUnknown)
     throw Exception("Server does not support LED state updates");
@@ -587,7 +587,7 @@ void SMsgWriter::writeLEDStateRect(rdr::U8 state)
 
 void SMsgWriter::writeQEMUKeyEventRect()
 {
-  if (!client->supportsQEMUKeyEvent)
+  if (!client->supportsEncoding(pseudoEncodingQEMUKeyEvent))
     throw Exception("Client does not support QEMU extended key events");
   if (++nRectsInUpdate > nRectsInHeader && nRectsInHeader)
     throw Exception("SMsgWriter::writeQEMUKeyEventRect: nRects out of sync");

--- a/common/rfb/SMsgWriter.cxx
+++ b/common/rfb/SMsgWriter.cxx
@@ -49,8 +49,8 @@ SMsgWriter::~SMsgWriter()
 
 void SMsgWriter::writeServerInit()
 {
-  os->writeU16(cp->width);
-  os->writeU16(cp->height);
+  os->writeU16(cp->width());
+  os->writeU16(cp->height());
   cp->pf().write(os);
   os->writeString(cp->name());
   endMsg();
@@ -422,15 +422,15 @@ void SMsgWriter::writeNoDataRects()
 
   // Send this before SetDesktopSize to make life easier on the clients
   if (needExtendedDesktopSize) {
-    writeExtendedDesktopSizeRect(0, 0, cp->width, cp->height,
-                                 cp->screenLayout);
+    writeExtendedDesktopSizeRect(0, 0, cp->width(), cp->height(),
+                                 cp->screenLayout());
     needExtendedDesktopSize = false;
   }
 
   // Some clients assume this is the last rectangle so don't send anything
   // more after this
   if (needSetDesktopSize) {
-    writeSetDesktopSizeRect(cp->width, cp->height);
+    writeSetDesktopSizeRect(cp->width(), cp->height());
     needSetDesktopSize = false;
   }
 }

--- a/common/rfb/SMsgWriter.cxx
+++ b/common/rfb/SMsgWriter.cxx
@@ -138,9 +138,7 @@ bool SMsgWriter::writeExtendedDesktopSize() {
   return true;
 }
 
-bool SMsgWriter::writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result,
-                                          int fb_width, int fb_height,
-                                          const ScreenSet& layout) {
+bool SMsgWriter::writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result) {
   ExtendedDesktopSizeMsg msg;
 
   if (!client->supportsEncoding(pseudoEncodingExtendedDesktopSize))
@@ -148,9 +146,6 @@ bool SMsgWriter::writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result,
 
   msg.reason = reason;
   msg.result = result;
-  msg.fb_width = fb_width;
-  msg.fb_height = fb_height;
-  msg.layout = layout;
 
   extendedDesktopSizeMsgs.push_back(msg);
 
@@ -415,7 +410,8 @@ void SMsgWriter::writeNoDataRects()
 
     for (ri = extendedDesktopSizeMsgs.begin();ri != extendedDesktopSizeMsgs.end();++ri) {
       writeExtendedDesktopSizeRect(ri->reason, ri->result,
-                                   ri->fb_width, ri->fb_height, ri->layout);
+                                   client->width(), client->height(),
+                                   client->screenLayout());
     }
 
     extendedDesktopSizeMsgs.clear();

--- a/common/rfb/SMsgWriter.cxx
+++ b/common/rfb/SMsgWriter.cxx
@@ -132,13 +132,12 @@ void SMsgWriter::writeDesktopSize(rdr::U16 reason, rdr::U16 result)
   extendedDesktopSizeMsgs.push_back(msg);
 }
 
-bool SMsgWriter::writeSetDesktopName() {
+void SMsgWriter::writeSetDesktopName()
+{
   if (!client->supportsEncoding(pseudoEncodingDesktopName))
-    return false;
+    throw Exception("Client does not support desktop name changes");
 
   needSetDesktopName = true;
-
-  return true;
 }
 
 void SMsgWriter::writeCursor()
@@ -151,26 +150,22 @@ void SMsgWriter::writeCursor()
   needCursor = true;
 }
 
-bool SMsgWriter::writeLEDState()
+void SMsgWriter::writeLEDState()
 {
   if (!client->supportsEncoding(pseudoEncodingLEDState))
-    return false;
+    throw Exception("Client does not support LED state");
   if (client->ledState() == ledUnknown)
-    return false;
+    throw Exception("Server has not specified LED state");
 
   needLEDState = true;
-
-  return true;
 }
 
-bool SMsgWriter::writeQEMUKeyEvent()
+void SMsgWriter::writeQEMUKeyEvent()
 {
   if (!client->supportsEncoding(pseudoEncodingQEMUKeyEvent))
-    return false;
+    throw Exception("Client does not support QEMU key events");
 
   needQEMUKeyEvent = true;
-
-  return true;
 }
 
 bool SMsgWriter::needFakeUpdate()

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -31,12 +31,12 @@ namespace rdr { class OutStream; }
 
 namespace rfb {
 
-  class ConnParams;
+  class ClientParams;
   struct ScreenSet;
 
   class SMsgWriter {
   public:
-    SMsgWriter(ConnParams* cp, rdr::OutStream* os);
+    SMsgWriter(ClientParams* client, rdr::OutStream* os);
     virtual ~SMsgWriter();
 
     // writeServerInit() must only be called at the appropriate time in the
@@ -140,7 +140,7 @@ namespace rfb {
     void writeLEDStateRect(rdr::U8 state);
     void writeQEMUKeyEventRect();
 
-    ConnParams* cp;
+    ClientParams* client;
     rdr::OutStream* os;
 
     int nRectsInUpdate;

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -69,17 +69,17 @@ namespace rfb {
     // write the relevant pseudo-rectangle as part of the next update.
     void writeDesktopSize(rdr::U16 reason, rdr::U16 result=0);
 
-    bool writeSetDesktopName();
+    void writeSetDesktopName();
 
     // Like setDesktopSize, we can't just write out a cursor message
     // immediately. 
     void writeCursor();
 
     // Same for LED state message
-    bool writeLEDState();
+    void writeLEDState();
 
     // And QEMU keyboard event handshake
-    bool writeQEMUKeyEvent();
+    void writeQEMUKeyEvent();
 
     // needFakeUpdate() returns true when an immediate update is needed in
     // order to flush out pseudo-rectangles to the client.

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -65,22 +65,15 @@ namespace rfb {
     // updates mode.
     void writeEndOfContinuousUpdates();
 
-    // writeSetDesktopSize() won't actually write immediately, but will
+    // writeDesktopSize() won't actually write immediately, but will
     // write the relevant pseudo-rectangle as part of the next update.
-    bool writeSetDesktopSize();
-    // Same thing for the extended version. The first version queues up a
-    // generic update of the current server state, but the second queues a
-    // specific message.
-    bool writeExtendedDesktopSize();
-    bool writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result);
+    void writeDesktopSize(rdr::U16 reason, rdr::U16 result=0);
 
     bool writeSetDesktopName();
 
     // Like setDesktopSize, we can't just write out a cursor message
     // immediately. 
-    bool writeSetCursor();
-    bool writeSetXCursor();
-    bool writeSetCursorWithAlpha();
+    void writeCursor();
 
     // Same for LED state message
     bool writeLEDState();
@@ -146,12 +139,8 @@ namespace rfb {
     int nRectsInUpdate;
     int nRectsInHeader;
 
-    bool needSetDesktopSize;
-    bool needExtendedDesktopSize;
     bool needSetDesktopName;
-    bool needSetCursor;
-    bool needSetXCursor;
-    bool needSetCursorWithAlpha;
+    bool needCursor;
     bool needLEDState;
     bool needQEMUKeyEvent;
 

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -32,6 +32,7 @@ namespace rdr { class OutStream; }
 namespace rfb {
 
   class ClientParams;
+  class PixelFormat;
   struct ScreenSet;
 
   class SMsgWriter {
@@ -41,7 +42,8 @@ namespace rfb {
 
     // writeServerInit() must only be called at the appropriate time in the
     // protocol initialisation.
-    void writeServerInit();
+    void writeServerInit(rdr::U16 width, rdr::U16 height,
+                         const PixelFormat& pf, const char* name);
 
     // Methods to write normal protocol messages
 

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -72,9 +72,7 @@ namespace rfb {
     // generic update of the current server state, but the second queues a
     // specific message.
     bool writeExtendedDesktopSize();
-    bool writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result,
-                                  int fb_width, int fb_height,
-                                  const ScreenSet& layout);
+    bool writeExtendedDesktopSize(rdr::U16 reason, rdr::U16 result);
 
     bool writeSetDesktopName();
 
@@ -159,8 +157,6 @@ namespace rfb {
 
     typedef struct {
       rdr::U16 reason, result;
-      int fb_width, fb_height;
-      ScreenSet layout;
     } ExtendedDesktopSizeMsg;
 
     std::list<ExtendedDesktopSizeMsg> extendedDesktopSizeMsgs;

--- a/common/rfb/ServerParams.cxx
+++ b/common/rfb/ServerParams.cxx
@@ -25,11 +25,8 @@ using namespace rfb;
 
 ServerParams::ServerParams()
   : majorVersion(0), minorVersion(0),
-    useCopyRect(false),
-    supportsLocalCursor(false), supportsLocalXCursor(false),
-    supportsLocalCursorWithAlpha(false),
+    supportsLocalCursor(false),
     supportsDesktopResize(false), supportsExtendedDesktopSize(false),
-    supportsDesktopRename(false), supportsLastRect(false),
     supportsLEDState(false), supportsQEMUKeyEvent(false),
     supportsSetDesktopSize(false), supportsFence(false),
     supportsContinuousUpdates(false),

--- a/common/rfb/ServerParams.cxx
+++ b/common/rfb/ServerParams.cxx
@@ -25,12 +25,9 @@ using namespace rfb;
 
 ServerParams::ServerParams()
   : majorVersion(0), minorVersion(0),
-    supportsLocalCursor(false),
-    supportsDesktopResize(false),
-    supportsLEDState(false), supportsQEMUKeyEvent(false),
+    supportsQEMUKeyEvent(false),
     supportsSetDesktopSize(false), supportsFence(false),
     supportsContinuousUpdates(false),
-    compressLevel(2), qualityLevel(-1),
     width_(0), height_(0), name_(0),
     ledState_(ledUnknown)
 {

--- a/common/rfb/ServerParams.cxx
+++ b/common/rfb/ServerParams.cxx
@@ -26,7 +26,7 @@ using namespace rfb;
 ServerParams::ServerParams()
   : majorVersion(0), minorVersion(0),
     supportsLocalCursor(false),
-    supportsDesktopResize(false), supportsExtendedDesktopSize(false),
+    supportsDesktopResize(false),
     supportsLEDState(false), supportsQEMUKeyEvent(false),
     supportsSetDesktopSize(false), supportsFence(false),
     supportsContinuousUpdates(false),

--- a/common/rfb/ServerParams.cxx
+++ b/common/rfb/ServerParams.cxx
@@ -1,0 +1,90 @@
+/* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
+ * Copyright (C) 2011 D. R. Commander.  All Rights Reserved.
+ * Copyright 2014-2018 Pierre Ossman for Cendio AB
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+#include <rfb/Exception.h>
+#include <rfb/ledStates.h>
+#include <rfb/ServerParams.h>
+
+using namespace rfb;
+
+ServerParams::ServerParams()
+  : majorVersion(0), minorVersion(0),
+    useCopyRect(false),
+    supportsLocalCursor(false), supportsLocalXCursor(false),
+    supportsLocalCursorWithAlpha(false),
+    supportsDesktopResize(false), supportsExtendedDesktopSize(false),
+    supportsDesktopRename(false), supportsLastRect(false),
+    supportsLEDState(false), supportsQEMUKeyEvent(false),
+    supportsSetDesktopSize(false), supportsFence(false),
+    supportsContinuousUpdates(false),
+    compressLevel(2), qualityLevel(-1),
+    width_(0), height_(0), name_(0),
+    ledState_(ledUnknown)
+{
+  setName("");
+  cursor_ = new Cursor(0, 0, Point(), NULL);
+}
+
+ServerParams::~ServerParams()
+{
+  delete [] name_;
+  delete cursor_;
+}
+
+void ServerParams::setDimensions(int width, int height)
+{
+  ScreenSet layout;
+  layout.add_screen(rfb::Screen(0, 0, 0, width, height, 0));
+  setDimensions(width, height, layout);
+}
+
+void ServerParams::setDimensions(int width, int height, const ScreenSet& layout)
+{
+  if (!layout.validate(width, height))
+    throw Exception("Attempted to configure an invalid screen layout");
+
+  width_ = width;
+  height_ = height;
+  screenLayout_ = layout;
+}
+
+void ServerParams::setPF(const PixelFormat& pf)
+{
+  pf_ = pf;
+
+  if (pf.bpp != 8 && pf.bpp != 16 && pf.bpp != 32)
+    throw Exception("setPF: not 8, 16 or 32 bpp?");
+}
+
+void ServerParams::setName(const char* name)
+{
+  delete [] name_;
+  name_ = strDup(name);
+}
+
+void ServerParams::setCursor(const Cursor& other)
+{
+  delete cursor_;
+  cursor_ = new Cursor(other);
+}
+
+void ServerParams::setLEDState(unsigned int state)
+{
+  ledState_ = state;
+}

--- a/common/rfb/ServerParams.h
+++ b/common/rfb/ServerParams.h
@@ -69,17 +69,10 @@ namespace rfb {
     unsigned int ledState() { return ledState_; }
     void setLEDState(unsigned int state);
 
-    bool supportsLocalCursor;
-    bool supportsDesktopResize;
-    bool supportsLEDState;
     bool supportsQEMUKeyEvent;
-
     bool supportsSetDesktopSize;
     bool supportsFence;
     bool supportsContinuousUpdates;
-
-    int compressLevel;
-    int qualityLevel;
 
   private:
 

--- a/common/rfb/ServerParams.h
+++ b/common/rfb/ServerParams.h
@@ -69,15 +69,9 @@ namespace rfb {
     unsigned int ledState() { return ledState_; }
     void setLEDState(unsigned int state);
 
-    bool useCopyRect;
-
     bool supportsLocalCursor;
-    bool supportsLocalXCursor;
-    bool supportsLocalCursorWithAlpha;
     bool supportsDesktopResize;
     bool supportsExtendedDesktopSize;
-    bool supportsDesktopRename;
-    bool supportsLastRect;
     bool supportsLEDState;
     bool supportsQEMUKeyEvent;
 

--- a/common/rfb/ServerParams.h
+++ b/common/rfb/ServerParams.h
@@ -71,7 +71,6 @@ namespace rfb {
 
     bool supportsLocalCursor;
     bool supportsDesktopResize;
-    bool supportsExtendedDesktopSize;
     bool supportsLEDState;
     bool supportsQEMUKeyEvent;
 

--- a/common/rfb/ServerParams.h
+++ b/common/rfb/ServerParams.h
@@ -1,0 +1,103 @@
+/* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
+ * Copyright 2014-2018 Pierre Ossman for Cendio AB
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+//
+// ServerParams - structure describing the current state of the remote server
+//
+
+#ifndef __RFB_SERVERPARAMS_H__
+#define __RFB_SERVERPARAMS_H__
+
+#include <rfb/Cursor.h>
+#include <rfb/PixelFormat.h>
+#include <rfb/ScreenSet.h>
+
+namespace rfb {
+
+  class ServerParams {
+  public:
+    ServerParams();
+    ~ServerParams();
+
+    int majorVersion;
+    int minorVersion;
+
+    void setVersion(int major, int minor) {
+      majorVersion = major; minorVersion = minor;
+    }
+    bool isVersion(int major, int minor) const {
+      return majorVersion == major && minorVersion == minor;
+    }
+    bool beforeVersion(int major, int minor) const {
+      return (majorVersion < major ||
+              (majorVersion == major && minorVersion < minor));
+    }
+    bool afterVersion(int major, int minor) const {
+      return !beforeVersion(major,minor+1);
+    }
+
+    const int width() const { return width_; }
+    const int height() const { return height_; }
+    const ScreenSet& screenLayout() const { return screenLayout_; }
+    void setDimensions(int width, int height);
+    void setDimensions(int width, int height, const ScreenSet& layout);
+
+    const PixelFormat& pf() const { return pf_; }
+    void setPF(const PixelFormat& pf);
+
+    const char* name() const { return name_; }
+    void setName(const char* name);
+
+    const Cursor& cursor() const { return *cursor_; }
+    void setCursor(const Cursor& cursor);
+
+    unsigned int ledState() { return ledState_; }
+    void setLEDState(unsigned int state);
+
+    bool useCopyRect;
+
+    bool supportsLocalCursor;
+    bool supportsLocalXCursor;
+    bool supportsLocalCursorWithAlpha;
+    bool supportsDesktopResize;
+    bool supportsExtendedDesktopSize;
+    bool supportsDesktopRename;
+    bool supportsLastRect;
+    bool supportsLEDState;
+    bool supportsQEMUKeyEvent;
+
+    bool supportsSetDesktopSize;
+    bool supportsFence;
+    bool supportsContinuousUpdates;
+
+    int compressLevel;
+    int qualityLevel;
+
+  private:
+
+    int width_;
+    int height_;
+    ScreenSet screenLayout_;
+
+    PixelFormat pf_;
+    char* name_;
+    Cursor* cursor_;
+    unsigned int ledState_;
+  };
+}
+#endif

--- a/common/rfb/TightDecoder.h
+++ b/common/rfb/TightDecoder.h
@@ -32,16 +32,16 @@ namespace rfb {
     TightDecoder();
     virtual ~TightDecoder();
     virtual void readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os);
+                          const ServerParams& server, rdr::OutStream* os);
     virtual bool doRectsConflict(const Rect& rectA,
                                  const void* bufferA,
                                  size_t buflenA,
                                  const Rect& rectB,
                                  const void* bufferB,
                                  size_t buflenB,
-                                 const ConnParams& cp);
+                                 const ServerParams& server);
     virtual void decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb);
 
   private:

--- a/common/rfb/TightEncoder.cxx
+++ b/common/rfb/TightEncoder.cxx
@@ -23,7 +23,6 @@
 #include <rfb/PixelBuffer.h>
 #include <rfb/Palette.h>
 #include <rfb/encodings.h>
-#include <rfb/ConnParams.h>
 #include <rfb/SConnection.h>
 #include <rfb/TightEncoder.h>
 #include <rfb/TightConstants.h>
@@ -68,7 +67,7 @@ TightEncoder::~TightEncoder()
 
 bool TightEncoder::isSupported()
 {
-  return conn->cp.supportsEncoding(encodingTight);
+  return conn->client.supportsEncoding(encodingTight);
 }
 
 void TightEncoder::setCompressLevel(int level)

--- a/common/rfb/TightJPEGEncoder.cxx
+++ b/common/rfb/TightJPEGEncoder.cxx
@@ -76,15 +76,15 @@ TightJPEGEncoder::~TightJPEGEncoder()
 
 bool TightJPEGEncoder::isSupported()
 {
-  if (!conn->cp.supportsEncoding(encodingTight))
+  if (!conn->client.supportsEncoding(encodingTight))
     return false;
 
   // Any one of these indicates support for JPEG
-  if (conn->cp.qualityLevel != -1)
+  if (conn->client.qualityLevel != -1)
     return true;
-  if (conn->cp.fineQualityLevel != -1)
+  if (conn->client.fineQualityLevel != -1)
     return true;
-  if (conn->cp.subsampling != -1)
+  if (conn->client.subsampling != -1)
     return true;
 
   // Tight support, but not JPEG

--- a/common/rfb/UpdateTracker.cxx
+++ b/common/rfb/UpdateTracker.cxx
@@ -60,19 +60,10 @@ void ClippingUpdateTracker::add_copied(const Region &dest, const Point &delta) {
 
 // SimpleUpdateTracker
 
-SimpleUpdateTracker::SimpleUpdateTracker(bool use_copyrect) {
-  copy_enabled = use_copyrect;
+SimpleUpdateTracker::SimpleUpdateTracker() {
 }
 
 SimpleUpdateTracker::~SimpleUpdateTracker() {
-}
-
-void SimpleUpdateTracker::enable_copyrect(bool enable) {
-  if (!enable && copy_enabled) {
-    add_changed(copied);
-    copied.clear();
-  }
-  copy_enabled=enable;
 }
 
 void SimpleUpdateTracker::add_changed(const Region &region) {
@@ -80,12 +71,6 @@ void SimpleUpdateTracker::add_changed(const Region &region) {
 }
 
 void SimpleUpdateTracker::add_copied(const Region &dest, const Point &delta) {
-  // Do we support copyrect?
-  if (!copy_enabled) {
-    add_changed(dest);
-    return;
-  }
-
   // Is there anything to do?
   if (dest.is_empty()) return;
 

--- a/common/rfb/UpdateTracker.h
+++ b/common/rfb/UpdateTracker.h
@@ -68,10 +68,8 @@ namespace rfb {
 
   class SimpleUpdateTracker : public UpdateTracker {
   public:
-    SimpleUpdateTracker(bool use_copyrect=true);
+    SimpleUpdateTracker();
     virtual ~SimpleUpdateTracker();
-
-    virtual void enable_copyrect(bool enable);
 
     virtual void add_changed(const Region &region);
     virtual void add_copied(const Region &dest, const Point &delta);
@@ -94,7 +92,6 @@ namespace rfb {
     Region changed;
     Region copied;
     Point copy_delta;
-    bool copy_enabled;
   };
 
 }

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -716,8 +716,7 @@ void VNCSConnectionST::setDesktopSize(int fb_width, int fb_height,
 
   // Don't bother the desktop with an invalid configuration
   if (!layout.validate(fb_width, fb_height)) {
-    writer()->writeExtendedDesktopSize(reasonClient, resultInvalid,
-                                       fb_width, fb_height, layout);
+    writer()->writeExtendedDesktopSize(reasonClient, resultInvalid);
     return;
   }
 
@@ -726,8 +725,7 @@ void VNCSConnectionST::setDesktopSize(int fb_width, int fb_height,
   // protocol-wise, but unnecessary.
   result = server->desktop->setScreenLayout(fb_width, fb_height, layout);
 
-  writer()->writeExtendedDesktopSize(reasonClient, result,
-                                     fb_width, fb_height, layout);
+  writer()->writeExtendedDesktopSize(reasonClient, result);
 
   // Only notify other clients on success
   if (result == resultSuccess) {
@@ -1127,9 +1125,7 @@ void VNCSConnectionST::screenLayoutChange(rdr::U16 reason)
   if (state() != RFBSTATE_NORMAL)
     return;
 
-  writer()->writeExtendedDesktopSize(reason, 0,
-                                     client.width(), client.height(),
-                                     client.screenLayout());
+  writer()->writeExtendedDesktopSize(reason, 0);
 }
 
 

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -829,6 +829,9 @@ void VNCSConnectionST::supportsContinuousUpdates()
 
 void VNCSConnectionST::supportsLEDState()
 {
+  if (client.ledState() == ledUnknown)
+    return;
+
   writer()->writeLEDState();
 }
 
@@ -1157,10 +1160,8 @@ void VNCSConnectionST::setDesktopName(const char *name)
   if (state() != RFBSTATE_NORMAL)
     return;
 
-  if (!writer()->writeSetDesktopName()) {
-    fprintf(stderr, "Client does not support desktop rename\n");
-    return;
-  }
+  if (client.supportsEncoding(pseudoEncodingDesktopName))
+    writer()->writeSetDesktopName();
 }
 
 void VNCSConnectionST::setLEDState(unsigned int ledstate)
@@ -1170,7 +1171,8 @@ void VNCSConnectionST::setLEDState(unsigned int ledstate)
 
   client.setLEDState(ledstate);
 
-  writer()->writeLEDState();
+  if (client.supportsLEDState())
+    writer()->writeLEDState();
 }
 
 void VNCSConnectionST::setSocketTimeouts()

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -385,8 +385,7 @@ bool VNCSConnectionST::needRenderedCursor()
   if (state() != RFBSTATE_NORMAL)
     return false;
 
-  if (!client.supportsLocalCursorWithAlpha &&
-      !client.supportsLocalCursor && !client.supportsLocalXCursor)
+  if (!client.supportsLocalCursor())
     return true;
   if (!server->cursorPos.equals(pointerEventPos) &&
       (time(0) - pointerEventTime) > 0)
@@ -572,7 +571,7 @@ void VNCSConnectionST::keyEvent(rdr::U32 keysym, rdr::U32 keycode, bool down) {
 
   // Lock key heuristics
   // (only for clients that do not support the LED state extension)
-  if (!client.supportsLEDState) {
+  if (!client.supportsLEDState()) {
     // Always ignore ScrollLock as we don't have a heuristic
     // for that
     if (keysym == XK_Scroll_Lock) {
@@ -787,7 +786,7 @@ void VNCSConnectionST::enableContinuousUpdates(bool enable,
 {
   Rect rect;
 
-  if (!client.supportsFence || !client.supportsContinuousUpdates)
+  if (!client.supportsFence() || !client.supportsContinuousUpdates())
     throw Exception("Client tried to enable continuous updates when not allowed");
 
   continuousUpdates = enable;
@@ -803,7 +802,7 @@ void VNCSConnectionST::enableContinuousUpdates(bool enable,
 }
 
 // supportsLocalCursor() is called whenever the status of
-// client.supportsLocalCursor has changed.  If the client does now support local
+// client.supportsLocalCursor() has changed.  If the client does now support local
 // cursor, we make sure that the old server-side rendered cursor is cleaned up
 // and the cursor is sent to the client.
 
@@ -825,7 +824,7 @@ void VNCSConnectionST::supportsContinuousUpdates()
 {
   // We refuse to use continuous updates if we cannot monitor the buffer
   // usage using fences.
-  if (!client.supportsFence)
+  if (!client.supportsFence())
     return;
 
   writer()->writeEndOfContinuousUpdates();
@@ -868,7 +867,7 @@ void VNCSConnectionST::writeRTTPing()
 {
   char type;
 
-  if (!client.supportsFence)
+  if (!client.supportsFence())
     return;
 
   congestion.updatePosition(sock->outStream().length());
@@ -895,7 +894,7 @@ bool VNCSConnectionST::isCongested()
   if (sock->outStream().bufferUsage() > 0)
     return true;
 
-  if (!client.supportsFence)
+  if (!client.supportsFence())
     return false;
 
   congestion.updatePosition(sock->outStream().length());

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -49,7 +49,7 @@ VNCSConnectionST::VNCSConnectionST(VNCServerST* server_, network::Socket *s,
     inProcessMessages(false),
     pendingSyncFence(false), syncFence(false), fenceFlags(0),
     fenceDataLen(0), fenceData(NULL), congestionTimer(this),
-    losslessTimer(this), server(server_), updates(false),
+    losslessTimer(this), server(server_),
     updateRenderedCursor(false), removeRenderedCursor(false),
     continuousUpdates(false), encodeManager(this), pointerEventTime(0),
     clientHasCursor(false),
@@ -971,8 +971,6 @@ void VNCSConnectionST::writeDataUpdate()
   UpdateInfo ui;
   bool needNewUpdateInfo;
   const RenderedCursor *cursor;
-
-  updates.enable_copyrect(client.useCopyRect);
 
   // See what the client has requested (if anything)
   if (continuousUpdates)

--- a/common/rfb/ZRLEDecoder.cxx
+++ b/common/rfb/ZRLEDecoder.cxx
@@ -21,7 +21,7 @@
 #include <rdr/MemInStream.h>
 #include <rdr/OutStream.h>
 
-#include <rfb/ConnParams.h>
+#include <rfb/ServerParams.h>
 #include <rfb/PixelBuffer.h>
 #include <rfb/ZRLEDecoder.h>
 
@@ -72,7 +72,7 @@ ZRLEDecoder::~ZRLEDecoder()
 }
 
 void ZRLEDecoder::readRect(const Rect& r, rdr::InStream* is,
-                           const ConnParams& cp, rdr::OutStream* os)
+                           const ServerParams& server, rdr::OutStream* os)
 {
   rdr::U32 len;
 
@@ -82,11 +82,11 @@ void ZRLEDecoder::readRect(const Rect& r, rdr::InStream* is,
 }
 
 void ZRLEDecoder::decodeRect(const Rect& r, const void* buffer,
-                             size_t buflen, const ConnParams& cp,
+                             size_t buflen, const ServerParams& server,
                              ModifiablePixelBuffer* pb)
 {
   rdr::MemInStream is(buffer, buflen);
-  const rfb::PixelFormat& pf = cp.pf();
+  const rfb::PixelFormat& pf = server.pf();
   switch (pf.bpp) {
   case 8:  zrleDecode8 (r, &is, &zis, pf, pb); break;
   case 16: zrleDecode16(r, &is, &zis, pf, pb); break;

--- a/common/rfb/ZRLEDecoder.h
+++ b/common/rfb/ZRLEDecoder.h
@@ -28,9 +28,9 @@ namespace rfb {
     ZRLEDecoder();
     virtual ~ZRLEDecoder();
     virtual void readRect(const Rect& r, rdr::InStream* is,
-                          const ConnParams& cp, rdr::OutStream* os);
+                          const ServerParams& server, rdr::OutStream* os);
     virtual void decodeRect(const Rect& r, const void* buffer,
-                            size_t buflen, const ConnParams& cp,
+                            size_t buflen, const ServerParams& server,
                             ModifiablePixelBuffer* pb);
   private:
     rdr::ZlibInStream zis;

--- a/common/rfb/ZRLEEncoder.cxx
+++ b/common/rfb/ZRLEEncoder.cxx
@@ -19,7 +19,6 @@
 #include <rdr/OutStream.h>
 #include <rfb/Exception.h>
 #include <rfb/encodings.h>
-#include <rfb/ConnParams.h>
 #include <rfb/Palette.h>
 #include <rfb/SConnection.h>
 #include <rfb/ZRLEEncoder.h>
@@ -43,7 +42,7 @@ ZRLEEncoder::~ZRLEEncoder()
 
 bool ZRLEEncoder::isSupported()
 {
-  return conn->cp.supportsEncoding(encodingZRLE);
+  return conn->client.supportsEncoding(encodingZRLE);
 }
 
 void ZRLEEncoder::writeRect(const PixelBuffer* pb, const Palette& palette)

--- a/tests/decperf.cxx
+++ b/tests/decperf.cxx
@@ -47,7 +47,7 @@ public:
   CConn(const char *filename);
   ~CConn();
 
-  virtual void setDesktopSize(int w, int h);
+  virtual void initDone();
   virtual void setPixelFormat(const rfb::PixelFormat& pf);
   virtual void setCursor(int, int, const rfb::Point&, const rdr::U8*);
   virtual void framebufferUpdateStart();
@@ -81,10 +81,8 @@ CConn::~CConn()
   delete in;
 }
 
-void CConn::setDesktopSize(int w, int h)
+void CConn::initDone()
 {
-  CConnection::setDesktopSize(w, h);
-
   setFramebuffer(new rfb::ManagedPixelBuffer(filePF,
                                              server.width(),
                                              server.height()));

--- a/tests/decperf.cxx
+++ b/tests/decperf.cxx
@@ -85,7 +85,7 @@ void CConn::setDesktopSize(int w, int h)
 {
   CConnection::setDesktopSize(w, h);
 
-  setFramebuffer(new rfb::ManagedPixelBuffer(filePF, cp.width, cp.height));
+  setFramebuffer(new rfb::ManagedPixelBuffer(filePF, cp.width(), cp.height()));
 }
 
 void CConn::setPixelFormat(const rfb::PixelFormat& pf)

--- a/tests/decperf.cxx
+++ b/tests/decperf.cxx
@@ -85,7 +85,9 @@ void CConn::setDesktopSize(int w, int h)
 {
   CConnection::setDesktopSize(w, h);
 
-  setFramebuffer(new rfb::ManagedPixelBuffer(filePF, cp.width(), cp.height()));
+  setFramebuffer(new rfb::ManagedPixelBuffer(filePF,
+                                             server.width(),
+                                             server.height()));
 }
 
 void CConn::setPixelFormat(const rfb::PixelFormat& pf)

--- a/tests/encperf.cxx
+++ b/tests/encperf.cxx
@@ -180,7 +180,7 @@ CConn::CConn(const char *filename)
   setDesktopSize(width, height);
 
   sc = new SConn();
-  sc->cp.setPF((bool)translate ? fbPF : pf);
+  sc->client.setPF((bool)translate ? fbPF : pf);
   sc->setEncodings(sizeof(encodings) / sizeof(*encodings), encodings);
 }
 
@@ -290,7 +290,7 @@ SConn::SConn()
   out = new DummyOutStream;
   setStreams(NULL, out);
 
-  setWriter(new rfb::SMsgWriter(&cp, out));
+  setWriter(new rfb::SMsgWriter(&client, out));
 
   manager = new Manager(this);
 }

--- a/tests/encperf.cxx
+++ b/tests/encperf.cxx
@@ -203,7 +203,7 @@ void CConn::setDesktopSize(int w, int h)
   CConnection::setDesktopSize(w, h);
 
   pb = new rfb::ManagedPixelBuffer((bool)translate ? fbPF : cp.pf(),
-                                   cp.width, cp.height);
+                                   cp.width(), cp.height());
   setFramebuffer(pb);
 }
 

--- a/tests/encperf.cxx
+++ b/tests/encperf.cxx
@@ -89,7 +89,7 @@ public:
   void getStats(double& ratio, unsigned long long& bytes,
                 unsigned long long& rawEquivalent);
 
-  virtual void setDesktopSize(int w, int h);
+  virtual void initDone();
   virtual void setCursor(int, int, const rfb::Point&, const rdr::U8*);
   virtual void framebufferUpdateStart();
   virtual void framebufferUpdateEnd();
@@ -196,11 +196,9 @@ void CConn::getStats(double& ratio, unsigned long long& bytes,
   sc->getStats(ratio, bytes, rawEquivalent);
 }
 
-void CConn::setDesktopSize(int w, int h)
+void CConn::initDone()
 {
   rfb::ModifiablePixelBuffer *pb;
-
-  CConnection::setDesktopSize(w, h);
 
   pb = new rfb::ManagedPixelBuffer((bool)translate ? fbPF : server.pf(),
                                    server.width(), server.height());

--- a/tests/encperf.cxx
+++ b/tests/encperf.cxx
@@ -202,8 +202,8 @@ void CConn::setDesktopSize(int w, int h)
 
   CConnection::setDesktopSize(w, h);
 
-  pb = new rfb::ManagedPixelBuffer((bool)translate ? fbPF : cp.pf(),
-                                   cp.width(), cp.height());
+  pb = new rfb::ManagedPixelBuffer((bool)translate ? fbPF : server.pf(),
+                                   server.width(), server.height());
   setFramebuffer(pb);
 }
 

--- a/unix/x0vncserver/XDesktop.cxx
+++ b/unix/x0vncserver/XDesktop.cxx
@@ -381,6 +381,20 @@ ScreenSet XDesktop::computeScreenLayout()
 
   layout = ::computeScreenLayout(&outputIdMap);
   XRRFreeScreenResources(res);
+
+  // Adjust the layout relative to the geometry
+  ScreenSet::iterator iter, iter_next;
+  Point offset(-geometry->offsetLeft(), -geometry->offsetTop());
+  for (iter = layout.begin();iter != layout.end();iter = iter_next) {
+    iter_next = iter; ++iter_next;
+    iter->dimensions = iter->dimensions.translate(offset);
+    if (iter->dimensions.enclosed_by(geometry->getRect()))
+        continue;
+    iter->dimensions = iter->dimensions.intersect(geometry->getRect());
+    if (iter->dimensions.is_empty()) {
+      layout.remove_screen(iter->id);
+    }
+  }
 #endif
 
   return layout;

--- a/unix/x0vncserver/XDesktop.cxx
+++ b/unix/x0vncserver/XDesktop.cxx
@@ -397,6 +397,11 @@ ScreenSet XDesktop::computeScreenLayout()
   }
 #endif
 
+  // Make sure that we have at least one screen
+  if (layout.num_screens() == 0)
+    layout.add_screen(rfb::Screen(0, 0, 0, geometry->width(),
+                                  geometry->height(), 0));
+
   return layout;
 }
 

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -308,13 +308,11 @@ void CConn::socketEvent(FL_SOCKET fd, void *data)
 
 ////////////////////// CConnection callback methods //////////////////////
 
-// serverInit() is called when the serverInit message has been received.  At
+// initDone() is called when the serverInit message has been received.  At
 // this point we create the desktop window and display it.  We also tell the
 // server the pixel format and encodings to use and request the first update.
-void CConn::serverInit()
+void CConn::initDone()
 {
-  CConnection::serverInit();
-
   // If using AutoSelect with old servers, start in FullColor
   // mode. See comment in autoSelectFormatAndEncoding. 
   if (server.beforeVersion(3, 8) && autoSelect)

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -80,17 +80,15 @@ CConn::CConn(const char* vncServerName, network::Socket* socket=NULL)
   setShared(::shared);
   sock = socket;
 
-  server.supportsLocalCursor = true;
-
-  server.supportsDesktopResize = true;
-
-  server.supportsLEDState = true;
+  supportsLocalCursor = true;
+  supportsDesktopResize = true;
+  supportsLEDState = true;
 
   if (customCompressLevel)
-    setCompressLevel(compressLevel);
+    setCompressLevel(::compressLevel);
 
   if (!noJpeg)
-    setQualityLevel(qualityLevel);
+    setQualityLevel(::qualityLevel);
 
   if(sock == NULL) {
     try {
@@ -452,7 +450,7 @@ void CConn::autoSelectFormatAndEncoding()
   int kbitsPerSecond = sock->inStream().kbitsPerSecond();
   unsigned int timeWaited = sock->inStream().timeWaited();
   bool newFullColour = fullColour;
-  int newQualityLevel = qualityLevel;
+  int newQualityLevel = ::qualityLevel;
 
   // Always use Tight
   setPreferredEncoding(encodingTight);
@@ -468,10 +466,10 @@ void CConn::autoSelectFormatAndEncoding()
     else
       newQualityLevel = 6;
 
-    if (newQualityLevel != qualityLevel) {
+    if (newQualityLevel != ::qualityLevel) {
       vlog.info(_("Throughput %d kbit/s - changing to quality %d"),
                 kbitsPerSecond, newQualityLevel);
-      qualityLevel.setParam(newQualityLevel);
+      ::qualityLevel.setParam(newQualityLevel);
       setQualityLevel(newQualityLevel);
     }
   }
@@ -540,12 +538,12 @@ void CConn::handleOptions(void *data)
   }
 
   if (customCompressLevel)
-    self->setCompressLevel(compressLevel);
+    self->setCompressLevel(::compressLevel);
   else
     self->setCompressLevel(-1);
 
   if (!noJpeg && !autoSelect)
-    self->setQualityLevel(qualityLevel);
+    self->setQualityLevel(::qualityLevel);
   else
     self->setQualityLevel(-1);
 

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -84,7 +84,6 @@ CConn::CConn(const char* vncServerName, network::Socket* socket=NULL)
 
   server.supportsDesktopResize = true;
   server.supportsExtendedDesktopSize = true;
-  server.supportsDesktopRename = true;
 
   server.supportsLEDState = true;
 

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -191,7 +191,7 @@ const char *CConn::connectionInfo()
   strcat(infoText, "\n");
 
   snprintf(scratch, sizeof(scratch),
-           _("Size: %d x %d"), cp.width, cp.height);
+           _("Size: %d x %d"), cp.width(), cp.height());
   strcat(infoText, scratch);
   strcat(infoText, "\n");
 
@@ -324,7 +324,8 @@ void CConn::serverInit()
 
   serverPF = cp.pf();
 
-  desktop = new DesktopWindow(cp.width, cp.height, cp.name(), serverPF, this);
+  desktop = new DesktopWindow(cp.width(), cp.height(),
+                              cp.name(), serverPF, this);
   fullColourPF = desktop->getPreferredPF();
 
   // Force a switch to the format and encoding we'd like
@@ -478,7 +479,8 @@ void CConn::fence(rdr::U32 flags, unsigned len, const char data[])
       if (cp.supportsContinuousUpdates) {
         vlog.info(_("Enabling continuous updates"));
         continuousUpdates = true;
-        writer()->writeEnableContinuousUpdates(true, 0, 0, cp.width, cp.height);
+        writer()->writeEnableContinuousUpdates(true, 0, 0,
+                                               cp.width(), cp.height());
       }
     }
   } else {
@@ -508,9 +510,10 @@ void CConn::resizeFramebuffer()
     return;
 
   if (continuousUpdates)
-    writer()->writeEnableContinuousUpdates(true, 0, 0, cp.width, cp.height);
+    writer()->writeEnableContinuousUpdates(true, 0, 0,
+                                           cp.width(), cp.height());
 
-  desktop->resizeFramebuffer(cp.width, cp.height);
+  desktop->resizeFramebuffer(cp.width(), cp.height());
 }
 
 // autoSelectFormatAndEncoding() chooses the format and encoding appropriate
@@ -647,7 +650,7 @@ void CConn::requestNewUpdate()
 
   if (forceNonincremental || !continuousUpdates) {
     pendingUpdate = true;
-    writer()->writeFramebufferUpdateRequest(Rect(0, 0, cp.width, cp.height),
+    writer()->writeFramebufferUpdateRequest(Rect(0, 0, cp.width(), cp.height()),
                                             !forceNonincremental);
   }
  

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -363,8 +363,7 @@ void CConn::setExtendedDesktopSize(unsigned reason, unsigned result,
 void CConn::setName(const char* name)
 {
   CConnection::setName(name);
-  if (desktop)
-    desktop->setName(name);
+  desktop->setName(name);
 }
 
 // framebufferUpdateStart() is called at the beginning of an update.
@@ -495,9 +494,6 @@ void CConn::setLEDState(unsigned int state)
 
 void CConn::resizeFramebuffer()
 {
-  if (!desktop)
-    return;
-
   if (continuousUpdates)
     writer()->writeEnableContinuousUpdates(true, 0, 0,
                                            server.width(),

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -83,7 +83,6 @@ CConn::CConn(const char* vncServerName, network::Socket* socket=NULL)
   server.supportsLocalCursor = true;
 
   server.supportsDesktopResize = true;
-  server.supportsExtendedDesktopSize = true;
 
   server.supportsLEDState = true;
 

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -51,7 +51,7 @@ public:
   static void socketEvent(FL_SOCKET fd, void *data);
 
   // CConnection callback methods
-  void serverInit();
+  void initDone();
 
   void setDesktopSize(int w, int h);
   void setExtendedDesktopSize(unsigned reason, unsigned result,

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -74,6 +74,8 @@ public:
 
   void fence(rdr::U32 flags, unsigned len, const char data[]);
 
+  void endOfContinuousUpdates();
+
   void setLEDState(unsigned int state);
 
 private:
@@ -114,8 +116,6 @@ private:
   bool continuousUpdates;
 
   bool forceNonincremental;
-
-  bool supportsSyncFence;
 };
 
 #endif

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -36,8 +36,6 @@ public:
   CConn(const char* vncServerName, network::Socket* sock);
   ~CConn();
 
-  void refreshFramebuffer();
-
   const char *connectionInfo();
 
   unsigned getUpdateCount();
@@ -74,8 +72,6 @@ public:
 
   void fence(rdr::U32 flags, unsigned len, const char data[]);
 
-  void endOfContinuousUpdates();
-
   void setLEDState(unsigned int state);
 
 private:
@@ -83,8 +79,7 @@ private:
   void resizeFramebuffer();
 
   void autoSelectFormatAndEncoding();
-  void checkEncodings();
-  void requestNewUpdate();
+  void updatePixelFormat();
 
   static void handleOptions(void *data);
 
@@ -103,19 +98,7 @@ private:
   rfb::PixelFormat serverPF;
   rfb::PixelFormat fullColourPF;
 
-  bool pendingPFChange;
-  rfb::PixelFormat pendingPF;
-
-  int currentEncoding, lastServerEncoding;
-
-  bool formatChange;
-  bool encodingChange;
-
-  bool firstUpdate;
-  bool pendingUpdate;
-  bool continuousUpdates;
-
-  bool forceNonincremental;
+  int lastServerEncoding;
 };
 
 #endif

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -235,7 +235,7 @@ void DesktopWindow::setName(const char *name)
 void DesktopWindow::updateWindow()
 {
   if (firstUpdate) {
-    if (cc->cp.supportsSetDesktopSize) {
+    if (cc->server.supportsSetDesktopSize) {
       // Hack: Wait until we're in the proper mode and position until
       // resizing things, otherwise we might send the wrong thing.
       if (delayedFullscreen)
@@ -487,7 +487,7 @@ void DesktopWindow::resize(int x, int y, int w, int h)
     // d) We're not still waiting for startup fullscreen to kick in
     //
     if (not firstUpdate and not delayedFullscreen and
-        ::remoteResize and cc->cp.supportsSetDesktopSize) {
+        ::remoteResize and cc->server.supportsSetDesktopSize) {
       // We delay updating the remote desktop as we tend to get a flood
       // of resize events as the user is dragging the window.
       Fl::remove_timeout(handleResizeTimeout, this);
@@ -1021,7 +1021,7 @@ void DesktopWindow::remoteResize(int width, int height)
     // to scroll) we just report a single virtual screen that covers
     // the entire framebuffer.
 
-    layout = cc->cp.screenLayout();
+    layout = cc->server.screenLayout();
 
     // Not sure why we have no screens, but adding a new one should be
     // safe as there is nothing to conflict with...
@@ -1077,8 +1077,8 @@ void DesktopWindow::remoteResize(int width, int height)
       sy -= viewport_rect.tl.y;
 
       // Look for perfectly matching existing screen...
-      for (iter = cc->cp.screenLayout().begin();
-           iter != cc->cp.screenLayout().end(); ++iter) {
+      for (iter = cc->server.screenLayout().begin();
+           iter != cc->server.screenLayout().end(); ++iter) {
         if ((iter->dimensions.tl.x == sx) &&
             (iter->dimensions.tl.y == sy) &&
             (iter->dimensions.width() == sw) &&
@@ -1087,7 +1087,7 @@ void DesktopWindow::remoteResize(int width, int height)
       }
 
       // Found it?
-      if (iter != cc->cp.screenLayout().end()) {
+      if (iter != cc->server.screenLayout().end()) {
         layout.add_screen(*iter);
         continue;
       }
@@ -1095,13 +1095,13 @@ void DesktopWindow::remoteResize(int width, int height)
       // Need to add a new one, which means we need to find an unused id
       while (true) {
         id = rand();
-        for (iter = cc->cp.screenLayout().begin();
-             iter != cc->cp.screenLayout().end(); ++iter) {
+        for (iter = cc->server.screenLayout().begin();
+             iter != cc->server.screenLayout().end(); ++iter) {
           if (iter->id == id)
             break;
         }
 
-        if (iter == cc->cp.screenLayout().end())
+        if (iter == cc->server.screenLayout().end())
           break;
       }
 
@@ -1115,14 +1115,14 @@ void DesktopWindow::remoteResize(int width, int height)
   }
 
   // Do we actually change anything?
-  if ((width == cc->cp.width()) &&
-      (height == cc->cp.height()) &&
-      (layout == cc->cp.screenLayout()))
+  if ((width == cc->server.width()) &&
+      (height == cc->server.height()) &&
+      (layout == cc->server.screenLayout()))
     return;
 
   char buffer[2048];
   vlog.debug("Requesting framebuffer resize from %dx%d to %dx%d",
-             cc->cp.width(), cc->cp.height(), width, height);
+             cc->server.width(), cc->server.height(), width, height);
   layout.print(buffer, sizeof(buffer));
   vlog.debug("%s", buffer);
 

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -1014,14 +1014,14 @@ void DesktopWindow::handleResizeTimeout(void *data)
 void DesktopWindow::remoteResize(int width, int height)
 {
   ScreenSet layout;
-  ScreenSet::iterator iter;
+  ScreenSet::const_iterator iter;
 
   if (!fullscreen_active() || (width > w()) || (height > h())) {
     // In windowed mode (or the framebuffer is so large that we need
     // to scroll) we just report a single virtual screen that covers
     // the entire framebuffer.
 
-    layout = cc->cp.screenLayout;
+    layout = cc->cp.screenLayout();
 
     // Not sure why we have no screens, but adding a new one should be
     // safe as there is nothing to conflict with...
@@ -1077,8 +1077,8 @@ void DesktopWindow::remoteResize(int width, int height)
       sy -= viewport_rect.tl.y;
 
       // Look for perfectly matching existing screen...
-      for (iter = cc->cp.screenLayout.begin();
-           iter != cc->cp.screenLayout.end(); ++iter) {
+      for (iter = cc->cp.screenLayout().begin();
+           iter != cc->cp.screenLayout().end(); ++iter) {
         if ((iter->dimensions.tl.x == sx) &&
             (iter->dimensions.tl.y == sy) &&
             (iter->dimensions.width() == sw) &&
@@ -1087,7 +1087,7 @@ void DesktopWindow::remoteResize(int width, int height)
       }
 
       // Found it?
-      if (iter != cc->cp.screenLayout.end()) {
+      if (iter != cc->cp.screenLayout().end()) {
         layout.add_screen(*iter);
         continue;
       }
@@ -1095,13 +1095,13 @@ void DesktopWindow::remoteResize(int width, int height)
       // Need to add a new one, which means we need to find an unused id
       while (true) {
         id = rand();
-        for (iter = cc->cp.screenLayout.begin();
-             iter != cc->cp.screenLayout.end(); ++iter) {
+        for (iter = cc->cp.screenLayout().begin();
+             iter != cc->cp.screenLayout().end(); ++iter) {
           if (iter->id == id)
             break;
         }
 
-        if (iter == cc->cp.screenLayout.end())
+        if (iter == cc->cp.screenLayout().end())
           break;
       }
 
@@ -1115,14 +1115,14 @@ void DesktopWindow::remoteResize(int width, int height)
   }
 
   // Do we actually change anything?
-  if ((width == cc->cp.width) &&
-      (height == cc->cp.height) &&
-      (layout == cc->cp.screenLayout))
+  if ((width == cc->cp.width()) &&
+      (height == cc->cp.height()) &&
+      (layout == cc->cp.screenLayout()))
     return;
 
   char buffer[2048];
   vlog.debug("Requesting framebuffer resize from %dx%d to %dx%d",
-             cc->cp.width, cc->cp.height, width, height);
+             cc->cp.width(), cc->cp.height(), width, height);
   layout.print(buffer, sizeof(buffer));
   vlog.debug("%s", buffer);
 

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -425,7 +425,7 @@ void Viewport::pushLEDState()
   unsigned int state;
 
   // Server support?
-  if (cc->cp.ledState() == ledUnknown)
+  if (cc->server.ledState() == ledUnknown)
     return;
 
   state = 0;
@@ -458,7 +458,7 @@ void Viewport::pushLEDState()
     state |= ledNumLock;
 
   // No support for Scroll Lock //
-  state |= (cc->cp.ledState() & ledScrollLock);
+  state |= (cc->server.ledState() & ledScrollLock);
 
 #else
   unsigned int mask;
@@ -484,17 +484,17 @@ void Viewport::pushLEDState()
     state |= ledScrollLock;
 #endif
 
-  if ((state & ledCapsLock) != (cc->cp.ledState() & ledCapsLock)) {
+  if ((state & ledCapsLock) != (cc->server.ledState() & ledCapsLock)) {
     vlog.debug("Inserting fake CapsLock to get in sync with server");
     handleKeyPress(0x3a, XK_Caps_Lock);
     handleKeyRelease(0x3a);
   }
-  if ((state & ledNumLock) != (cc->cp.ledState() & ledNumLock)) {
+  if ((state & ledNumLock) != (cc->server.ledState() & ledNumLock)) {
     vlog.debug("Inserting fake NumLock to get in sync with server");
     handleKeyPress(0x45, XK_Num_Lock);
     handleKeyRelease(0x45);
   }
-  if ((state & ledScrollLock) != (cc->cp.ledState() & ledScrollLock)) {
+  if ((state & ledScrollLock) != (cc->server.ledState() & ledScrollLock)) {
     vlog.debug("Inserting fake ScrollLock to get in sync with server");
     handleKeyPress(0x46, XK_Scroll_Lock);
     handleKeyRelease(0x46);


### PR DESCRIPTION
ConnParams is currently used both in the server and client, and as a general dumping grounds for state. As such it is very difficult to tell what things mean, and what is actually used.

So to clean this up I've split it in to two objects, ServerParams and ClientParams. It is now also solely about keeping track of the *state of the other end*. That means some stuff got pushed to other layers.

At the same time I also moved some stuff up from the viewer in to the general code.


All of this done so I could get some better abstraction for how things are encoded. The goal was to be able to implement some VMware extensions without having to touch half the tree to do so.