### PR TITLE
Make sure we start a dbus session

### DIFF
--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -233,7 +233,7 @@ $ENV{XAUTHORITY} = $xauthorityFile;
 
 @cmd = ("xinit");
 
-push(@cmd, $Xsession, $session{'Exec'});
+push(@cmd, $Xsession, "dbus-run-session $session{'Exec'}");
 
 push(@cmd, '--');
 


### PR DESCRIPTION
As explained in https://github.com/TigerVNC/tigervnc/pull/838#issuecomment-624223381. We need to make sure a dbus session is started. I tested this on RHEL 8 and this makes it work for me while I'm logged in with the same user into GNOME.