### PR TITLE
Fix "vncserver" display check to better identify available display numbers

### DIFF
--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -391,13 +391,6 @@ sub CheckDisplayNumber
 	return 0;
     }
 
-    if (-e "/usr/spool/sockets/X11/$n") {
-	warn("\nWarning: $host:$n is taken because of ".
-             "/usr/spool/sockets/X11/$n\n");
-	warn "Remove this file if there is no X server $host:$n\n";
-	return 0;
-    }
-
     return 1;
 }
 

--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -374,21 +374,17 @@ sub CheckDisplayNumber
     my $rfb_port = 5900 + $n;
     my $x11_port = 6000 + $n;
 
-    socket(S, $AF_INET, $SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
-    eval 'setsockopt(S, &SOL_SOCKET, &SO_REUSEADDR, pack("l", 1))';
-    if (!bind(S, pack('S n x12', $AF_INET, $x11_port))) {
-	close(S);
-	return 0;
+    for my $port ($rfb_port, $x11_port) {
+        # Bind to port to confirm it is not in use.
+        socket(S, $AF_INET, $SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
+        eval 'setsockopt(S, &SOL_SOCKET, &SO_REUSEADDR, pack("l", 1))';
+        if (!bind(S, pack('S n x12', $AF_INET, $port))) {
+            # Port is in use.
+            close(S);
+            return 0;
+        }
+        close(S);
     }
-    close(S);
-
-    socket(S, $AF_INET, $SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
-    eval 'setsockopt(S, &SOL_SOCKET, &SO_REUSEADDR, pack("l", 1))';
-    if (!bind(S, pack('S n x12', $AF_INET, $rfb_port))) {
-	close(S);
-	return 0;
-    }
-    close(S);
 
     my $x11_unix_domain = "/tmp/.X11-unix/X$n";
 

--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -361,7 +361,9 @@ sub LoadXSession {
 
 sub CheckDisplayNumber
 {
-    local ($n) = @_;
+    my($n) = @_;
+
+    use Socket;
 
     my $x11_lock_path = "/tmp/.X$n-lock";
 
@@ -378,9 +380,9 @@ sub CheckDisplayNumber
 
     for my $port ($rfb_port, $x11_port) {
         # Bind to port to confirm it is not in use.
-        socket(S, $AF_INET, $SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
-        eval 'setsockopt(S, &SOL_SOCKET, &SO_REUSEADDR, pack("l", 1))';
-        if (!bind(S, pack('S n x12', $AF_INET, $port))) {
+        socket(S, PF_INET, SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
+        setsockopt(S, SOL_SOCKET, SO_REUSEADDR, 1);
+        if (!bind(S, sockaddr_in($port, INADDR_ANY))) {
             # Port is in use.
             close(S);
             return 0;
@@ -443,37 +445,5 @@ sub SanityCheck
 
     if (!defined($ENV{HOME})) {
 	die "$prog: The HOME environment variable is not set.\n";
-    }
-
-    #
-    # Find socket constants. 'use Socket' is a perl5-ism, so we wrap it in an
-    # eval, and if it fails we try 'require "sys/socket.ph"'.  If this fails,
-    # we just guess at the values.  If you find perl moaning here, just
-    # hard-code the values of AF_INET and SOCK_STREAM.  You can find these out
-    # for your platform by looking in /usr/include/sys/socket.h and related
-    # files.
-    #
-
-    chop($os = `uname`);
-    chop($osrev = `uname -r`);
-
-    eval 'use Socket';
-    if ($@) {
-	eval 'require "sys/socket.ph"';
-	if ($@) {
-	    if (($os eq "SunOS") && ($osrev !~ /^4/)) {
-		$AF_INET = 2;
-		$SOCK_STREAM = 2;
-	    } else {
-		$AF_INET = 2;
-		$SOCK_STREAM = 1;
-	    }
-	} else {
-	    $AF_INET = &AF_INET;
-	    $SOCK_STREAM = &SOCK_STREAM;
-	}
-    } else {
-	$AF_INET = &AF_INET;
-	$SOCK_STREAM = &SOCK_STREAM;
     }
 }

--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -393,9 +393,14 @@ sub CheckDisplayNumber
     my $x11_unix_domain = "/tmp/.X11-unix/X$n";
 
     if (-e $x11_unix_domain) {
-	warn "\nWarning: $host:$n is taken because of $x11_unix_domain\n";
-	warn "Remove this file if there is no X server $host:$n\n";
-	return 0;
+        # Connect to UNIX domain socket to confirm it is not in use.
+        socket(S, PF_UNIX, SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
+        if (connect(S, sockaddr_un($x11_unix_domain))) {
+            # UNIX domain socket is in use.
+            close(S);
+            return 0;
+        }
+        close(S);
     }
 
     return 1;

--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -363,15 +363,20 @@ sub CheckDisplayNumber
 {
     local ($n) = @_;
 
-    if (-e "/tmp/.X$n-lock") {
-	warn "\nWarning: $host:$n is taken because of /tmp/.X$n-lock\n";
+    my $x11_lock_path = "/tmp/.X$n-lock";
+
+    if (-e $x11_lock_path) {
+	warn "\nWarning: $host:$n is taken because of $x11_lock_path\n";
 	warn "Remove this file if there is no X server $host:$n\n";
 	return 0;
     }
 
+    my $rfb_port = 5900 + $n;
+    my $x11_port = 6000 + $n;
+
     socket(S, $AF_INET, $SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
     eval 'setsockopt(S, &SOL_SOCKET, &SO_REUSEADDR, pack("l", 1))';
-    if (!bind(S, pack('S n x12', $AF_INET, 6000 + $n))) {
+    if (!bind(S, pack('S n x12', $AF_INET, $x11_port))) {
 	close(S);
 	return 0;
     }
@@ -379,14 +384,16 @@ sub CheckDisplayNumber
 
     socket(S, $AF_INET, $SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
     eval 'setsockopt(S, &SOL_SOCKET, &SO_REUSEADDR, pack("l", 1))';
-    if (!bind(S, pack('S n x12', $AF_INET, 5900 + $n))) {
+    if (!bind(S, pack('S n x12', $AF_INET, $rfb_port))) {
 	close(S);
 	return 0;
     }
     close(S);
 
-    if (-e "/tmp/.X11-unix/X$n") {
-	warn "\nWarning: $host:$n is taken because of /tmp/.X11-unix/X$n\n";
+    my $x11_unix_domain = "/tmp/.X11-unix/X$n";
+
+    if (-e $x11_unix_domain) {
+	warn "\nWarning: $host:$n is taken because of $x11_unix_domain\n";
 	warn "Remove this file if there is no X server $host:$n\n";
 	return 0;
     }

--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -363,6 +363,12 @@ sub CheckDisplayNumber
 {
     local ($n) = @_;
 
+    if (-e "/tmp/.X$n-lock") {
+	warn "\nWarning: $host:$n is taken because of /tmp/.X$n-lock\n";
+	warn "Remove this file if there is no X server $host:$n\n";
+	return 0;
+    }
+
     socket(S, $AF_INET, $SOCK_STREAM, 0) || die "$prog: socket failed: $!\n";
     eval 'setsockopt(S, &SOL_SOCKET, &SO_REUSEADDR, pack("l", 1))';
     if (!bind(S, pack('S n x12', $AF_INET, 6000 + $n))) {
@@ -378,12 +384,6 @@ sub CheckDisplayNumber
 	return 0;
     }
     close(S);
-
-    if (-e "/tmp/.X$n-lock") {
-	warn "\nWarning: $host:$n is taken because of /tmp/.X$n-lock\n";
-	warn "Remove this file if there is no X server $host:$n\n";
-	return 0;
-    }
 
     if (-e "/tmp/.X11-unix/X$n") {
 	warn "\nWarning: $host:$n is taken because of /tmp/.X11-unix/X$n\n";

--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -366,9 +366,11 @@ sub CheckDisplayNumber
     my $x11_lock_path = "/tmp/.X$n-lock";
 
     if (-e $x11_lock_path) {
-	warn "\nWarning: $host:$n is taken because of $x11_lock_path\n";
-	warn "Remove this file if there is no X server $host:$n\n";
-	return 0;
+        my($pid) = `cat "$x11_lock_path"` =~ /^\s*(\d+)\s*$/;
+        if (defined($pid) && kill(0, $pid)) {
+            # Lock is associated with valid PID.
+            return 0;
+        }
     }
 
     my $rfb_port = 5900 + $n;


### PR DESCRIPTION
There are a number of situations than can occur when the X
server is not shut down cleanly. These situations can leave
files around that "vncserver" has previously mis-identified
as evidence that the display number is still in use. These
changes reduce the occurrences of these false positives,
ensuring that "vncserver" handles these situations gracefully.

Instead of checking for existence of `/tmp/.X<n>-lock`, the
code will now extract the PID from this file and confirm that
a process exists with the same PID. This will eliminate
false positives in the case that this file references a PID
that no longer exists. The Xorg server does not have a problem
with fixing this file when it next starts up. It is only
important to avoid using the port if it is still in use.

Instead of checking for existence of `/tmp/.X11-unix/X<n>`, the
code will now attempt to connect to the socket to confirm that
there is a server process listening on this UNIX domain socket.
The Xorg server does not have a problem with fixing this file
when it next starts up. It is only important to avoid using
the UNIX domain socket if it is still in use.

The ordering of the code has changed, such that that check for
a lock file happens first. This should ensure that the fast
path does not require to bind() or connect() to any sockets
which can both have side effects. The slow path will still
do all checks, so there is no risk to this change.

The check for existence of `/usr/spool/sockets/X11/<n>` has
been removed. This file is only relevant on HP-UX, and
TigerVNC dropped support for HP-UX in commit 31e5aa3ddd2.

The section of code updated now requires Perl 5. This
removes legacy cruft that should not be necessary on any
supported platforms.