### PR TITLE
Support the VMware Cursor Position extension on vncviewer 

### DIFF
--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -43,8 +43,8 @@ static LogWriter vlog("CConnection");
 
 CConnection::CConnection()
   : csecurity(0),
-    supportsLocalCursor(false), supportsDesktopResize(false),
-    supportsLEDState(false),
+    supportsLocalCursor(false), supportsCursorPosition(false),
+    supportsDesktopResize(false), supportsLEDState(false),
     is(0), os(0), reader_(0), writer_(0),
     shared(false),
     state_(RFBSTATE_UNINITIALISED),
@@ -804,6 +804,9 @@ void CConnection::updateEncodings()
     encodings.push_back(pseudoEncodingVMwareCursor);
     encodings.push_back(pseudoEncodingCursor);
     encodings.push_back(pseudoEncodingXCursor);
+  }
+  if (supportsCursorPosition) {
+    encodings.push_back(pseudoEncodingVMwareCursorPosition);
   }
   if (supportsDesktopResize) {
     encodings.push_back(pseudoEncodingDesktopSize);

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -239,6 +239,7 @@ namespace rfb {
     // Optional capabilities that a subclass is expected to set to true
     // if supported
     bool supportsLocalCursor;
+    bool supportsCursorPosition;
     bool supportsDesktopResize;
     bool supportsLEDState;
 

--- a/common/rfb/CMsgHandler.h
+++ b/common/rfb/CMsgHandler.h
@@ -52,6 +52,7 @@ namespace rfb {
                                         const ScreenSet& layout);
     virtual void setCursor(int width, int height, const Point& hotspot,
                            const rdr::U8* data) = 0;
+    virtual void setCursorPos(const Point& pos) = 0;
     virtual void setPixelFormat(const PixelFormat& pf);
     virtual void setName(const char* name);
     virtual void fence(rdr::U32 flags, unsigned len, const char data[]);

--- a/common/rfb/CMsgReader.cxx
+++ b/common/rfb/CMsgReader.cxx
@@ -165,6 +165,10 @@ bool CMsgReader::readMsg()
     case pseudoEncodingVMwareCursor:
       ret = readSetVMwareCursor(dataRect.width(), dataRect.height(), dataRect.tl);
       break;
+    case pseudoEncodingVMwareCursorPosition:
+      handler->setCursorPos(dataRect.tl);
+      ret = true;
+      break;
     case pseudoEncodingDesktopName:
       ret = readSetDesktopName(dataRect.tl.x, dataRect.tl.y,
                                dataRect.width(), dataRect.height());

--- a/common/rfb/ClientParams.cxx
+++ b/common/rfb/ClientParams.cxx
@@ -30,7 +30,7 @@ ClientParams::ClientParams()
     compressLevel(2), qualityLevel(-1), fineQualityLevel(-1),
     subsampling(subsampleUndefined),
     width_(0), height_(0), name_(0),
-    ledState_(ledUnknown)
+    cursorPos_(0, 0), ledState_(ledUnknown)
 {
   setName("");
 
@@ -83,6 +83,11 @@ void ClientParams::setCursor(const Cursor& other)
 {
   delete cursor_;
   cursor_ = new Cursor(other);
+}
+
+void ClientParams::setCursorPos(const Point& pos)
+{
+  cursorPos_ = pos;
 }
 
 bool ClientParams::supportsEncoding(rdr::S32 encoding) const
@@ -178,6 +183,13 @@ bool ClientParams::supportsLocalCursor() const
   if (supportsEncoding(pseudoEncodingCursor))
     return true;
   if (supportsEncoding(pseudoEncodingXCursor))
+    return true;
+  return false;
+}
+
+bool ClientParams::supportsCursorPosition() const
+{
+  if (supportsEncoding(pseudoEncodingVMwareCursorPosition))
     return true;
   return false;
 }

--- a/common/rfb/ClientParams.h
+++ b/common/rfb/ClientParams.h
@@ -77,6 +77,9 @@ namespace rfb {
     const Cursor& cursor() const { return *cursor_; }
     void setCursor(const Cursor& cursor);
 
+    const Point& cursorPos() const { return cursorPos_; }
+    void setCursorPos(const Point& pos);
+
     bool supportsEncoding(rdr::S32 encoding) const;
 
     void setEncodings(int nEncodings, const rdr::S32* encodings);
@@ -91,6 +94,7 @@ namespace rfb {
     // Wrappers to check for functionality rather than specific
     // encodings
     bool supportsLocalCursor() const;
+    bool supportsCursorPosition() const;
     bool supportsDesktopSize() const;
     bool supportsLEDState() const;
     bool supportsFence() const;
@@ -110,6 +114,7 @@ namespace rfb {
     PixelFormat pf_;
     char* name_;
     Cursor* cursor_;
+    Point cursorPos_;
     std::set<rdr::S32> encodings_;
     unsigned int ledState_;
     rdr::U32 clipFlags;

--- a/common/rfb/encodings.h
+++ b/common/rfb/encodings.h
@@ -61,6 +61,7 @@ namespace rfb {
 
   // VMware-specific
   const int pseudoEncodingVMwareCursor = 0x574d5664;
+  const int pseudoEncodingVMwareCursorPosition = 0x574d5666;
   const int pseudoEncodingVMwareLEDState = 0x574d5668;
 
   // UltraVNC-specific

--- a/tests/perf/decperf.cxx
+++ b/tests/perf/decperf.cxx
@@ -66,6 +66,7 @@ public:
   virtual void initDone();
   virtual void setPixelFormat(const rfb::PixelFormat& pf);
   virtual void setCursor(int, int, const rfb::Point&, const rdr::U8*);
+  virtual void setCursorPos(const rfb::Point&);
   virtual void framebufferUpdateStart();
   virtual void framebufferUpdateEnd();
   virtual void setColourMapEntries(int, int, rdr::U16*);
@@ -141,6 +142,10 @@ void CConn::setPixelFormat(const rfb::PixelFormat& pf)
 }
 
 void CConn::setCursor(int, int, const rfb::Point&, const rdr::U8*)
+{
+}
+
+void CConn::setCursorPos(const rfb::Point&)
 {
 }
 

--- a/tests/perf/encperf.cxx
+++ b/tests/perf/encperf.cxx
@@ -95,6 +95,7 @@ public:
   virtual void initDone() {};
   virtual void resizeFramebuffer();
   virtual void setCursor(int, int, const rfb::Point&, const rdr::U8*);
+  virtual void setCursorPos(const rfb::Point&);
   virtual void framebufferUpdateStart();
   virtual void framebufferUpdateEnd();
   virtual bool dataRect(const rfb::Rect&, int);
@@ -213,6 +214,10 @@ void CConn::resizeFramebuffer()
 }
 
 void CConn::setCursor(int, int, const rfb::Point&, const rdr::U8*)
+{
+}
+
+void CConn::setCursorPos(const rfb::Point&)
 {
 }
 

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -84,6 +84,7 @@ CConn::CConn(const char* vncServerName, network::Socket* socket=NULL)
   sock = socket;
 
   supportsLocalCursor = true;
+  supportsCursorPosition = true;
   supportsDesktopResize = true;
   supportsLEDState = false;
 
@@ -428,6 +429,11 @@ void CConn::setCursor(int width, int height, const Point& hotspot,
                       const rdr::U8* data)
 {
   desktop->setCursor(width, height, hotspot, data);
+}
+
+void CConn::setCursorPos(const Point& pos)
+{
+  desktop->setCursorPos(pos);
 }
 
 void CConn::fence(rdr::U32 flags, unsigned len, const char data[])

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -63,6 +63,7 @@ public:
 
   void setCursor(int width, int height, const rfb::Point& hotspot,
                  const rdr::U8* data);
+  void setCursorPos(const rfb::Point& pos);
 
   void fence(rdr::U32 flags, unsigned len, const char data[]);
 

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -66,6 +66,9 @@ public:
   void setCursor(int width, int height, const rfb::Point& hotspot,
                  const rdr::U8* data);
 
+  // Server-provided cursor position
+  void setCursorPos(const rfb::Point& pos);
+
   // Change client LED state
   void setLEDState(unsigned int state);
 


### PR DESCRIPTION
This change makes it possible for re-synchronizing the remote cursor on
the vncviewer when in fullscreen mode. This is done by locally moving
the cursor position to what the server thinks it should be.

Now SDL games should work!