### PR TITLE
Fix issue with pid file not being created

### DIFF
--- a/unix/vncserver
+++ b/unix/vncserver
@@ -335,7 +335,7 @@ $cmd .= " >> " . &quotedString($desktopLog) . " 2>&1";
 
 # Run $cmd and record the process ID.
 $pidFile = "$vncUserDir/$host:$displayNumber.pid";
-system("$cmd & echo \$! >$pidFile");
+system("/usr/bin/sh -c \"echo \$\$ >$pidFile && exec $cmd\"");
 
 # Give Xvnc a chance to start up
 


### PR DESCRIPTION
When running from under `systemd`'s unit (user-specific), for some reason the pid file
doesn't get created.  This fix addresses the issue.