### PR TITLE
Remove trailing spaces in user name

### DIFF
--- a/unix/vncserver/vncsession-start.in
+++ b/unix/vncserver/vncsession-start.in
@@ -33,7 +33,7 @@ fi
 
 DISPLAY="$1"
 
-USER=`grep "^${DISPLAY}=" "${USERSFILE}" 2>/dev/null | head -1 | cut -d = -f 2-`
+USER=`grep "^ *${DISPLAY}=" "${USERSFILE}" 2>/dev/null | head -1 | cut -d = -f 2- | sed 's/ *$//g'`
 
 if [ -z "${USER}" ]; then
 	echo "No user configured for display ${DISPLAY}" >&2


### PR DESCRIPTION
It's quite easy to make a mistake and add an additional space when configuring users in the vncserver.users config file. You will then get an error that the user doesn't exist and it's hard to spot the mistake. Same applies for a space before the display number.