### PR TITLE
Fix for macOS Catalina / FLTK HiDPI issue (#805)

### DIFF
--- a/vncviewer/Surface_OSX.cxx
+++ b/vncviewer/Surface_OSX.cxx
@@ -142,6 +142,14 @@ void Surface::draw(int src_x, int src_y, int x, int y, int w, int h)
   // matrix as otherwise we get a massive performance hit
   CGContextConcatCTM(fl_gc, CGAffineTransformInvert(CGContextGetCTM(fl_gc)));
 
+  // Scale the image as necessary for the screen. If this is a HiDPI screen,
+  // the CGContext will have increased dimensions compared to the FL_Window.
+
+  double sf_h = (CGBitmapContextGetHeight(fl_gc) / Fl_Window::current()->h());
+  double sf_w = (CGBitmapContextGetWidth(fl_gc) / Fl_Window::current()->w());
+
+  CGContextScaleCTM(fl_gc, sf_h, sf_w);
+
   // macOS Coordinates are from bottom left, not top left
   y = Fl_Window::current()->h() - (y + h);
 
@@ -177,6 +185,12 @@ void Surface::blend(int src_x, int src_y, int x, int y, int w, int h, int a)
   // Reset the transformation matrix back to the default identity
   // matrix as otherwise we get a massive performance hit
   CGContextConcatCTM(fl_gc, CGAffineTransformInvert(CGContextGetCTM(fl_gc)));
+
+  // Scale the image as necessary for the screen. If this is a HiDPI screen,
+  // the CGContext will have increased dimensions compared to the FL_Window.
+
+  double sf_h = (CGBitmapContextGetHeight(fl_gc) / Fl_Window::current()->h());
+  double sf_w = (CGBitmapContextGetWidth(fl_gc) / Fl_Window::current()->w());
 
   // macOS Coordinates are from bottom left, not top left
   y = Fl_Window::current()->h() - (y + h);


### PR DESCRIPTION
Looks like Bug #805 is not an FLTK bug, but rather due to TigerVNC drawing directly into the CoreGraphics context that is backing the FLTK window.

This may not be the cleanest fix, but it does work as expected.

If I merely remove the call that applies CGAffineTransformInvert() on the transformation matrix, I get an image flipped in the vertical, probably because of how macOS uses the lower left hand corner as origin.