### PR TITLE
 Make system error messeges in Windows 10 use UTF-8

### DIFF
--- a/common/network/TcpSocket.cxx
+++ b/common/network/TcpSocket.cxx
@@ -202,7 +202,7 @@ TcpSocket::TcpSocket(const char *host, int port)
     if (err == 0)
       throw Exception("No useful address for host");
     else
-      throw SocketException("unable connect to socket", err);
+      throw SocketException("unable to connect to socket", err);
   }
 
   // Take proper ownership of the socket

--- a/common/network/TcpSocket.cxx
+++ b/common/network/TcpSocket.cxx
@@ -133,8 +133,7 @@ TcpSocket::TcpSocket(const char *host, int port)
   hints.ai_next = NULL;
 
   if ((result = getaddrinfo(host, NULL, &hints, &ai)) != 0) {
-    throw Exception("unable to resolve host by name: %s",
-                    gai_strerror(result));
+    throw GAIException("unable to resolve host by name", result);
   }
 
   sock = -1;
@@ -452,8 +451,7 @@ void network::createTcpListeners(std::list<SocketListener*> *listeners,
   snprintf (service, sizeof (service) - 1, "%d", port);
   service[sizeof (service) - 1] = '\0';
   if ((result = getaddrinfo(addr, service, &hints, &ai)) != 0)
-    throw rdr::Exception("unable to resolve listening address: %s",
-                         gai_strerror(result));
+    throw GAIException("unable to resolve listening address", result);
 
   try {
     createTcpListeners(listeners, ai);
@@ -645,8 +643,7 @@ TcpFilter::Pattern TcpFilter::parsePattern(const char* p) {
     }
 
     if ((result = getaddrinfo (p, NULL, &hints, &ai)) != 0) {
-      throw Exception("unable to resolve host by name: %s",
-                      gai_strerror(result));
+      throw GAIException("unable to resolve host by name", result);
     }
 
     memcpy (&pattern.address.u.sa, ai->ai_addr, ai->ai_addrlen);

--- a/common/rdr/Exception.cxx
+++ b/common/rdr/Exception.cxx
@@ -54,33 +54,16 @@ SystemException::SystemException(const char* s, int err_)
 {
   strncat(str_, ": ", len-1-strlen(str_));
 #ifdef _WIN32
-  // Windows error messages are crap, so use unix ones for common errors.
-  const char* msg = 0;
-  switch (err) {
-  case WSAECONNREFUSED: msg = "Connection refused";       break;
-  case WSAETIMEDOUT:    msg = "Connection timed out";     break;
-  case WSAECONNRESET:   msg = "Connection reset by peer"; break;
-  case WSAECONNABORTED: msg = "Connection aborted";       break;
-  }
-  if (msg) {
-    strncat(str_, msg, len-1-strlen(str_));
-  } else {
-#ifdef UNICODE
-    WCHAR* tmsg = new WCHAR[len-strlen(str_)];
-    FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                  0, err, 0, tmsg, len-1-strlen(str_), 0);
-    WideCharToMultiByte(CP_ACP, 0, tmsg, wcslen(tmsg)+1,
-		              str_+strlen(str_), len-strlen(str_), 0, 0);
-    delete [] tmsg;
-#else
-    char* currStr = str_+strlen(str_);
-    FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                  0, err, 0, currStr, len-1-strlen(str_), 0);
-#endif
-    int l = strlen(str_);
-    if ((l >= 2) && (str_[l-2] == '\r') && (str_[l-1] == '\n'))
+  wchar_t *currStr = new wchar_t[len-strlen(str_)];
+  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                 0, err, 0, currStr, len-1-strlen(str_), 0);
+  WideCharToMultiByte(CP_UTF8, 0, currStr, -1, str_+strlen(str_),
+                      len-1-strlen(str_), 0, 0);
+  delete [] currStr;
+
+  int l = strlen(str_);
+  if ((l >= 2) && (str_[l-2] == '\r') && (str_[l-1] == '\n'))
       str_[l-2] = 0;
-  }
 
 #else
   strncat(str_, strerror(err), len-1-strlen(str_));

--- a/common/rdr/Exception.h
+++ b/common/rdr/Exception.h
@@ -40,12 +40,17 @@ namespace rdr {
   struct SystemException : public Exception {
     int err;
     SystemException(const char* s, int err_);
-  }; 
+  };
+
+  struct GAIException : public Exception {
+    int err;
+    GAIException(const char* s, int err_);
+  };
 
   struct TimedOut : public Exception {
     TimedOut() : Exception("Timed out") {}
   };
- 
+
   struct EndOfStream : public Exception {
     EndOfStream() : Exception("End of stream") {}
   };


### PR DESCRIPTION
The previous system error messages did not support Unicode characters. This commit will use UTF-8 encoding to be able to display error messages in every language.