### PR TITLE
Xvnc: Added the ability to listen on both a Unix socket and TCP port.

### DIFF
--- a/unix/x0vncserver/x0vncserver.cxx
+++ b/unix/x0vncserver/x0vncserver.cxx
@@ -261,7 +261,9 @@ int main(int argc, char** argv)
     if (rfbunixpath.getValueStr()[0] != '\0') {
       listeners.push_back(new network::UnixListener(rfbunixpath, rfbunixmode));
       vlog.info("Listening on %s (mode %04o)", (const char*)rfbunixpath, (int)rfbunixmode);
-    } else {
+    }
+
+    if ((int)rfbport != -1) {
       if (localhostOnly)
         createLocalTcpListeners(&listeners, (int)rfbport);
       else

--- a/unix/x0vncserver/x0vncserver.man
+++ b/unix/x0vncserver/x0vncserver.man
@@ -55,7 +55,8 @@ DISPLAY environment variable.
 .B \-rfbport \fIport\fP
 Specifies the TCP port on which x0vncserver listens for connections from
 viewers (the protocol used in VNC is called RFB - "remote framebuffer").
-The default port is 5900.
+The default port is 5900. Listening on TCP port can be disabled with
+-\frfbport\fP=-1.
 .
 .TP
 .B \-UseIPv4
@@ -68,7 +69,7 @@ Use IPv6 for incoming and outgoing connections. Default is on.
 .TP
 .B \-rfbunixpath \fIpath\fP
 Specifies the path of a Unix domain socket on which x0vncserver listens for
-connections from viewers, instead of listening on a TCP port.
+connections from viewers.
 .
 .TP
 .B \-rfbunixmode \fImode\fP

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -78,7 +78,8 @@ Each desktop has a name which may be displayed by the viewer. It defaults to
 .B \-rfbport \fIport\fP
 Specifies the TCP port on which Xvnc listens for connections from viewers (the
 protocol used in VNC is called RFB - "remote framebuffer").  The default is
-5900 plus the display number.
+5900 plus the display number. Listening on TCP port can be disabled with
+-\frfbport\fP=-1.
 .
 .TP
 .B \-UseIPv4
@@ -91,7 +92,7 @@ Use IPv6 for incoming and outgoing connections. Default is on.
 .TP
 .B \-rfbunixpath \fIpath\fP
 Specifies the path of a Unix domain socket on which Xvnc listens for
-connections from viewers, instead of listening on a TCP port.
+connections from viewers.
 .
 .TP
 .B \-rfbunixmode \fImode\fP

--- a/unix/xserver/hw/vnc/vncExtInit.cc
+++ b/unix/xserver/hw/vnc/vncExtInit.cc
@@ -168,13 +168,17 @@ void vncExtensionInit(void)
 
       if (!desktop[scr]) {
         std::list<network::SocketListener*> listeners;
+        bool inetd = false;
         if (scr == 0 && vncInetdSock != -1) {
+          inetd = true;
           if (network::isSocketListening(vncInetdSock))
           {
             listeners.push_back(new network::TcpListener(vncInetdSock));
             vlog.info("inetd wait");
           }
-        } else if (((const char*)rfbunixpath)[0] != '\0') {
+        }
+
+        if (!inetd && ((const char*)rfbunixpath)[0] != '\0') {
           char path[PATH_MAX];
           int mode = (int)rfbunixmode;
 
@@ -189,7 +193,9 @@ void vncExtensionInit(void)
 
           vlog.info("Listening for VNC connections on %s (mode %04o)",
                     path, mode);
-        } else {
+        }
+
+        if (!inetd && rfbport != -1) {
           const char *addr = interface;
           int port = rfbport;
           if (port == 0) port = 5900 + atoi(vncGetDisplay());


### PR DESCRIPTION
Added an option to allow Xvnc to listen on both a Unix socket and TCP port.  When the option is not set, the same behaviour as before is kept (i.e. setting a unix socket path disables listening on TCP port).