### PR TITLE
xkb map exhaustion fix

### DIFF
--- a/unix/xserver/hw/vnc/Input.c
+++ b/unix/xserver/hw/vnc/Input.c
@@ -533,14 +533,13 @@ static void vncKeysymKeyboardEvent(KeySym keysym, int down)
 
 	/* No matches. Will have to add a new entry... */
 	if (keycode == 0) {
-		keycode = vncAddKeysym(keysym, state);
+		keycode = vncAddKeysym(keysym, state, 1);
 		if (keycode == 0) {
 			LOG_ERROR("Failure adding new keysym 0x%x", keysym);
 			return;
 		}
 
-		LOG_INFO("Added unknown keysym 0x%x to keycode %d",
-		         keysym, keycode);
+		//LOG_INFO("Added unknown keysym 0x%x to keycode %d", keysym, keycode);
 
 		/*
 		 * The state given to addKeysym() is just a hint and

--- a/unix/xserver/hw/vnc/Input.h
+++ b/unix/xserver/hw/vnc/Input.h
@@ -55,7 +55,7 @@ KeyCode vncKeysymToKeycode(KeySym keysym, unsigned state, unsigned *new_state);
 
 int vncIsAffectedByNumLock(KeyCode keycode);
 
-KeyCode vncAddKeysym(KeySym keysym, unsigned state);
+KeyCode vncAddKeysym(KeySym keysym, unsigned state, unsigned fastmode);
 
 #ifdef __cplusplus
 }

--- a/unix/xserver/hw/vnc/InputXKB.c
+++ b/unix/xserver/hw/vnc/InputXKB.c
@@ -572,7 +572,7 @@ int vncIsAffectedByNumLock(KeyCode keycode)
 	return 1;
 }
 
-KeyCode vncAddKeysym(KeySym keysym, unsigned state)
+KeyCode vncAddKeysym(KeySym keysym, unsigned state, unsigned fastmode)
 {
 	DeviceIntPtr master;
 	XkbDescPtr xkb;
@@ -587,13 +587,18 @@ KeyCode vncAddKeysym(KeySym keysym, unsigned state)
 
 	master = GetMaster(vncKeyboardDev, KEYBOARD_OR_FLOAT);
 	xkb = master->key->xkbInfo->desc;
-	for (key = xkb->max_key_code; key >= xkb->min_key_code; key--) {
-		if (XkbKeyNumGroups(xkb, key) == 0)
-			break;
-	}
 
-	if (key < xkb->min_key_code)
-		return 0;
+	if (fastmode) {
+		key = xkb->max_key_code;
+	} else {
+		for (key = xkb->max_key_code; key >= xkb->min_key_code; key--) {
+			if (XkbKeyNumGroups(xkb, key) == 0)
+				break;
+		}
+
+		if (key < xkb->min_key_code)
+			return 0;
+	}
 
 	memset(&changes, 0, sizeof(changes));
 	memset(&cause, 0, sizeof(cause));


### PR DESCRIPTION
Fix for issue #93. Tested a few weeks by me, no issues so far.
Tried testing Round Robin feature, turned out it wasn't such a good idea, as some of my local keys were conflicting with some existing exotic keys and therefore were not subjected to AddSym.

The simplest solution turned out to be the best one so far.