### PR TITLE
Use cmake TIMESTAMP function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Setup
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 if(POLICY CMP0022)
   cmake_policy(SET CMP0022 OLD)
 endif()
@@ -43,9 +43,7 @@ if(MSVC)
 endif()
 
 if(NOT BUILD_TIMESTAMP)
-  set(BUILD_TIMESTAMP "")
-  execute_process(COMMAND "date" "+%Y-%m-%d %H:%M" OUTPUT_VARIABLE BUILD_TIMESTAMP)
-  string(REGEX REPLACE "\n" "" BUILD_TIMESTAMP ${BUILD_TIMESTAMP})
+  STRING(TIMESTAMP BUILD_TIMESTAMP "%Y-%m-%d %H:%M" UTC)
 endif()
 
 # Default to optimised builds instead of debug ones. Our code has no bugs ;)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 
 project(tigervnc-java Java)
 if(NOT VERSION)
@@ -25,13 +25,10 @@ set(JAVA_KEYPASS NOTFOUND CACHE STRING "Password used to protect the private key
 set(JAVA_TSA_URL NOTFOUND CACHE STRING "URL of Time Stamping Authority (TSA)")
 
 if(NOT BUILD)
-	execute_process(COMMAND "date" "+%Y%m%d" OUTPUT_VARIABLE BUILD)
+	STRING(TIMESTAMP BUILD "%Y%m%d" UTC)
 endif()
-execute_process(COMMAND "date" "+%b %d %Y" OUTPUT_VARIABLE JAVA_DATE)
-execute_process(COMMAND "date" "+%H:%M:%S" OUTPUT_VARIABLE JAVA_TIME)
-string(REGEX REPLACE "\n" "" JAVA_DATE ${JAVA_DATE})
-string(REGEX REPLACE "\n" "" JAVA_TIME ${JAVA_TIME})
-string(REGEX REPLACE "\n" "" BUILD ${BUILD})
+STRING(TIMESTAMP JAVA_DATE "%Y-%m-%d" UTC)
+STRING(TIMESTAMP JAVA_TIME "%H:%M:%S" UTC)
 
 set(JAVA_SOURCES "")
 set(JAVA_CLASSES "")


### PR DESCRIPTION
Use cmake TIMESTAMP function 
because it is not only platform independent
but also allows to override the build date
This helps to make the java timestamp file in tigervnc  builds reproducible.

See https://reproducible-builds.org/ for why this is good

Also adds UTC flag, to be independent of timezone.
Also changes JAVA_DATE format to ISO-8601 date format.

Requires cmake-2.8.11+ from 2013