### PR TITLE
OS X Japanese Keyboard Support

### DIFF
--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -358,6 +358,9 @@ static const int kvk_map[][2] = {
   { kVK_ANSI_Keypad7,           XK_KP_7 },
   { kVK_ANSI_Keypad8,           XK_KP_8 },
   { kVK_ANSI_Keypad9,           XK_KP_9 },
+  // Japanese Keyboard Support
+  { kVK_JIS_Eisu,               XK_Muhenkan },
+  { kVK_JIS_Kana,               XK_Hiragana_Katakana },
 };
 
 int cocoa_event_keysym(const void *event)


### PR DESCRIPTION
Added OS X JIS Keyboard keys (kVK_JIS_Eisu, kvK_JIS_Kana). The Kana and Eisu keys are used to alter IME behavior, but currently the Kana key produces an unwanted space character and the Eisu key does not work.