### PR TITLE
Do not return returncode indicating error when listing sessions

### DIFF
--- a/unix/vncserver
+++ b/unix/vncserver
@@ -709,7 +709,7 @@ sub List
 	    }
 	}
     }
-    exit 1;
+    exit;
 }
 
 


### PR DESCRIPTION
Running "vncserver -list" will always return 1, which usually indicates an error, but this call is harmless and 0 should be returned instead.