### PR TITLE
Windows Clipboard Polling

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -557,16 +557,10 @@ void Viewport::resize(int x, int y, int w, int h)
   Fl_Widget::resize(x, y, w, h);
 }
 
-
-int Viewport::handle(int event)
+void Viewport::sendClipboardData(const char* text, const size_t length)
 {
   char *filtered;
-  int buttonMask, wheelMask;
-  DownMap::const_iterator iter;
-
-  switch (event) {
-  case FL_PASTE:
-    filtered = convertLF(Fl::event_text(), Fl::event_length());
+    filtered = convertLF(text, length);
 
     vlog.debug("Sending clipboard data (%d bytes)", (int)strlen(filtered));
 
@@ -578,6 +572,16 @@ int Viewport::handle(int event)
     }
 
     strFree(filtered);
+}
+
+int Viewport::handle(int event)
+{
+  int buttonMask, wheelMask;
+  DownMap::const_iterator iter;
+
+  switch (event) {
+  case FL_PASTE:
+    sendClipboardData(Fl::event_text(), Fl::event_length());
 
     return 1;
 

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -92,6 +92,8 @@ private:
 
 #ifdef WIN32
   static void handleAltGrTimeout(void *data);
+  char* readClipboardData();
+  void readAndSendClipboardData();
 #endif
 
   void pushLEDState();

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -79,6 +79,7 @@ private:
 
   static void handleClipboardChange(int source, void *data);
 
+  void sendClipboardData(const char* text, const size_t length);
   void flushPendingClipboard();
 
   void handlePointerEvent(const rfb::Point& pos, int buttonMask);


### PR DESCRIPTION
Dear tigervnc-devs,

This is quite an ugly hack to try to avoid problems like in #188. At least, Excel seems to stop complaining about the clipboard being blocked.

It reads the clipboard data and sends it to the server while on FL_FOCUS instead of adding a clipboard listener with a callback. This is a Windows-only change.

You might be interested in something like this. Or not :smile:

Cheers,
Juanito