### PR TITLE
Don't show the context menu hint when no hotkey is chosen

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -536,8 +536,11 @@ void DesktopWindow::menuOverlay(void* data)
   DesktopWindow *self;
 
   self = (DesktopWindow*)data;
-  self->setOverlay(_("Press %s to open the context menu"),
-                   (const char*)menuKey);
+
+  if (strcmp((const char*)menuKey, "") != 0) {
+    self->setOverlay(_("Press %s to open the context menu"),
+                     (const char*)menuKey);
+  }
 }
 
 void DesktopWindow::setOverlay(const char* text, ...)


### PR DESCRIPTION
If "Menu key" is set to "None" the viewer will display a hint saying "Press  to open the context menu". I think it's better to just not show the hint in this case.