### PR TITLE
1.6 branch

### DIFF
--- a/common/rfb/ConnParams.cxx
+++ b/common/rfb/ConnParams.cxx
@@ -70,6 +70,14 @@ void ConnParams::writeVersion(rdr::OutStream* os)
   os->flush();
 }
 
+// We will be padding the reflector string with spaces, to differentiate NUL characters and garbage that is present
+// in the old version.
+void ConnParams::writeReflectorString(rdr::OutStream* os) {
+  char str[250];
+  sprintf(str, "ID:%-246s\n", this->reflectorString); // We are padding with spaces
+  os->writeBytes(str, 250);
+  os->flush();
+}
 void ConnParams::setPF(const PixelFormat& pf)
 {
   pf_ = pf;

--- a/common/rfb/ConnParams.h
+++ b/common/rfb/ConnParams.h
@@ -67,6 +67,20 @@ namespace rfb {
       return !beforeVersion(major,minor+1);
     }
 
+    bool isReflectorStringDefined() {
+      return this->reflectorString != NULL;
+    }
+
+    void setReflectorString(char *string) {
+      this->reflectorString = string;
+    }
+
+    void writeReflectorString(rdr::OutStream* os);
+
+    void resetVersion() {
+      this->verStrPos = 0;
+    }
+
     int width;
     int height;
     ScreenSet screenLayout;
@@ -106,6 +120,7 @@ namespace rfb {
 
     PixelFormat pf_;
     char* name_;
+    char* reflectorString = NULL;
     Cursor cursor_;
     std::set<rdr::S32> encodings_;
     char verStr[13];

--- a/common/rfb/Hostname.h
+++ b/common/rfb/Hostname.h
@@ -25,9 +25,11 @@
 
 namespace rfb {
 
-  static void getHostAndPort(const char* hi, char** host, int* port, int basePort=5900) {
+  static void getHostAndPort(const char* hi, char** host, char** reflector, int* port, int basePort=5900) {
     CharArray portBuf;
     CharArray hostBuf;
+    CharArray reflectorBuf;
+
     if (hi == NULL)
       throw rdr::Exception("NULL host specified");
     if (hi[0] == '[') {
@@ -38,7 +40,15 @@ namespace rfb {
     }
     if (strSplit(portBuf.buf, ':', hostBuf.buf ? 0 : &hostBuf.buf, &portBuf.buf)) {
       if (portBuf.buf[0] == ':') {
-        *port = atoi(&portBuf.buf[1]);
+        if (strContains(&portBuf.buf[1], ':') && strSplit(&portBuf.buf[1], ':', &portBuf.buf, &reflectorBuf.buf)) {
+          *port = atoi(portBuf.buf);
+          if (reflectorBuf.buf[0] == ':' && strlen(reflectorBuf.buf) > 4 && strncmp(reflectorBuf.buf, ":ID:", 3) == 0
+              && strSplit(&reflectorBuf.buf[3], ':', 0, &reflectorBuf.buf)) {
+            *reflector = reflectorBuf.takeBuf();
+          }
+        } else {
+          *port = atoi(&portBuf.buf[1]);
+        }
       } else {
         *port = atoi(portBuf.buf);
         if (*port < 100) *port += basePort;

--- a/unix/xserver/hw/vnc/vncExtInit.cc
+++ b/unix/xserver/hw/vnc/vncExtInit.cc
@@ -277,9 +277,10 @@ int vncConnectClient(const char *addr)
   }
 
   char *host;
+  char *reflectorString;
   int port;
 
-  getHostAndPort(addr, &host, &port, 5500);
+  getHostAndPort(addr, &host, &reflectorString, &port, 5500);
 
   try {
     network::Socket* sock = new network::TcpSocket(host, port);

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -105,7 +105,9 @@ CConn::CConn(const char* vncServerName, network::Socket* socket=NULL)
 
   if(sock == NULL) {
     try {
-      getHostAndPort(vncServerName, &serverHost, &serverPort);
+      char *reflectorString = NULL;
+      getHostAndPort(vncServerName, &serverHost, &reflectorString, &serverPort);
+      cp.setReflectorString(reflectorString);
 
       sock = new network::TcpSocket(serverHost, serverPort);
       vlog.info(_("connected to host %s port %d"), serverHost, serverPort);

--- a/vncviewer/i18n.h
+++ b/vncviewer/i18n.h
@@ -20,6 +20,10 @@
 #ifndef _I18N_H
 #define _I18N_H 1
 
+#ifndef LC_MESSAGES
+#define LC_MESSAGES 'C'
+#endif
+
 #include "gettext.h"
 
 /* Need to tell gcc that pgettext() doesn't screw up format strings */

--- a/win/winvnc/VNCServerWin32.cxx
+++ b/win/winvnc/VNCServerWin32.cxx
@@ -219,10 +219,18 @@ bool VNCServerWin32::addNewClient(const char* client) {
   TcpSocket* sock = 0;
   try {
     CharArray hostname;
+    CharArray reflector;
     int port;
-    getHostAndPort(client, &hostname.buf, &port, 5500);
+    getHostAndPort(client, &hostname.buf, &reflector.buf, &port, 5500);
     vlog.error("port=%d", port);
+    vlog.error("reflector=%s", reflector.buf);
     sock = new TcpSocket(hostname.buf, port);
+    if (reflector.buf != NULL) {
+      char str[250];
+      sprintf(str, "ID:%-247s", reflector.buf);
+      sock->outStream().writeBytes(str, 250);
+      sock->outStream().flush();
+    }
     if (queueCommand(AddClient, sock, 0))
       return true;
     delete sock;


### PR DESCRIPTION
Allows vncviewer and winvnc server to connect to a reflector via a reflector ID.  Unfortunately, I needed Windows XP support which is why I did this on 1.6.  