### PR TITLE
[SELinux] Allow vnc_session_t type execute itself

### DIFF
--- a/unix/vncserver/selinux/vncsession.te
+++ b/unix/vncserver/selinux/vncsession.te
@@ -32,6 +32,8 @@ files_pid_filetrans(vnc_session_t, vnc_session_var_run_t, file)
 
 auth_write_login_records(vnc_session_t)
 
+can_exec(vnc_session_t, vnc_session_exec_t)
+
 userdom_spec_domtrans_all_users(vnc_session_t)
 userdom_signal_all_users(vnc_session_t)
 


### PR DESCRIPTION
vncsession-start is running in SELinux vnc_session_t domain because of
"SELinuxContext=system_u:system_r:vnc_session_t:s0" option in systemd
vncserver@.service unit file. vncsession-start executing binary
vncsession with SELinux label/type vnc_session_t. This access was not
allowed in vncsession policy.

cc @grulja 