### PR TITLE
fix compiler warning FullFramePixelBuffer::stride’ is used uninitialized

### DIFF
--- a/vncviewer/PlatformPixelBuffer.cxx
+++ b/vncviewer/PlatformPixelBuffer.cxx
@@ -36,7 +36,7 @@ static rfb::LogWriter vlog("PlatformPixelBuffer");
 PlatformPixelBuffer::PlatformPixelBuffer(int width, int height) :
   FullFramePixelBuffer(rfb::PixelFormat(32, 24, false, true,
                                         255, 255, 255, 16, 8, 0),
-                       width, height, 0, stride),
+                       width, height, 0, width),
   Surface(width, height)
 #if !defined(WIN32) && !defined(__APPLE__)
   , shminfo(NULL), xim(NULL)


### PR DESCRIPTION
With commit 403ac27 parameter "int stride" got removed from constructor "PlatformPixelBuffer::PlatformPixelBuffer."
Before this parameter was passed to the constructor of "FullFramePixelBuffer".
"FullFramePixelBuffer" has also a member with the same name "stride". :(

Now this uninitialized FullFramePixelBuffer::stride gets passed to the
constructor FullFramePixelBuffer::FullFramePixelBuffer.

Now I understand the value of naming class members with a preceding "m_".