### PR TITLE
Read username and passwrod from env.

### DIFF
--- a/vncviewer/UserDialog.cxx
+++ b/vncviewer/UserDialog.cxx
@@ -78,7 +78,7 @@ void UserDialog::getUserPasswd(bool secure, char** user, char** password)
   char *envUsername = getenv("VNC_USERNAME");
   char *envPassword = getenv("VNC_PASSWORD");
 
-  if(envUsername && envPassword) {
+  if(user && envUsername && envPassword) {
     *user = strdup(envUsername);
     *password = strdup(envPassword);
     return;

--- a/vncviewer/UserDialog.cxx
+++ b/vncviewer/UserDialog.cxx
@@ -75,6 +75,19 @@ void UserDialog::getUserPasswd(bool secure, char** user, char** password)
   CharArray passwordFileStr(passwordFile.getData());
 
   assert(password);
+  char *envUsername = getenv("VNC_USERNAME");
+  char *envPassword = getenv("VNC_PASSWORD");
+
+  if(envUsername && envPassword) {
+    *user = strdup(envUsername);
+    *password = strdup(envPassword);
+    return;
+  }
+
+  if (!user && envPassword) {
+    *password = strdup(envPassword);
+    return;
+  }
 
   if (!user && passwordFileStr.buf[0]) {
     ObfuscatedPasswd obfPwd(256);

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -52,7 +52,8 @@ given too, but the given configuration file will overwrite any conflicting
 parameters.
 
 If the VNC server is successfully contacted, you will be prompted for a
-password to authenticate you.  If the password is correct, a window will appear
+password to authenticate you. You can also add 'VNC_USERNAME' and 'VNC_PASSWORD'
+to environment variables. If the password is correct, a window will appear
 showing the desktop of the VNC server.
 
 .SH AUTOMATIC PROTOCOL SELECTION


### PR DESCRIPTION
as #957 describes, `vncviewer` currently can not pass username password to command-line(only use dialog to interactively input), this cause much trouble in scripting.
This PR implement getting username and password from environment function, documentation will be added later.