### PR TITLE
Fix wrap-aware isAfter function in Congestion.cxx

### DIFF
--- a/common/rfb/Congestion.cxx
+++ b/common/rfb/Congestion.cxx
@@ -70,7 +70,7 @@ static const unsigned MAXIMUM_WINDOW = 4194304;
 
 // Compare position even when wrapped around
 static inline bool isAfter(unsigned a, unsigned b) {
-  return (int)a - (int)b > 0;
+  return a != b && a - b <= UINT_MAX / 2;
 }
 
 static LogWriter vlog("Congestion");


### PR DESCRIPTION
This is a follow-up on crash observed in https://github.com/TigerVNC/tigervnc/issues/652
the fix done there does not work in all environments.

Result of overflow on signed integer arithmetic is undefined in C/C++ standard.
So in previous version clang can compile the statement as (int)a > (int)b (i.e. assuming no overflow), which leads to incorrect result.

Correct deterministic behavior means doing overflow arithmetic as unsigned, using:
   (int)(a - b) > 0