### PR TITLE
macOS and clang compilation-related updates

### DIFF
--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -380,8 +380,6 @@ void CSecurityTLS::checkSession()
     throw AuthFailureException("Could not find certificate to display");
   }
 
-  size_t out_size = 0;
-  char *out_buf = NULL;
   char *certinfo = NULL;
   int len = 0;
 
@@ -415,18 +413,14 @@ void CSecurityTLS::checkSession()
 
   delete [] certinfo;
 
-  if (gnutls_x509_crt_export(crt, GNUTLS_X509_FMT_PEM, NULL, &out_size)
-      == GNUTLS_E_SHORT_MEMORY_BUFFER)
-    throw AuthFailureException("Out of memory");
-
   // Save cert
-  out_buf =  new char[out_size];
+  size_t out_size = 4096; // Handle max cert size
+  char *out_buf = new char[out_size];
   if (out_buf == NULL)
     throw AuthFailureException("Out of memory");
 
   if (gnutls_x509_crt_export(crt, GNUTLS_X509_FMT_PEM, out_buf, &out_size) < 0)
-    throw AuthFailureException("certificate issuer unknown, and certificate "
-                               "export failed");
+    throw AuthFailureException("certificate export failed");
 
   char *homeDir = NULL;
   if (getvnchomedir(&homeDir) == -1)

--- a/common/rfb/JpegCompressor.h
+++ b/common/rfb/JpegCompressor.h
@@ -49,7 +49,7 @@ namespace rfb {
 
     inline rdr::U8* getstart() { return start; }
 
-    inline int overrun(int itemSize, int nItems) {
+    inline size_t overrun(size_t itemSize, size_t nItems) {
       return MemOutStream::overrun(itemSize, nItems);
     }
 

--- a/common/rfb/SSecurityTLS.h
+++ b/common/rfb/SSecurityTLS.h
@@ -60,7 +60,6 @@ namespace rfb {
     gnutls_certificate_credentials_t cert_cred;
     char *keyfile, *certfile;
 
-    int type;
     bool anon;
 
     rdr::InStream* tlsis;

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -145,9 +145,9 @@ int cocoa_is_keyboard_event(const void *event)
   nsevent = (NSEvent*)event;
 
   switch ([nsevent type]) {
-  case NSKeyDown:
-  case NSKeyUp:
-  case NSFlagsChanged:
+  case NSEventTypeKeyDown:
+  case NSEventTypeKeyUp:
+  case NSEventTypeFlagsChanged:
     return 1;
   default:
     return 0;
@@ -160,10 +160,10 @@ int cocoa_is_key_press(const void *event)
 
   nsevent = (NSEvent*)event;
 
-  if ([nsevent type] == NSKeyDown)
+  if ([nsevent type] == NSEventTypeKeyDown)
     return 1;
 
-  if ([nsevent type] == NSFlagsChanged) {
+  if ([nsevent type] == NSEventTypeFlagsChanged) {
     UInt32 mask;
 
     // We don't see any event on release of CapsLock
@@ -388,11 +388,11 @@ int cocoa_event_keysym(const void *event)
   // other platforms.
 
   modifiers = 0;
-  if ([nsevent modifierFlags] & NSAlphaShiftKeyMask)
+  if ([nsevent modifierFlags] & NSEventModifierFlagCapsLock)
     modifiers |= alphaLock;
-  if ([nsevent modifierFlags] & NSShiftKeyMask)
+  if ([nsevent modifierFlags] & NSEventModifierFlagShift)
     modifiers |= shiftKey;
-  if ([nsevent modifierFlags] & NSAlternateKeyMask)
+  if ([nsevent modifierFlags] & NSEventModifierFlagOption)
     modifiers |= optionKey;
 
   chars = key_translate(key_code, modifiers);

--- a/vncviewer/gettext.h
+++ b/vncviewer/gettext.h
@@ -145,7 +145,7 @@ __inline
 inline
 #endif
 #endif
-static const char *
+static const __attribute__ ((format_arg (3))) char *
 pgettext_aux (const char *domain,
               const char *msg_ctxt_id, const char *msgid,
               int category)

--- a/vncviewer/i18n.h
+++ b/vncviewer/i18n.h
@@ -27,7 +27,7 @@
 static const char *
 pgettext_aux (const char *domain,
               const char *msg_ctxt_id, const char *msgid,
-              int category) __attribute__ ((format_arg (3)));
+              int category);
 #endif
 
 #define _(String) gettext (String)


### PR DESCRIPTION
- macOS key event names that were deprecated have been updated
- clang 11 compilation-related changes