### PR TITLE
macOS and clang compilation-related updates

### DIFF
--- a/common/rfb/JpegCompressor.h
+++ b/common/rfb/JpegCompressor.h
@@ -49,7 +49,7 @@ namespace rfb {
 
     inline rdr::U8* getstart() { return start; }
 
-    inline int overrun(int itemSize, int nItems) {
+    inline size_t overrun(size_t itemSize, size_t nItems) {
       return MemOutStream::overrun(itemSize, nItems);
     }
 

--- a/common/rfb/SSecurityTLS.h
+++ b/common/rfb/SSecurityTLS.h
@@ -60,7 +60,6 @@ namespace rfb {
     gnutls_certificate_credentials_t cert_cred;
     char *keyfile, *certfile;
 
-    int type;
     bool anon;
 
     rdr::InStream* tlsis;

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -145,9 +145,9 @@ int cocoa_is_keyboard_event(const void *event)
   nsevent = (NSEvent*)event;
 
   switch ([nsevent type]) {
-  case NSKeyDown:
-  case NSKeyUp:
-  case NSFlagsChanged:
+  case NSEventTypeKeyDown:
+  case NSEventTypeKeyUp:
+  case NSEventTypeFlagsChanged:
     return 1;
   default:
     return 0;
@@ -160,10 +160,10 @@ int cocoa_is_key_press(const void *event)
 
   nsevent = (NSEvent*)event;
 
-  if ([nsevent type] == NSKeyDown)
+  if ([nsevent type] == NSEventTypeKeyDown)
     return 1;
 
-  if ([nsevent type] == NSFlagsChanged) {
+  if ([nsevent type] == NSEventTypeFlagsChanged) {
     UInt32 mask;
 
     // We don't see any event on release of CapsLock
@@ -388,11 +388,11 @@ int cocoa_event_keysym(const void *event)
   // other platforms.
 
   modifiers = 0;
-  if ([nsevent modifierFlags] & NSAlphaShiftKeyMask)
+  if ([nsevent modifierFlags] & NSEventModifierFlagCapsLock)
     modifiers |= alphaLock;
-  if ([nsevent modifierFlags] & NSShiftKeyMask)
+  if ([nsevent modifierFlags] & NSEventModifierFlagShift)
     modifiers |= shiftKey;
-  if ([nsevent modifierFlags] & NSAlternateKeyMask)
+  if ([nsevent modifierFlags] & NSEventModifierFlagOption)
     modifiers |= optionKey;
 
   chars = key_translate(key_code, modifiers);

--- a/vncviewer/gettext.h
+++ b/vncviewer/gettext.h
@@ -145,7 +145,7 @@ __inline
 inline
 #endif
 #endif
-static const char *
+__attribute__ ((format_arg (3))) static const char *
 pgettext_aux (const char *domain,
               const char *msg_ctxt_id, const char *msgid,
               int category)

--- a/vncviewer/i18n.h
+++ b/vncviewer/i18n.h
@@ -24,10 +24,10 @@
 
 /* Need to tell gcc that pgettext() doesn't screw up format strings */
 #ifdef __GNUC__
-static const char *
+__attribute__ ((format_arg (3))) static const char *
 pgettext_aux (const char *domain,
               const char *msg_ctxt_id, const char *msgid,
-              int category) __attribute__ ((format_arg (3)));
+              int category);
 #endif
 
 #define _(String) gettext (String)


### PR DESCRIPTION
- Updated deprecated macOS key event types
- Addressed compilation issues with clang 11