### PR TITLE
Runtime selection of BGRA ordering

### DIFF
--- a/unix/vncserver/selinux/vncsession.te
+++ b/unix/vncserver/selinux/vncsession.te
@@ -53,6 +53,7 @@ manage_lnk_files_pattern(vnc_session_t, xdm_home_t, xdm_home_t)
 userdom_user_home_dir_filetrans(vnc_session_t, xdm_home_t, dir, ".vnc")
 userdom_admin_home_dir_filetrans(vnc_session_t, xdm_home_t, dir, ".vnc")
 
+# This also affects other tools, e.g. vncpasswd
 userdom_admin_home_dir_filetrans(userdomain, xdm_home_t, dir, ".vnc")
 userdom_user_home_dir_filetrans(userdomain, xdm_home_t, dir, ".vnc")
 


### PR DESCRIPTION
For issue #1073 replace the compile time selection of BGRA ordering in changeset cc647db with
runtime selection using the X Visual mask.