### PR TITLE
Correction to socket error connection message

### DIFF
--- a/common/network/UnixSocket.cxx
+++ b/common/network/UnixSocket.cxx
@@ -69,7 +69,7 @@ UnixSocket::UnixSocket(const char *path)
   }
 
   if (result == -1)
-    throw SocketException("unable connect to socket", err);
+    throw SocketException("unable to connect to socket", err);
 
   setFd(sock);
 }


### PR DESCRIPTION
When connecting from a client to the vncserver, if the socket connection fails, the error popup currently states "unable connect to socket". This pull request contains a one-line code change to make this error "unable to connect to socket" to be more correct and consistent with the other socket errors. Thank you