### PR TITLE
Windows JIS Keyboard Support

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -1060,6 +1060,16 @@ int Viewport::handleSystemEvent(void *event, void *data)
 
     self->handleKeyPress(keyCode, keySym);
 
+    // We don't get reliable WM_KEYUP for these
+    switch (keySym) {
+    case XK_Zenkaku_Hankaku:
+    case XK_Eisu_toggle:
+    case XK_Katakana:
+    case XK_Hiragana:
+    case XK_Romaji:
+      self->handleKeyRelease(keyCode);
+    }
+
     return 1;
   } else if ((msg->message == WM_KEYUP) || (msg->message == WM_SYSKEYUP)) {
     UINT vKey;

--- a/vncviewer/win32.c
+++ b/vncviewer/win32.c
@@ -145,7 +145,6 @@ static const int vkey_map[][3] = {
   { VK_MENU,                XK_Alt_L,       XK_Alt_R },
   { VK_PAUSE,               XK_Pause,       NoSymbol },
   { VK_CAPITAL,             XK_Caps_Lock,   NoSymbol },
-  /* FIXME: IME keys */
   { VK_ESCAPE,              XK_Escape,      NoSymbol },
   { VK_CONVERT,             XK_Henkan,      NoSymbol },
   { VK_NONCONVERT,          XK_Muhenkan,    NoSymbol },
@@ -227,12 +226,17 @@ static const int vkey_map[][3] = {
 
 // Japanese
 static const int vkey_map_jp[][3] = {
+  { VK_KANA,                XK_Hiragana_Katakana, NoSymbol },
+  { VK_KANJI,               XK_Kanji,       NoSymbol },
   { VK_OEM_ATTN,            XK_Eisu_toggle, NoSymbol },
   { VK_OEM_FINISH,          XK_Katakana,    NoSymbol },
   { VK_OEM_COPY,            XK_Hiragana,    NoSymbol },
+  // These are really XK_Zenkaku/XK_Hankaku but we have no way of
+  // keeping the client and server in sync
   { VK_OEM_AUTO,            XK_Zenkaku_Hankaku, NoSymbol },
   { VK_OEM_ENLW,            XK_Zenkaku_Hankaku, NoSymbol },
   { VK_OEM_BACKTAB,         XK_Romaji,      NoSymbol },
+  { VK_ATTN,                XK_Romaji,      NoSymbol },
 };
 
 static int lookup_vkey_map(UINT vkey, int extended, const int map[][3], size_t size)

--- a/vncviewer/win32.c
+++ b/vncviewer/win32.c
@@ -21,6 +21,7 @@
 
 #define XK_MISCELLANY
 #define XK_XKB_KEYS
+#define XK_KOREAN
 #include <rfb/keysymdef.h>
 #include <rfb/XF86keysym.h>
 
@@ -239,6 +240,12 @@ static const int vkey_map_jp[][3] = {
   { VK_ATTN,                XK_Romaji,      NoSymbol },
 };
 
+// Korean
+static const int vkey_map_ko[][3] = {
+  { VK_HANGUL,              XK_Hangul,      NoSymbol },
+  { VK_HANJA,               XK_Hangul_Hanja, NoSymbol },
+};
+
 static int lookup_vkey_map(UINT vkey, int extended, const int map[][3], size_t size)
 {
   size_t i;
@@ -279,6 +286,13 @@ int win32_vkey_to_keysym(UINT vkey, int extended)
   if (primary_lang == LANG_JAPANESE) {
     ret = lookup_vkey_map(vkey, extended,
                           vkey_map_jp, ARRAY_SIZE(vkey_map_jp));
+    if (ret != NoSymbol)
+      return ret;
+  }
+
+  if (primary_lang == LANG_KOREAN) {
+    ret = lookup_vkey_map(vkey, extended,
+                          vkey_map_ko, ARRAY_SIZE(vkey_map_ko));
     if (ret != NoSymbol)
       return ret;
   }

--- a/vncviewer/win32.c
+++ b/vncviewer/win32.c
@@ -144,6 +144,8 @@ static const int vkey_map[][3] = {
   { VK_CAPITAL,             XK_Caps_Lock,   NoSymbol },
   /* FIXME: IME keys */
   { VK_ESCAPE,              XK_Escape,      NoSymbol },
+  { VK_CONVERT,             XK_Henkan,      NoSymbol },
+  { VK_NONCONVERT,          XK_Muhenkan,    NoSymbol },
   { VK_PRIOR,               XK_KP_Prior,    XK_Prior },
   { VK_NEXT,                XK_KP_Next,     XK_Next },
   { VK_END,                 XK_KP_End,      XK_End },
@@ -216,6 +218,13 @@ static const int vkey_map[][3] = {
   { VK_MEDIA_PLAY_PAUSE,    NoSymbol,       XF86XK_AudioPlay },
   { VK_LAUNCH_MAIL,         NoSymbol,       XF86XK_Mail },
   { VK_LAUNCH_APP2,         NoSymbol,       XF86XK_Calculator },
+  // Japanese keyboard support
+  { VK_OEM_ATTN,            XK_Eisu_toggle, NoSymbol },
+  { VK_OEM_FINISH,          XK_Katakana,    NoSymbol },
+  { VK_OEM_COPY,            XK_Hiragana,    NoSymbol },
+  { VK_OEM_AUTO,            XK_Zenkaku_Hankaku, NoSymbol },
+  { VK_OEM_ENLW,            XK_Zenkaku_Hankaku, NoSymbol },
+  { VK_OEM_BACKTAB,         XK_Romaji,      NoSymbol },
 };
 
 int win32_vkey_to_keysym(UINT vkey, int extended)


### PR DESCRIPTION
Added vkey mappings for Japanese keyboards because the special keys for Japanese input do not work on TigerVNC currently.