### PR TITLE
Handle unsolicited clipboard transfers

### DIFF
--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -504,10 +504,8 @@ void CConnection::handleClipboardRequest(rdr::U32 flags)
 
 void CConnection::handleClipboardPeek(rdr::U32 flags)
 {
-  if (!hasLocalClipboard)
-    return;
   if (server.clipboardFlags() & rfb::clipboardNotify)
-    writer()->writeClipboardNotify(rfb::clipboardUTF8);
+    writer()->writeClipboardNotify(hasLocalClipboard ? rfb::clipboardUTF8 : 0);
 }
 
 void CConnection::handleClipboardNotify(rdr::U32 flags)

--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -495,10 +495,14 @@ void CConnection::handleClipboardCaps(rdr::U32 flags,
 
 void CConnection::handleClipboardRequest(rdr::U32 flags)
 {
-  if (!(flags & rfb::clipboardUTF8))
+  if (!(flags & rfb::clipboardUTF8)) {
+    vlog.debug("Ignoring clipboard request for unsupported formats 0x%x", flags);
     return;
-  if (!hasLocalClipboard)
+  }
+  if (!hasLocalClipboard) {
+    vlog.debug("Ignoring unexpected clipboard request");
     return;
+  }
   handleClipboardRequest();
 }
 
@@ -525,8 +529,10 @@ void CConnection::handleClipboardProvide(rdr::U32 flags,
                                          const size_t* lengths,
                                          const rdr::U8* const* data)
 {
-  if (!(flags & rfb::clipboardUTF8))
+  if (!(flags & rfb::clipboardUTF8)) {
+    vlog.debug("Ignoring clipboard provide with unsupported formats 0x%x", flags);
     return;
+  }
 
   strFree(serverClipboard);
   serverClipboard = NULL;

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -287,6 +287,7 @@ namespace rfb {
 
     char* serverClipboard;
     bool hasLocalClipboard;
+    bool unsolicitedClipboardAttempt;
   };
 }
 #endif

--- a/common/rfb/CMsgHandler.cxx
+++ b/common/rfb/CMsgHandler.cxx
@@ -21,6 +21,7 @@
 #include <rfb/Exception.h>
 #include <rfb/LogWriter.h>
 #include <rfb/CMsgHandler.h>
+#include <rfb/clipboardTypes.h>
 #include <rfb/screenTypes.h>
 
 static rfb::LogWriter vlog("CMsgHandler");
@@ -101,6 +102,46 @@ void CMsgHandler::setLEDState(unsigned int state)
 
 void CMsgHandler::handleClipboardCaps(rdr::U32 flags, const rdr::U32* lengths)
 {
+  int i;
+
+  vlog.debug("Got server clipboard capabilities:");
+  for (i = 0;i < 16;i++) {
+    if (flags & (1 << i)) {
+      const char *type;
+
+      switch (1 << i) {
+        case clipboardUTF8:
+          type = "Plain text";
+          break;
+        case clipboardRTF:
+          type = "Rich text";
+          break;
+        case clipboardHTML:
+          type = "HTML";
+          break;
+        case clipboardDIB:
+          type = "Images";
+          break;
+        case clipboardFiles:
+          type = "Files";
+          break;
+        default:
+          vlog.debug("    Unknown format 0x%x", 1 << i);
+          continue;
+      }
+
+      if (lengths[i] == 0)
+        vlog.debug("    %s (only notify)", type);
+      else {
+        char bytes[1024];
+
+        iecPrefix(lengths[i], "B", bytes, sizeof(bytes));
+        vlog.debug("    %s (automatically send up to %s)",
+                   type, bytes);
+      }
+    }
+  }
+
   server.setClipboardCaps(flags, lengths);
 }
 

--- a/common/rfb/ClientParams.cxx
+++ b/common/rfb/ClientParams.cxx
@@ -143,6 +143,18 @@ void ClientParams::setLEDState(unsigned int state)
   ledState_ = state;
 }
 
+rdr::U32 ClientParams::clipboardSize(unsigned int format) const
+{
+  int i;
+
+  for (i = 0;i < 16;i++) {
+    if (((unsigned)1 << i) == format)
+      return clipSizes[i];
+  }
+
+  throw Exception("Invalid clipboard format 0x%x", format);
+}
+
 void ClientParams::setClipboardCaps(rdr::U32 flags, const rdr::U32* lengths)
 {
   int i, num;

--- a/common/rfb/ClientParams.h
+++ b/common/rfb/ClientParams.h
@@ -85,6 +85,7 @@ namespace rfb {
     void setLEDState(unsigned int state);
 
     rdr::U32 clipboardFlags() const { return clipFlags; }
+    rdr::U32 clipboardSize(unsigned int format) const;
     void setClipboardCaps(rdr::U32 flags, const rdr::U32* lengths);
 
     // Wrappers to check for functionality rather than specific

--- a/common/rfb/SConnection.cxx
+++ b/common/rfb/SConnection.cxx
@@ -327,10 +327,14 @@ void SConnection::clientCutText(const char* str)
 
 void SConnection::handleClipboardRequest(rdr::U32 flags)
 {
-  if (!(flags & rfb::clipboardUTF8))
+  if (!(flags & rfb::clipboardUTF8)) {
+    vlog.debug("Ignoring clipboard request for unsupported formats 0x%x", flags);
     return;
-  if (!hasLocalClipboard)
+  }
+  if (!hasLocalClipboard) {
+    vlog.debug("Ignoring unexpected clipboard request");
     return;
+  }
   handleClipboardRequest();
 }
 
@@ -357,8 +361,10 @@ void SConnection::handleClipboardProvide(rdr::U32 flags,
                                          const size_t* lengths,
                                          const rdr::U8* const* data)
 {
-  if (!(flags & rfb::clipboardUTF8))
+  if (!(flags & rfb::clipboardUTF8)) {
+    vlog.debug("Ignoring clipboard provide with unsupported formats 0x%x", flags);
     return;
+  }
 
   strFree(clientClipboard);
   clientClipboard = NULL;

--- a/common/rfb/SConnection.cxx
+++ b/common/rfb/SConnection.cxx
@@ -315,6 +315,8 @@ void SConnection::setEncodings(int nEncodings, const rdr::S32* encodings)
 
 void SConnection::clientCutText(const char* str)
 {
+  hasLocalClipboard = false;
+
   strFree(clientClipboard);
   clientClipboard = NULL;
 
@@ -343,10 +345,12 @@ void SConnection::handleClipboardNotify(rdr::U32 flags)
   strFree(clientClipboard);
   clientClipboard = NULL;
 
-  if (flags & rfb::clipboardUTF8)
+  if (flags & rfb::clipboardUTF8) {
+    hasLocalClipboard = false;
     handleClipboardAnnounce(true);
-  else
+  } else {
     handleClipboardAnnounce(false);
+  }
 }
 
 void SConnection::handleClipboardProvide(rdr::U32 flags,
@@ -361,6 +365,7 @@ void SConnection::handleClipboardProvide(rdr::U32 flags,
 
   clientClipboard = convertLF((const char*)data[0], lengths[0]);
 
+  // FIXME: Should probably verify that this data was actually requested
   handleClipboardData(clientClipboard);
 }
 

--- a/common/rfb/SConnection.cxx
+++ b/common/rfb/SConnection.cxx
@@ -334,10 +334,8 @@ void SConnection::handleClipboardRequest(rdr::U32 flags)
 
 void SConnection::handleClipboardPeek(rdr::U32 flags)
 {
-  if (!hasLocalClipboard)
-    return;
   if (client.clipboardFlags() & rfb::clipboardNotify)
-    writer()->writeClipboardNotify(rfb::clipboardUTF8);
+    writer()->writeClipboardNotify(hasLocalClipboard ? rfb::clipboardUTF8 : 0);
 }
 
 void SConnection::handleClipboardNotify(rdr::U32 flags)

--- a/common/rfb/SConnection.h
+++ b/common/rfb/SConnection.h
@@ -255,6 +255,7 @@ namespace rfb {
 
     char* clientClipboard;
     bool hasLocalClipboard;
+    bool unsolicitedClipboardAttempt;
   };
 }
 #endif

--- a/common/rfb/SMsgHandler.cxx
+++ b/common/rfb/SMsgHandler.cxx
@@ -17,11 +17,15 @@
  * USA.
  */
 #include <rfb/Exception.h>
+#include <rfb/LogWriter.h>
 #include <rfb/SMsgHandler.h>
 #include <rfb/ScreenSet.h>
+#include <rfb/clipboardTypes.h>
 #include <rfb/encodings.h>
 
 using namespace rfb;
+
+static LogWriter vlog("SMsgHandler");
 
 SMsgHandler::SMsgHandler()
 {
@@ -66,6 +70,46 @@ void SMsgHandler::setEncodings(int nEncodings, const rdr::S32* encodings)
 
 void SMsgHandler::handleClipboardCaps(rdr::U32 flags, const rdr::U32* lengths)
 {
+  int i;
+
+  vlog.debug("Got client clipboard capabilities:");
+  for (i = 0;i < 16;i++) {
+    if (flags & (1 << i)) {
+      const char *type;
+
+      switch (1 << i) {
+        case clipboardUTF8:
+          type = "Plain text";
+          break;
+        case clipboardRTF:
+          type = "Rich text";
+          break;
+        case clipboardHTML:
+          type = "HTML";
+          break;
+        case clipboardDIB:
+          type = "Images";
+          break;
+        case clipboardFiles:
+          type = "Files";
+          break;
+        default:
+          vlog.debug("    Unknown format 0x%x", 1 << i);
+          continue;
+      }
+
+      if (lengths[i] == 0)
+        vlog.debug("    %s (only notify)", type);
+      else {
+        char bytes[1024];
+
+        iecPrefix(lengths[i], "B", bytes, sizeof(bytes));
+        vlog.debug("    %s (automatically send up to %s)",
+                   type, bytes);
+      }
+    }
+  }
+
   client.setClipboardCaps(flags, lengths);
 }
 

--- a/common/rfb/ServerParams.cxx
+++ b/common/rfb/ServerParams.cxx
@@ -87,6 +87,18 @@ void ServerParams::setLEDState(unsigned int state)
   ledState_ = state;
 }
 
+rdr::U32 ServerParams::clipboardSize(unsigned int format) const
+{
+  int i;
+
+  for (i = 0;i < 16;i++) {
+    if (((unsigned)1 << i) == format)
+      return clipSizes[i];
+  }
+
+  throw Exception("Invalid clipboard format 0x%x", format);
+}
+
 void ServerParams::setClipboardCaps(rdr::U32 flags, const rdr::U32* lengths)
 {
   int i, num;

--- a/common/rfb/ServerParams.h
+++ b/common/rfb/ServerParams.h
@@ -70,6 +70,7 @@ namespace rfb {
     void setLEDState(unsigned int state);
 
     rdr::U32 clipboardFlags() const { return clipFlags; }
+    rdr::U32 clipboardSize(unsigned int format) const;
     void setClipboardCaps(rdr::U32 flags, const rdr::U32* lengths);
 
     bool supportsQEMUKeyEvent;

--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -169,7 +169,7 @@ void VNCServerST::removeSocket(network::Socket* sock) {
       if (pointerClient == *ci)
         pointerClient = NULL;
       if (clipboardClient == *ci)
-        clipboardClient = NULL;
+        handleClipboardAnnounce(*ci, false);
       clipboardRequestors.remove(*ci);
 
       // - Delete the per-Socket resources

--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -515,8 +515,10 @@ void VNCServerST::handleClipboardAnnounce(VNCSConnectionST* client,
 void VNCServerST::handleClipboardData(VNCSConnectionST* client,
                                       const char* data)
 {
-  if (client != clipboardClient)
+  if (client != clipboardClient) {
+    slog.debug("Ignoring unexpected clipboard data");
     return;
+  }
   desktop->handleClipboardData(data);
 }
 

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -291,12 +291,8 @@ void Viewport::handleClipboardAnnounce(bool available)
   if (!acceptClipboard)
     return;
 
-  if (available)
-    vlog.debug("Got notification of new clipboard on server");
-  else
-    vlog.debug("Clipboard is no longer available on server");
-
   if (!available) {
+    vlog.debug("Clipboard is no longer available on server");
     pendingServerClipboard = false;
     return;
   }
@@ -304,10 +300,12 @@ void Viewport::handleClipboardAnnounce(bool available)
   pendingClientClipboard = false;
 
   if (!hasFocus()) {
+    vlog.debug("Got notification of new clipboard on server whilst not focused, will request data later");
     pendingServerClipboard = true;
     return;
   }
 
+  vlog.debug("Got notification of new clipboard on server, requesting data");
   cc->requestClipboard();
 }
 
@@ -759,12 +757,14 @@ void Viewport::handleClipboardChange(int source, void *data)
   self->pendingServerClipboard = false;
 
   if (!self->hasFocus()) {
+    vlog.debug("Local clipboard changed whilst not focused, will notify server later");
     self->pendingClientClipboard = true;
     // Clear any older client clipboard from the server
     self->cc->announceClipboard(false);
     return;
   }
 
+  vlog.debug("Local clipboard changed, notifying server");
   try {
     self->cc->announceClipboard(true);
   } catch (rdr::Exception& e) {
@@ -777,6 +777,7 @@ void Viewport::handleClipboardChange(int source, void *data)
 void Viewport::flushPendingClipboard()
 {
   if (pendingServerClipboard) {
+    vlog.debug("Focus regained after remote clipboard change, requesting data");
     try {
       cc->requestClipboard();
     } catch (rdr::Exception& e) {
@@ -785,6 +786,7 @@ void Viewport::flushPendingClipboard()
     }
   }
   if (pendingClientClipboard) {
+    vlog.debug("Focus regained after local clipboard change, notifying server");
     try {
       cc->announceClipboard(true);
     } catch (rdr::Exception& e) {


### PR DESCRIPTION
The extended clipboard protocol has the ability for the peer to request things to be sent automatically, without a request message. Make sure we honor such settings.
