### PR TITLE
Added option to specify RFB version to be used

### DIFF
--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -82,6 +82,9 @@ AliasParameter lowColourLevelAlias("LowColourLevel", "Alias for LowColorLevel", 
 StringParameter preferredEncoding("PreferredEncoding",
                                   "Preferred encoding to use (Tight, ZRLE, Hextile or"
                                   " Raw)", "Tight");
+StringParameter rfbVersion("rfbVersion",
+                           "Use specific RFB version (3.3, 3.7 or 3.8)",
+                           "");
 BoolParameter customCompressLevel("CustomCompressLevel",
                                   "Use custom compression level. "
                                   "Default if CompressLevel is specified.", false);
@@ -164,6 +167,7 @@ static VoidParameter* parameterArray[] = {
   &fullColour,
   &lowColourLevel,
   &preferredEncoding,
+  &rfbVersion,
   &customCompressLevel,
   &compressLevel,
   &noJpeg,

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -33,6 +33,7 @@ extern rfb::AliasParameter fullColourAlias;
 extern rfb::IntParameter lowColourLevel;
 extern rfb::AliasParameter lowColourLevelAlias;
 extern rfb::StringParameter preferredEncoding;
+extern rfb::StringParameter rfbVersion;
 extern rfb::BoolParameter customCompressLevel;
 extern rfb::IntParameter compressLevel;
 extern rfb::BoolParameter noJpeg;


### PR DESCRIPTION
I need an option to force a specific version of the RFB protocol for use with tools like [vncdotool](https://github.com/sibson/vncdotool).