### PR TITLE
Remove variable length arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_install:
  - popd
 
 script:
- - cmake . && make
+ - cmake -DCMAKE_BUILD_TYPE=Debug . && make
  - cd java && cmake . && make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat=2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wformat=2")
 # Make sure we catch these issues whilst developing
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Werror=vla")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Werror=vla")
 ENDIF()
 
 option(ENABLE_ASAN "Enable address sanitizer support" OFF)

--- a/common/rfb/CMsgReader.cxx
+++ b/common/rfb/CMsgReader.cxx
@@ -210,7 +210,7 @@ void CMsgReader::readSetXCursor(int width, int height, const Point& hotspot)
   if (width > maxCursorSize || height > maxCursorSize)
     throw Exception("Too big cursor");
 
-  rdr::U8 buf[width*height*4];
+  rdr::U8Array rgba(width*height*4);
 
   if (width * height > 0) {
     rdr::U8 pr, pg, pb;
@@ -235,7 +235,7 @@ void CMsgReader::readSetXCursor(int width, int height, const Point& hotspot)
     is->readBytes(mask.buf, mask_len);
 
     int maskBytesPerRow = (width+7)/8;
-    out = buf;
+    out = rgba.buf;
     for (y = 0;y < height;y++) {
       for (x = 0;x < width;x++) {
         int byte = y * maskBytesPerRow + x / 8;
@@ -261,7 +261,7 @@ void CMsgReader::readSetXCursor(int width, int height, const Point& hotspot)
     }
   }
 
-  handler->setCursor(width, height, hotspot, buf);
+  handler->setCursor(width, height, hotspot, rgba.buf);
 }
 
 void CMsgReader::readSetCursor(int width, int height, const Point& hotspot)
@@ -275,7 +275,7 @@ void CMsgReader::readSetCursor(int width, int height, const Point& hotspot)
   rdr::U8Array mask(mask_len);
 
   int x, y;
-  rdr::U8 buf[width*height*4];
+  rdr::U8Array rgba(width*height*4);
   rdr::U8* in;
   rdr::U8* out;
 
@@ -284,7 +284,7 @@ void CMsgReader::readSetCursor(int width, int height, const Point& hotspot)
 
   int maskBytesPerRow = (width+7)/8;
   in = data.buf;
-  out = buf;
+  out = rgba.buf;
   for (y = 0;y < height;y++) {
     for (x = 0;x < width;x++) {
       int byte = y * maskBytesPerRow + x / 8;
@@ -302,7 +302,7 @@ void CMsgReader::readSetCursor(int width, int height, const Point& hotspot)
     }
   }
 
-  handler->setCursor(width, height, hotspot, buf);
+  handler->setCursor(width, height, hotspot, rgba.buf);
 }
 
 void CMsgReader::readSetCursorWithAlpha(int width, int height, const Point& hotspot)

--- a/common/rfb/TightDecoder.cxx
+++ b/common/rfb/TightDecoder.cxx
@@ -266,15 +266,16 @@ void TightDecoder::decodeRect(const Rect& r, const void* buffer,
       buflen -= 1;
 
       if (pf.is888()) {
-        rdr::U8 tightPalette[palSize * 3];
+        size_t len = palSize * 3;
+        rdr::U8Array tightPalette(len);
 
-        assert(buflen >= sizeof(tightPalette));
+        assert(buflen >= sizeof(len));
 
-        memcpy(tightPalette, bufptr, sizeof(tightPalette));
-        bufptr += sizeof(tightPalette);
-        buflen -= sizeof(tightPalette);
+        memcpy(tightPalette.buf, bufptr, len);
+        bufptr += len;
+        buflen -= len;
 
-        pf.bufferFromRGB(palette, tightPalette, palSize);
+        pf.bufferFromRGB(palette, tightPalette.buf, palSize);
       } else {
         size_t len;
 

--- a/tests/encperf.cxx
+++ b/tests/encperf.cxx
@@ -423,8 +423,9 @@ int main(int argc, char **argv)
   }
 
   int runCount = count;
-  struct stats runs[runCount];
-  double values[runCount], dev[runCount];
+  struct stats *runs = new struct stats[runCount];
+  double *values = new double[runCount];
+  double *dev = new double[runCount];
   double median, meddev;
 
   if (fn == NULL) {

--- a/vncviewer/gettext.h
+++ b/vncviewer/gettext.h
@@ -1,24 +1,26 @@
 /* Convenience header for conditional use of GNU <libintl.h>.
-   Copyright (C) 1995-1998, 2000-2002, 2004-2006, 2009-2011 Free Software Foundation, Inc.
+   Copyright (C) 1995-1998, 2000-2002, 2004-2006, 2009-2018 Free Software
+   Foundation, Inc.
 
-   This program is free software: you can redistribute it and/or modify
+   This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 3 of the License, or
-   (at your option) any later version.
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, see <https://www.gnu.org/licenses/>.  */
 
 #ifndef _LIBGETTEXT_H
 #define _LIBGETTEXT_H 1
 
-/* NLS can be disabled through the configure --disable-nls option.  */
-#if ENABLE_NLS
+/* NLS can be disabled through the configure --disable-nls option
+   or through "#define ENABLE NLS 0" before including this file.  */
+#if defined ENABLE_NLS && ENABLE_NLS
 
 /* Get declarations of GNU message catalog functions.  */
 # include <libintl.h>
@@ -183,7 +185,8 @@ npgettext_aux (const char *domain,
 #include <string.h>
 
 #if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) \
-     /* || __STDC_VERSION__ >= 199901L */ )
+     /* || __STDC_VERSION__ == 199901L
+        || (__STDC_VERSION__ >= 201112L && !defined __STDC_NO_VLA__) */ )
 # define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1
 #else
 # define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 0
@@ -224,15 +227,17 @@ dcpgettext_expr (const char *domain,
   if (msg_ctxt_id != NULL)
 #endif
     {
+      int found_translation;
       memcpy (msg_ctxt_id, msgctxt, msgctxt_len - 1);
       msg_ctxt_id[msgctxt_len - 1] = '\004';
       memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
       translation = dcgettext (domain, msg_ctxt_id, category);
+      found_translation = (translation != msg_ctxt_id);
 #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
       if (msg_ctxt_id != buf)
         free (msg_ctxt_id);
 #endif
-      if (translation != msg_ctxt_id)
+      if (found_translation)
         return translation;
     }
   return msgid;
@@ -270,15 +275,17 @@ dcnpgettext_expr (const char *domain,
   if (msg_ctxt_id != NULL)
 #endif
     {
+      int found_translation;
       memcpy (msg_ctxt_id, msgctxt, msgctxt_len - 1);
       msg_ctxt_id[msgctxt_len - 1] = '\004';
       memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
       translation = dcngettext (domain, msg_ctxt_id, msgid_plural, n, category);
+      found_translation = !(translation == msg_ctxt_id || translation == msgid_plural);
 #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
       if (msg_ctxt_id != buf)
         free (msg_ctxt_id);
 #endif
-      if (!(translation == msg_ctxt_id || translation == msgid_plural))
+      if (found_translation)
         return translation;
     }
   return (n == 1 ? msgid : msgid_plural);

--- a/vncviewer/gettext.h
+++ b/vncviewer/gettext.h
@@ -184,7 +184,7 @@ npgettext_aux (const char *domain,
 
 #include <string.h>
 
-#if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) \
+#if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__ && !defined __cplusplus) \
      /* || __STDC_VERSION__ == 199901L
         || (__STDC_VERSION__ >= 201112L && !defined __STDC_NO_VLA__) */ )
 # define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -325,9 +325,10 @@ static void setKeyInt(const char *_name, const int _value, HKEY* hKey) {
 
 static bool getKeyString(const char* _name, char* dest, size_t destSize, HKEY* hKey) {
   
-  DWORD buffersize = 256;
-  WCHAR value[destSize];
+  const DWORD buffersize = 256;
   wchar_t name[buffersize];
+  WCHAR* value;
+  DWORD valuesize;
 
   unsigned size = fl_utf8towc(_name, strlen(_name)+1, name, buffersize);
   if (size >= buffersize) {
@@ -335,8 +336,11 @@ static bool getKeyString(const char* _name, char* dest, size_t destSize, HKEY* h
     return false;
   }
 
-  LONG res = RegQueryValueExW(*hKey, name, 0, NULL, (LPBYTE)value, &buffersize);
+  value = new WCHAR[destSize];
+  valuesize = destSize;
+  LONG res = RegQueryValueExW(*hKey, name, 0, NULL, (LPBYTE)value, &valuesize);
   if (res != ERROR_SUCCESS){
+    delete [] value;
     if (res == ERROR_FILE_NOT_FOUND) {
       // The value does not exist, defaults will be used.
     } else {
@@ -346,18 +350,19 @@ static bool getKeyString(const char* _name, char* dest, size_t destSize, HKEY* h
     return false;
   }
   
-  char utf8val[destSize];
-  size = fl_utf8fromwc(utf8val, sizeof(utf8val), value, wcslen(value)+1);
-  if (size >= sizeof(utf8val)) {
+  char* utf8val = new char[destSize];
+  size = fl_utf8fromwc(utf8val, destSize, value, wcslen(value)+1);
+  delete [] value;
+  if (size >= destSize) {
+    delete [] utf8val;
     vlog.error(_("The parameter %s was too large to read from the registry"), _name);
     return false;
   }
-  const char *ret = utf8val;
   
-  if(decodeValue(ret, dest, destSize))
-    return true;
-  else 
-    return false;
+  bool ret = decodeValue(utf8val, dest, destSize);
+  delete [] utf8val;
+
+  return ret;
 }
 
 


### PR DESCRIPTION
They aren't really allowed in C++ (g++ allows them as an extension), and their usage is often not recommended anyway.

Also add checks to complain if someone tries to add any back.