### PR TITLE
Fix "vncserver -list" to have deterministic order and correct filter.

### DIFF
--- a/unix/vncserver
+++ b/unix/vncserver
@@ -699,8 +699,8 @@ sub List
     closedir(dir);
     print "\nTigerVNC server sessions:\n\n";
     print "X DISPLAY #\tPROCESS ID\n";
-    foreach my $file (@filelist) {
-	if ($file =~ /$host:(\d+)$\.pid/) {
+    foreach my $file (sort @filelist) {
+	if ($file =~ /^\Q$host\E:(\d+)\.pid$/) {
 	    chop($tmp_pid = `cat $vncUserDir/$file`);
 	    if (kill 0, $tmp_pid) {
 		print ":".$1."\t\t".`cat $vncUserDir/$file`;


### PR DESCRIPTION
When listing sessions, use lexicographical order insead of directory order.

The filtering regular expression is vulnerable to misinterpretation, and
include a strange reference to ` $\ ` that is likely a typo:

       if ($file =~ /$host:(\d+)$\.pid/) {

It only works because ` $\ ` is normally empty, so it is acting like:

       if ($file =~ /$host:(\d+).pid/) {

This pattern is vulnerable if `$host` contains any regular expression
characters, including `.`, and also the `.` before pid is not literal.

This has been corrected to:

       if ($file =~ /^\Q$host\E:(\d+)\.pid$/) {