### PR TITLE
Make timeouts exit cleanly

### DIFF
--- a/common/network/Socket.h
+++ b/common/network/Socket.h
@@ -144,13 +144,6 @@ namespace network {
     //   This is only necessary if the Socket has been put in non-blocking
     //   mode and needs this callback to flush the buffer.
     virtual void processSocketWriteEvent(network::Socket* sock) = 0;
-
-    // checkTimeouts() allows the server to check socket timeouts, etc.  The
-    //   return value is the number of milliseconds to wait before
-    //   checkTimeouts() should be called again.  If this number is zero then
-    //   there is no timeout and checkTimeouts() should be called the next time
-    //   an event occurs.
-    virtual int checkTimeouts() = 0;
   };
 
 }

--- a/common/rfb/SDesktop.h
+++ b/common/rfb/SDesktop.h
@@ -75,6 +75,12 @@ namespace rfb {
     virtual void queryConnection(network::Socket* sock,
                                  const char* userName) = 0;
 
+    // terminate() is called by the server when it wishes to terminate
+    // itself, e.g. because it was configured to terminate when no one is
+    // using it.
+
+    virtual void terminate() = 0;
+
     // setScreenLayout() requests to reconfigure the framebuffer and/or
     // the layout of screens.
     virtual unsigned int setScreenLayout(int __unused_attr fb_width,

--- a/common/rfb/VNCSConnectionST.h
+++ b/common/rfb/VNCSConnectionST.h
@@ -77,11 +77,6 @@ namespace rfb {
     void setLEDStateOrClose(unsigned int state);
     void approveConnectionOrClose(bool accept, const char* reason);
 
-    // checkIdleTimeout() returns the number of milliseconds left until the
-    // idle timeout expires.  If it has expired, the connection is closed and
-    // zero is returned.  Zero is also returned if there is no idle timeout.
-    int checkIdleTimeout();
-
     // The following methods never throw exceptions
 
     // getComparerState() returns if this client would like the framebuffer
@@ -182,7 +177,8 @@ namespace rfb {
 
     std::map<rdr::U32, rdr::U32> pressedKeys;
 
-    time_t lastEventTime;
+    Timer idleTimer;
+
     time_t pointerEventTime;
     Point pointerEventPos;
     bool clientHasCursor;

--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -227,14 +227,8 @@ void VNCServerST::processSocketWriteEvent(network::Socket* sock)
 int VNCServerST::checkTimeouts()
 {
   int timeout = 0;
-  std::list<VNCSConnectionST*>::iterator ci, ci_next;
 
   soonestTimeout(&timeout, Timer::checkTimeouts());
-
-  for (ci=clients.begin();ci!=clients.end();ci=ci_next) {
-    ci_next = ci; ci_next++;
-    soonestTimeout(&timeout, (*ci)->checkIdleTimeout());
-  }
   
   return timeout;
 }

--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -574,13 +574,13 @@ bool VNCServerST::handleTimeout(Timer* t)
     return true;
   } else if (t == &idleTimer) {
     slog.info("MaxIdleTime reached, exiting");
-    exit(0);
+    desktop->terminate();
   } else if (t == &disconnectTimer) {
     slog.info("MaxDisconnectionTime reached, exiting");
-    exit(0);
+    desktop->terminate();
   } else if (t == &connectTimer) {
     slog.info("MaxConnectionTime reached, exiting");
-    exit(0);
+    desktop->terminate();
   }
 
   return false;

--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -224,16 +224,6 @@ void VNCServerST::processSocketWriteEvent(network::Socket* sock)
   throw rdr::Exception("invalid Socket in VNCServerST");
 }
 
-int VNCServerST::checkTimeouts()
-{
-  int timeout = 0;
-
-  soonestTimeout(&timeout, Timer::checkTimeouts());
-  
-  return timeout;
-}
-
-
 // VNCServer methods
 
 void VNCServerST::blockUpdates()

--- a/common/rfb/VNCServerST.h
+++ b/common/rfb/VNCServerST.h
@@ -76,12 +76,6 @@ namespace rfb {
     //   Flush pending data from the Socket on to the network.
     virtual void processSocketWriteEvent(network::Socket* sock);
 
-    // checkTimeouts
-    //   Returns the number of milliseconds left until the next idle timeout
-    //   expires.  If any have already expired, the corresponding connections
-    //   are closed.  Zero is returned if there is no idle timeout.
-    virtual int checkTimeouts();
-
 
     // Methods overridden from VNCServer
 

--- a/common/rfb/VNCServerST.h
+++ b/common/rfb/VNCServerST.h
@@ -198,9 +198,9 @@ namespace rfb {
 
     KeyRemapper* keyRemapper;
 
-    time_t lastUserInputTime;
-    time_t lastDisconnectTime;
-    time_t lastConnectionTime;
+    Timer idleTimer;
+    Timer disconnectTimer;
+    Timer connectTimer;
 
     Timer frameTimer;
   };

--- a/unix/x0vncserver/XDesktop.cxx
+++ b/unix/x0vncserver/XDesktop.cxx
@@ -19,6 +19,8 @@
  */
 
 #include <assert.h>
+#include <signal.h>
+#include <unistd.h>
 
 #include <rfb/LogWriter.h>
 
@@ -271,6 +273,10 @@ void XDesktop::stop() {
 
   delete pb;
   pb = 0;
+}
+
+void XDesktop::terminate() {
+  kill(getpid(), SIGTERM);
 }
 
 bool XDesktop::isRunning() {

--- a/unix/x0vncserver/XDesktop.h
+++ b/unix/x0vncserver/XDesktop.h
@@ -49,6 +49,7 @@ public:
   // -=- SDesktop interface
   virtual void start(rfb::VNCServer* vs);
   virtual void stop();
+  virtual void terminate();
   bool isRunning();
   virtual void queryConnection(network::Socket* sock,
                                const char* userName);

--- a/unix/x0vncserver/x0vncserver.cxx
+++ b/unix/x0vncserver/x0vncserver.cxx
@@ -322,7 +322,7 @@ int main(int argc, char** argv)
         }
       }
 
-      soonestTimeout(&wait_ms, server.checkTimeouts());
+      soonestTimeout(&wait_ms, Timer::checkTimeouts());
 
       tv.tv_sec = wait_ms / 1000;
       tv.tv_usec = (wait_ms % 1000) * 1000;
@@ -357,7 +357,7 @@ int main(int argc, char** argv)
         }
       }
 
-      server.checkTimeouts();
+      Timer::checkTimeouts();
 
       // Client list could have been changed.
       server.getSockets(&sockets);

--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -368,7 +368,7 @@ void XserverDesktop::blockHandler(int* timeout)
     }
 
     // Trigger timers and check when the next will expire
-    int nextTimeout = server->checkTimeouts();
+    int nextTimeout = Timer::checkTimeouts();
     if (nextTimeout > 0 && (*timeout == -1 || nextTimeout < *timeout))
       *timeout = nextTimeout;
   } catch (rdr::Exception& e) {

--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -22,6 +22,7 @@
 //
 
 #include <assert.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
@@ -422,6 +423,11 @@ void XserverDesktop::approveConnection(uint32_t opaqueId, bool accept,
 //
 // SDesktop callbacks
 
+
+void XserverDesktop::terminate()
+{
+  kill(getpid(), SIGTERM);
+}
 
 void XserverDesktop::pointerEvent(const Point& pos, int buttonMask)
 {

--- a/unix/xserver/hw/vnc/XserverDesktop.h
+++ b/unix/xserver/hw/vnc/XserverDesktop.h
@@ -87,6 +87,7 @@ public:
   // rfb::SDesktop callbacks
   virtual void start(rfb::VNCServer* vs);
   virtual void stop();
+  virtual void terminate();
   virtual void queryConnection(network::Socket* sock,
                                const char* userName);
   virtual void pointerEvent(const rfb::Point& pos, int buttonMask);

--- a/win/rfb_win32/SDisplay.cxx
+++ b/win/rfb_win32/SDisplay.cxx
@@ -71,6 +71,7 @@ SDisplay::SDisplay()
     statusLocation(0), queryConnectionHandler(0), ledState(0)
 {
   updateEvent.h = CreateEvent(0, TRUE, FALSE, 0);
+  terminateEvent.h = CreateEvent(0, TRUE, FALSE, 0);
 }
 
 SDisplay::~SDisplay()
@@ -138,6 +139,11 @@ void SDisplay::stop()
   vlog.debug("stopped");
 
   if (statusLocation) *statusLocation = false;
+}
+
+void SDisplay::terminate()
+{
+  SetEvent(terminateEvent);
 }
 
 

--- a/win/rfb_win32/SDisplay.h
+++ b/win/rfb_win32/SDisplay.h
@@ -72,6 +72,7 @@ namespace rfb {
 
       virtual void start(VNCServer* vs);
       virtual void stop();
+      virtual void terminate();
       virtual void queryConnection(network::Socket* sock,
                                    const char* userName);
       virtual void pointerEvent(const Point& pos, int buttonmask);
@@ -89,6 +90,7 @@ namespace rfb {
       // -=- EventHandler interface
 
       HANDLE getUpdateEvent() {return updateEvent;}
+      HANDLE getTerminateEvent() {return terminateEvent;}
       virtual void processEvent(HANDLE event);
 
       // -=- Notification of whether or not SDisplay is started
@@ -161,6 +163,8 @@ namespace rfb {
 
       // -=- Event signalled to trigger an update to be flushed
       Handle updateEvent;
+      // -=- Event signalled to terminate the server
+      Handle terminateEvent;
 
       // -=- Where to write the active/inactive indicator to
       bool* statusLocation;

--- a/win/rfb_win32/SocketManager.cxx
+++ b/win/rfb_win32/SocketManager.cxx
@@ -21,6 +21,7 @@
 #include <winsock2.h>
 #include <list>
 #include <rfb/LogWriter.h>
+#include <rfb/Timer.h>
 #include <rfb_win32/SocketManager.h>
 
 using namespace rfb;
@@ -161,7 +162,7 @@ int SocketManager::checkTimeouts() {
 
   std::map<HANDLE,ListenInfo>::iterator i;
   for (i=listeners.begin(); i!=listeners.end(); i++)
-    soonestTimeout(&timeout, i->second.server->checkTimeouts());
+    soonestTimeout(&timeout, Timer::checkTimeouts());
 
   std::list<network::Socket*> shutdownSocks;
   std::map<HANDLE,ConnInfo>::iterator j, j_next;

--- a/win/winvnc/VNCServerWin32.cxx
+++ b/win/winvnc/VNCServerWin32.cxx
@@ -76,6 +76,7 @@ VNCServerWin32::VNCServerWin32()
 
   // Register the desktop's event to be handled
   sockMgr.addEvent(desktop.getUpdateEvent(), &desktop);
+  sockMgr.addEvent(desktop.getTerminateEvent(), this);
 
   // Register the queued command event to be handled
   sockMgr.addEvent(commandEvent, this);
@@ -335,7 +336,8 @@ void VNCServerWin32::processEvent(HANDLE event_) {
       command = NoCommand;
       commandSig->signal();
     }
-  } else if (event_ == sessionEvent.h) {
+  } else if ((event_ == sessionEvent.h) ||
+             (event_ == desktop.getTerminateEvent())) {
     stop();
   }
 }


### PR DESCRIPTION
Make sure the various exit timeouts does a proper shutdown of the server and don't just call `exit()`.

Fixes #727.