### PR TITLE
fix too early remove of iterator in VNCServerST::removeSocket

### DIFF
--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -165,8 +165,6 @@ void VNCServerST::removeSocket(network::Socket* sock) {
   std::list<VNCSConnectionST*>::iterator ci;
   for (ci = clients.begin(); ci != clients.end(); ci++) {
     if ((*ci)->getSock() == sock) {
-      clients.remove(*ci);
-
       // - Remove any references to it
       if (pointerClient == *ci)
         pointerClient = NULL;
@@ -181,6 +179,8 @@ void VNCServerST::removeSocket(network::Socket* sock) {
 
       // - Delete the per-Socket resources
       delete *ci;
+
+      clients.remove(*ci);
 
       CharArray name;
       name.buf = sock->getPeerEndpoint();


### PR DESCRIPTION
I do not know if someone has already noticed it but in VNCServerST::removeSocket the iterator is removed too early, and used afterward.

This patch fix the issue.

Best regards