### PR TITLE
ARGB runtime XImage byteorder selection

### DIFF
--- a/vncviewer/Surface_X11.cxx
+++ b/vncviewer/Surface_X11.cxx
@@ -123,17 +123,17 @@ void Surface::alloc()
   // we find such a format
   templ.type = PictTypeDirect;
   templ.depth = 32;
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  templ.direct.alpha = 0;
-  templ.direct.red   = 8;
-  templ.direct.green = 16;
-  templ.direct.blue  = 24;
-#else
-  templ.direct.alpha = 24;
-  templ.direct.red   = 16;
-  templ.direct.green = 8;
-  templ.direct.blue  = 0;
-#endif
+  if (XImageByteOrder(fl_display) == MSBFirst) {
+    templ.direct.alpha = 0;
+    templ.direct.red   = 8;
+    templ.direct.green = 16;
+    templ.direct.blue  = 24;
+  } else {
+    templ.direct.alpha = 24;
+    templ.direct.red   = 16;
+    templ.direct.green = 8;
+    templ.direct.blue  = 0;
+  }
   templ.direct.alphaMask = 0xff;
   templ.direct.redMask = 0xff;
   templ.direct.greenMask = 0xff;


### PR DESCRIPTION
Respin of the original runtime ARGB selection pull request to solve the regression introduced by #cc647db.
and being tracked under #1073.  This uses XImageByteOrder() instead.  Tested on Solaris/SPARC server
and Solaris/x86 client.