### PR TITLE
Support for middle mouse emulation using ALT+leftClick.

### DIFF
--- a/po/tigervnc.pot
+++ b/po/tigervnc.pot
@@ -310,7 +310,11 @@ msgid "View only (ignore mouse and keyboard)"
 msgstr ""
 
 #: vncviewer/OptionsDialog.cxx:726
-msgid "Emulate middle mouse button"
+msgid "Emulate middle mouse button left+right"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:731
+msgid "Emulate middle mouse button ALT+left"
 msgstr ""
 
 #: vncviewer/OptionsDialog.cxx:732

--- a/tests/unit/emulatemb.cxx
+++ b/tests/unit/emulatemb.cxx
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <vector>
+#include <map>
 #include <unistd.h>
 
 #include <rfb/Rect.h>
@@ -33,29 +34,293 @@ static const int right          = 0x04;
 static const int both           = 0x05;
 static const int middleAndRight = 0x06;
 
+#define a_code   0x001e
+#define a_sym    0x0061
+#define cmd_code 0x00db
+#define cmd_sym  0xffe9
+
+#define debug 0
+
 rfb::BoolParameter emulateMiddleButton("dummy_name", "dummy_desc", true);
+rfb::BoolParameter emulateMiddleButtonMod("dummy_name", "dummy_desc", false);
 
 class TestClass : public EmulateMB
 {
 public:
+  TestClass() : EmulateMB(cmd_sym) {printed = 0;}
   virtual void sendPointerEvent(const rfb::Point& pos, int buttonMask);
+  void writeKeyEvent(rdr::U32 keySym, rdr::U32 keyCode, bool down);
 
-  struct PointerEventParams {rfb::Point pos; int mask; };
+  struct PointerEventParams
+  {
+    bool keyEvent;
+    rfb::Point pos;
+    int mask;
+
+    // Middle Button Emulation with Modifier (ALT+Left_click) middle button emulation test code.
+    rdr::U32 keySym;
+    rdr::U32 keyCode;
+    bool down;
+  };
+
+  void handleKeyPress(int keyCode, rdr::U32 keySym);
+  void handleKeyRelease(int keyCode);
+  void filterPointerEvent(const rfb::Point& pos, int buttonMask) {
+    EmulateMB::filterPointerEvent(pos, buttonMask);
+  }
 
   std::vector<PointerEventParams> results;
+  void printResults();
+  int printed;
 };
+
+void TestClass::printResults()
+{
+  for (std::vector<PointerEventParams>::iterator it = results.begin(); it != results.end(); ++it)
+    printf("    sym=%d code=%d down=%s\n", it->keySym, it->keyCode, it->down ? "True" : "False");
+}
 
 void TestClass::sendPointerEvent(const rfb::Point& pos, int buttonMask)
 {
-  PointerEventParams params;
+  PointerEventParams params = {};
+  params.keyEvent = false;
   params.pos = pos;
   params.mask = buttonMask;
+
+  results.push_back(params);
+}
+
+void TestClass::handleKeyPress(int keyCode, rdr::U32 keySym)
+{
+  if (!filterKeyPress(keyCode, keySym))
+    writeKeyEvent(keySym, keyCode, true);
+}
+
+void TestClass::handleKeyRelease(int keyCode)
+{
+  if (!filterKeyRelease(keyCode))
+    writeKeyEvent(0, keyCode, false);
+}
+
+void TestClass::writeKeyEvent(rdr::U32 keySym, rdr::U32 keyCode, bool down)
+{
+  PointerEventParams params = {};
+  params.keyEvent = true;
+  params.keySym = keySym;
+  params.keyCode = keyCode;
+  params.down = down;
+
   results.push_back(params);
 }
 
 #define ASSERT_EQ(expr, val) if ((expr) != (val)) { \
   printf("FAILED on line %d (%s equals %d, expected %d)\n", __LINE__, #expr, (int)(expr), (int)(val)); \
+  test.printResults(); \
   return; \
+}
+
+#define PRESS true
+#define RELEASE false
+
+#define ASSERT_KEY(DOWN, CODE, SYM) do { \
+  ASSERT_EQ(test.results[i].down, DOWN); \
+  ASSERT_EQ(test.results[i].keyCode, CODE); \
+  if ((DOWN) == PRESS) {ASSERT_EQ(test.results[i].keySym, SYM);} \
+  ASSERT_EQ(test.results[i].pos.x, 0); \
+  ASSERT_EQ(test.results[i].pos.y, 0); \
+  ASSERT_EQ(test.results[i].mask, 0); \
+  ++i; \
+} while (0)
+
+#define ASSERT_MOUSE(X, Y, MASK) do { \
+  ASSERT_EQ(test.results[i].pos.x, X); \
+  ASSERT_EQ(test.results[i].pos.y, Y); \
+  ASSERT_EQ(test.results[i].mask, MASK); \
+  ASSERT_EQ(test.results[i].down, 0); \
+  ASSERT_EQ(test.results[i].keyCode, 0); \
+  ASSERT_EQ(test.results[i].keySym, 0); \
+  ++i; \
+} while (0)
+
+// Test press & release of 'a', press & release cmd-a.
+void testMBEMKeyPress(bool enabled)
+{
+  TestClass test;
+
+  printf("%s(%s): ", __func__, enabled ? "Enabled" : "Disabled");
+
+  emulateMiddleButton.setParam(false);
+  emulateMiddleButtonMod.setParam(enabled);
+
+  test.handleKeyPress(a_code, a_sym);
+  test.handleKeyRelease(a_code);
+
+  test.handleKeyPress(cmd_code, cmd_sym);
+  test.handleKeyPress(a_code, a_sym);
+  test.handleKeyRelease(a_code);
+  test.handleKeyRelease(cmd_code);
+
+  ASSERT_EQ(test.results.size(), 6);
+
+  int i = 0;
+  ASSERT_KEY(PRESS,   a_code, a_sym);
+  ASSERT_KEY(RELEASE, a_code, 0);
+
+  ASSERT_KEY(PRESS,   cmd_code, cmd_sym);
+  ASSERT_KEY(PRESS,   a_code, a_sym);
+  ASSERT_KEY(RELEASE, a_code, 0);
+  ASSERT_KEY(RELEASE, cmd_code, 0);
+
+  printf("OK\n");
+}
+
+// Test press + release of modifier
+void testMBEMModifier(bool enabled)
+{
+  TestClass test;
+
+  printf("%s(%s): ", __func__, enabled ? "Enabled" : "Disabled");
+
+  emulateMiddleButton.setParam(false);
+  emulateMiddleButtonMod.setParam(enabled);
+
+  test.handleKeyPress(cmd_code, cmd_sym);
+  test.handleKeyRelease(cmd_code);
+
+  ASSERT_EQ(test.results.size(), 2);
+  int i = 0;
+  ASSERT_KEY(PRESS,   cmd_code, cmd_sym);
+  ASSERT_KEY(RELEASE, cmd_code, 0);
+
+  printf("OK\n");
+}
+
+// Test left click, cmd-left click (emulate middle), cmd-left click out of order (cmd-press, button1-press, cmd-release, button1-release)
+void testMBEMClick()
+{
+  TestClass test;
+
+  printf("%s: ", __func__);
+
+  emulateMiddleButton.setParam(false);
+  emulateMiddleButtonMod.setParam(true);
+
+  test.filterPointerEvent(rfb::Point(0, 10), left);
+  test.filterPointerEvent(rfb::Point(0, 10), empty);
+
+  test.handleKeyPress(cmd_code, cmd_sym);
+  test.filterPointerEvent(rfb::Point(0, 10), left);
+  test.filterPointerEvent(rfb::Point(0, 10), empty);
+  test.handleKeyRelease(cmd_code);
+
+  // Out of order
+  test.handleKeyPress(cmd_code, cmd_sym);
+  test.filterPointerEvent(rfb::Point(0, 10), left);
+  test.handleKeyRelease(cmd_code);
+  test.filterPointerEvent(rfb::Point(0, 10), empty);
+
+  ASSERT_EQ(test.results.size(), 6);
+  int i = 0;
+  ASSERT_MOUSE(0, 10, left);
+  ASSERT_MOUSE(0, 10, empty);
+
+  ASSERT_MOUSE(0, 10, middle);
+  ASSERT_MOUSE(0, 10, empty);
+
+  ASSERT_MOUSE(0, 10, middle);
+  ASSERT_MOUSE(0, 10, empty);
+
+  printf("OK\n");
+}
+
+// Test cmd-press, left-click, a-click, left-click
+void testMBEMKeyAndClick()
+{
+  TestClass test;
+
+  printf("%s: ", __func__);
+
+  emulateMiddleButton.setParam(false);
+  emulateMiddleButtonMod.setParam(true);
+
+  test.handleKeyPress(cmd_code, cmd_sym);
+  test.filterPointerEvent(rfb::Point(0, 10), left);
+  test.filterPointerEvent(rfb::Point(0, 10), empty);
+
+  test.handleKeyPress(a_code, a_sym);
+  test.handleKeyRelease(a_code);
+
+  test.filterPointerEvent(rfb::Point(0, 10), left);
+  test.filterPointerEvent(rfb::Point(0, 10), empty);
+
+  test.handleKeyRelease(cmd_code);
+
+  ASSERT_EQ(test.results.size(), 8);
+  int i = 0;
+  ASSERT_MOUSE(0, 10, middle);
+  ASSERT_MOUSE(0, 10, empty);
+
+  ASSERT_KEY(PRESS,   cmd_code, cmd_sym);
+  ASSERT_KEY(PRESS,   a_code, a_sym);
+  ASSERT_KEY(RELEASE, a_code, 0);
+  ASSERT_KEY(RELEASE, cmd_code, 0);
+
+  ASSERT_MOUSE(0, 10, middle);
+  ASSERT_MOUSE(0, 10, empty);
+
+  printf("OK\n");
+}
+
+// Test modifier-press, button-3, modifier release.
+void testMBEMRightClick()
+{
+  TestClass test;
+
+  printf("%s: ", __func__);
+
+  emulateMiddleButton.setParam(false);
+  emulateMiddleButtonMod.setParam(true);
+
+  test.handleKeyPress(cmd_code, cmd_sym);
+  test.filterPointerEvent(rfb::Point(0, 10), right);
+  test.filterPointerEvent(rfb::Point(0, 10), empty);
+  test.handleKeyRelease(cmd_code);
+
+  ASSERT_EQ(test.results.size(), 4);
+  int i = 0;
+
+  ASSERT_KEY(PRESS,   cmd_code, cmd_sym);
+  ASSERT_MOUSE(0, 10, right);
+  ASSERT_MOUSE(0, 10, empty);
+  ASSERT_KEY(RELEASE, cmd_code, 0);
+
+  printf("OK\n");
+}
+
+void testMBEMMultiClick()
+{
+  TestClass test;
+
+  printf("%s: ", __func__);
+
+  emulateMiddleButton.setParam(false);
+  emulateMiddleButtonMod.setParam(true);
+
+  test.handleKeyPress(cmd_code, cmd_sym);
+  test.filterPointerEvent(rfb::Point(0, 10), left);
+  test.filterPointerEvent(rfb::Point(0, 10), both);
+  test.filterPointerEvent(rfb::Point(0, 10), left);
+  test.filterPointerEvent(rfb::Point(0, 10), empty);
+  test.handleKeyRelease(cmd_code);
+
+  ASSERT_EQ(test.results.size(), 4);
+  int i = 0;
+  ASSERT_MOUSE(0, 10, middle);
+  ASSERT_MOUSE(0, 10, middleAndRight);
+  ASSERT_MOUSE(0, 10, middle);
+  ASSERT_MOUSE(0, 10, empty);
+
+  printf("OK\n");
 }
 
 void testDisabledOption()
@@ -482,6 +747,17 @@ int main(int argc, char** argv)
 
   testDragAndTimeout();
   testDragAndRelease();
+
+  testMBEMKeyPress(false);
+  testMBEMKeyPress(true);
+
+  testMBEMModifier(false);
+  testMBEMModifier(true);
+
+  testMBEMClick();
+  testMBEMKeyAndClick();
+  testMBEMRightClick();
+  testMBEMMultiClick();
 
   return 0;
 }

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -264,6 +264,7 @@ void OptionsDialog::loadOptions(void)
 
   viewOnlyCheckbox->value(viewOnly);
   emulateMBCheckbox->value(emulateMiddleButton);
+  emulateMBModCheckbox->value(emulateMiddleButtonMod);
   acceptClipboardCheckbox->value(acceptClipboard);
 #if !defined(WIN32) && !defined(__APPLE__)
   setPrimaryCheckbox->value(setPrimary);
@@ -389,6 +390,7 @@ void OptionsDialog::storeOptions(void)
   /* Input */
   viewOnly.setParam(viewOnlyCheckbox->value());
   emulateMiddleButton.setParam(emulateMBCheckbox->value());
+  emulateMiddleButtonMod.setParam(emulateMBModCheckbox->value());
   acceptClipboard.setParam(acceptClipboardCheckbox->value());
 #if !defined(WIN32) && !defined(__APPLE__)
   setPrimary.setParam(setPrimaryCheckbox->value());
@@ -723,7 +725,12 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
   emulateMBCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                    CHECK_MIN_WIDTH,
                                                    CHECK_HEIGHT,
-                                                   _("Emulate middle mouse button")));
+                                                   _("Emulate middle mouse button left+right")));
+  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+  emulateMBModCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
+                                                   CHECK_MIN_WIDTH,
+                                                   CHECK_HEIGHT,
+                                                   _("Emulate middle mouse button ALT+left")));
   ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
   acceptClipboardCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -111,6 +111,7 @@ protected:
   /* Input */
   Fl_Check_Button *viewOnlyCheckbox;
   Fl_Check_Button *emulateMBCheckbox;
+  Fl_Check_Button *emulateMBModCheckbox;
   Fl_Check_Button *acceptClipboardCheckbox;
 #if !defined(WIN32) && !defined(__APPLE__)
   Fl_Check_Button *setPrimaryCheckbox;

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -89,6 +89,8 @@ private:
 
   static int handleSystemEvent(void *event, void *data);
 
+  void writeKeyEvent(rdr::U32 keySym, rdr::U32 keyCode, bool down);
+
 #ifdef WIN32
   static void handleAltGrTimeout(void *data);
   void resolveAltGrDetection(bool isAltGrSequence);

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -61,6 +61,10 @@ BoolParameter emulateMiddleButton("EmulateMiddleButton",
                                   "Emulate middle mouse button by pressing "
                                   "left and right mouse buttons simultaneously",
                                   false);
+BoolParameter emulateMiddleButtonMod("EmulateMiddleButtonMod",
+                                  "Emulate middle mouse button by pressing "
+                                  "ALT (command on MAC) and left mouse buttons simultaneously",
+                                  false);
 BoolParameter dotWhenNoCursor("DotWhenNoCursor",
                               "Show the dot cursor when the server sends an "
                               "invisible cursor", false);
@@ -176,6 +180,7 @@ static VoidParameter* parameterArray[] = {
 #endif // HAVE_GNUTLS
   &SecurityClient::secTypes,
   &emulateMiddleButton,
+  &emulateMiddleButtonMod,
   &dotWhenNoCursor,
   &reconnectOnError,
   &autoSelect,

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -33,6 +33,7 @@
 
 extern rfb::IntParameter pointerEventInterval;
 extern rfb::BoolParameter emulateMiddleButton;
+extern rfb::BoolParameter emulateMiddleButtonMod;
 extern rfb::BoolParameter dotWhenNoCursor;
 
 extern rfb::StringParameter passwordFile;

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -295,6 +295,11 @@ Emulate middle mouse button by pressing left and right mouse buttons
 simultaneously. Default is off.
 .
 .TP
+.B \-EmulateMiddleButtonMod
+Emulate middle mouse button by pressing ALT (Command on MAC) and left mouse button
+simultaneously. Default is off.
+.
+.TP
 .B \-Log \fIlogname\fP:\fIdest\fP:\fIlevel\fP
 Configures the debug log settings.  \fIdest\fP can currently be \fBstderr\fP or
 \fBstdout\fP, and \fIlevel\fP is between 0 and 100, 100 meaning most verbose


### PR DESCRIPTION
Useful for MacBook and other touchpads where it's hard or impossible
to press the left and right buttons simultameously