### PR TITLE
xserver: add no-op input thread init function

### DIFF
--- a/unix/xserver/hw/vnc/Input.c
+++ b/unix/xserver/hw/vnc/Input.c
@@ -711,3 +711,12 @@ static void vncKeysymKeyboardEvent(KeySym keysym, int down)
 	 */
 	mieqProcessInputEvents();
 }
+
+#if INPUTTHREAD
+/** This function is called in Xserver/os/inputthread.c when starting
+    the input thread. */
+void
+ddxInputThreadInit(void)
+{
+}
+#endif


### PR DESCRIPTION
This allows Xvnc to build with xorg-server 1.20.7, which requires OS
layers to implement a ddxInputThreadInit function when configured with
--enable-input-thread (the default).

relevant xorg-server commit: e3f26605d85d987da434640f52646d728f1fe919