### PR TITLE
Add "High Resolution" mode for OSX

### DIFF
--- a/release/Info.plist.in
+++ b/release/Info.plist.in
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>TigerVNC Viewer</string>
 	<key>NSHighResolutionCapable</key>
-	<string>False</string>
+	<string>True</string>
 	<key>CFBundleGetInfoString</key>
 	<string>@VERSION@, Copyright © 1998-2021 [many holders]</string>
 	<key>CFBundleIconFile</key>

--- a/vncviewer/Surface_OSX.cxx
+++ b/vncviewer/Surface_OSX.cxx
@@ -87,10 +87,13 @@ static void render(CGContextRef gc, CGColorSpaceRef lut,
   CGContextSetBlendMode(gc, mode);
   CGContextSetAlpha(gc, alpha);
 
-  rect.origin.x = x;
-  rect.origin.y = y;
-  rect.size.width = w;
-  rect.size.height = h;
+  // adjust rect with cocoa scale factor to support HiDPI
+  const double scale_factor = cocoa_get_scale_factor();
+
+  rect.origin.x = x * scale_factor;
+  rect.origin.y = y * scale_factor;
+  rect.size.width = w * scale_factor;
+  rect.size.height = h * scale_factor;
 
   CGContextDrawImage(gc, rect, subimage);
 

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -42,4 +42,6 @@ int cocoa_set_num_lock_state(bool on);
 int cocoa_get_caps_lock_state(bool *on);
 int cocoa_get_num_lock_state(bool *on);
 
+double cocoa_get_scale_factor();
+
 #endif

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -500,3 +500,7 @@ int cocoa_get_num_lock_state(bool *on)
 {
   return cocoa_get_modifier_lock_state(kIOHIDNumLockState, on);
 }
+
+double cocoa_get_scale_factor(){
+    return [[NSScreen mainScreen] backingScaleFactor];
+}


### PR DESCRIPTION
Fixes #878 

This commit fixes the HiDPI incompatibility of vncviewer on OSX. 

Now the sizes of the render images are multiplied by the backingScaleFactor and can be displayed normally on the screen: https://developer.apple.com/documentation/appkit/nsscreen/1388385-backingscalefactor?language=objc

# Before
## NSHighResolutionCapable: False
![image](https://user-images.githubusercontent.com/43196707/107855040-1fe9eb80-6dee-11eb-9c83-519099ba1143.png)
## NSHighResolutionCapable: True
![image](https://user-images.githubusercontent.com/43196707/107854126-e2825f80-6de7-11eb-8edb-47d25b08f532.png)

# After:
## NSHighResolutionCapable: True
![image](https://user-images.githubusercontent.com/43196707/107855005-ca154380-6ded-11eb-900a-822c048eea56.png)
## NSHighResolutionCapable: True
![image](https://user-images.githubusercontent.com/43196707/107854129-eada9a80-6de7-11eb-9d67-a3f212a083a6.png)

# Known Issues:
The vncviewer viewport sizes are not committed to the server at launch, and the control still mismatches with the image in the beginning. The user will need to either specify "-Maximize" in the arguments, or manually resize the viewer after launching the viewer. This issue is no longer observed when I compile the viewer with FLTK 1.4.0:
https://www.fltk.org/doc-1.4/drawing.html#ssect_DrawingUnit:~:text=DPI%2Dindependent

(Sorry this is my first time submitting a pull request. It will be great if you can point out anything inappropriate. Thanks in advance!)