### PR TITLE
Fix segmentation fault in SMsgWriter::writeNoDataUpdate()

### DIFF
--- a/common/rfb/SMsgWriter.cxx
+++ b/common/rfb/SMsgWriter.cxx
@@ -355,7 +355,7 @@ void SMsgWriter::writePseudoRects()
 
 void SMsgWriter::writeNoDataRects()
 {
-  if (!extendedDesktopSizeMsgs.empty()) {
+  if (!extendedDesktopSizeMsgs.empty() && client->screenLayout().num_screens() > 0) {
     if (client->supportsEncoding(pseudoEncodingExtendedDesktopSize)) {
       std::list<ExtendedDesktopSizeMsg>::const_iterator ri;
       for (ri = extendedDesktopSizeMsgs.begin();ri != extendedDesktopSizeMsgs.end();++ri) {


### PR DESCRIPTION
writeNoDataUpdate() calls writeNoDataRects(), which uses client->screenLayout()
in a call to writeExtendedDesktopSizeRect() without a check, if the layout
is empty. Unfortunately there is a race condition and there might not have
been a layout set before the first call, leading to a crash when blindly
using the layout. We have experienced several related crashes.

Fix: SMsgWriter::writeNoDataRects(): check that client layout has a screen before
trying to send encodings to it.

Signed-off-by: Amon Ott <a.ott@m-privacy.de>