### PR TITLE
vncviewer on X11: Fix rendering bugs on startup

### DIFF
--- a/vncviewer/PlatformPixelBuffer.cxx
+++ b/vncviewer/PlatformPixelBuffer.cxx
@@ -104,6 +104,9 @@ rfb::Rect PlatformPixelBuffer::getDamage(void)
   mutex.unlock();
 
 #if !defined(WIN32) && !defined(__APPLE__)
+  if (r.width() == 0 || r.height() == 0)
+    return r;
+
   GC gc;
 
   gc = XCreateGC(fl_display, pixmap, 0, NULL);


### PR DESCRIPTION
On X11, on startup, vncviewer renders uninitialized Pixmap contents before the first full update is received. The actual results may be driver specific (on my machine, it just renders random GPU memory contents), but it's a bug either way.

As with any good bug, the fix turned out to be a one-liner: clear the pixmap once after creation.

As this introduces a tiny bit of overhead, I added a second commit with a tiny performance optimization I noticed.