### PR TITLE
Apply patch from openSUSE to fix build with xorg-server 1.20

### DIFF
--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -295,6 +295,15 @@ void ddxBeforeReset(void)
 }
 #endif
 
+#if INPUTTHREAD
+/** This function is called in Xserver/os/inputthread.c when starting
+    the input thread. */
+void
+ddxInputThreadInit(void)
+{
+}
+#endif
+
 void ddxUseMsg(void)
 {
     vncPrintBanner();

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -295,7 +295,7 @@ void ddxBeforeReset(void)
 }
 #endif
 
-#if INPUTTHREAD
+#if XORG_VERSION_CURRENT >= XORG_VERSION_NUMERIC(1,20,7,0,0) && INPUTTHREAD
 /** This function is called in Xserver/os/inputthread.c when starting
     the input thread. */
 void


### PR DESCRIPTION
Originally authored by Stefan Dirsch (openSUSE xorg-maintainers).

Obtained from: https://build.opensuse.org/package/view_file/X11:XOrg/tigervnc/u_xorg-server-1.20.7-ddxInputThreadInit.patch

----

It fails to build with the following log if the patch isn't applied.

```
  CC       libvnccommon_la-qnum_to_xorgevdev.lo
  CC       libvnccommon_la-qnum_to_xorgkbd.lo
  CXXLD    libvnccommon.la
  CXXLD    Xvnc
ld: error: duplicate symbol: ddxInputThreadInit
>>> defined at xvnc.c
>>>            Xvnc-xvnc.o:(ddxInputThreadInit)
>>> defined at Input.c
>>>            libvnccommon_la-Input.o:(.text+0xDC0) in archive ./.libs/libvnccommon.a
c++: error: linker command failed with exit code 1 (use -v to see invocation)
*** Error code 1

Stop.
make[3]: stopped in /wrkdirs/usr/ports/net/tigervnc-server/work/tigervnc-1.11.0/unix/xserver/hw/vnc
*** Error code 1
*** Error code 1
*** Error code 1

Stop.
````