### PR TITLE
Handle keys reported only by KeyEvent.getExtendedKeyCode

### DIFF
--- a/java/com/tigervnc/vncviewer/KeyMap.java
+++ b/java/com/tigervnc/vncviewer/KeyMap.java
@@ -161,7 +161,7 @@ public class KeyMap {
 
   public static int vkey_to_keysym(KeyEvent ev)
   {
-    int keyCode = ev.getKeyCode();
+    int keyCode = ev.getExtendedKeyCode();
 
     // Start with keys that either don't generate a symbol, or
     // generate the same symbol as some other key.

--- a/java/com/tigervnc/vncviewer/KeyMap.java
+++ b/java/com/tigervnc/vncviewer/KeyMap.java
@@ -161,7 +161,7 @@ public class KeyMap {
 
   public static int vkey_to_keysym(KeyEvent ev)
   {
-    int keyCode = ev.getExtendedKeyCode();
+    int keyCode = get_keycode_fallback_extended(ev);
 
     // Start with keys that either don't generate a symbol, or
     // generate the same symbol as some other key.
@@ -215,6 +215,11 @@ public class KeyMap {
       return Keysym2ucs.ucs2keysym(ucs);
 
     return NoSymbol;
+  }
+
+  public static int get_keycode_fallback_extended(final KeyEvent ev) {
+    final int keyCode = ev.getKeyCode();
+    return (keyCode == 0) ? ev.getExtendedKeyCode() : keyCode;
   }
 
   private static int vk_to_ascii(int vk, boolean shift) {

--- a/java/com/tigervnc/vncviewer/PasswdDialog.java
+++ b/java/com/tigervnc/vncviewer/PasswdDialog.java
@@ -96,12 +96,12 @@ class PasswdDialog extends Dialog implements UserInfo,
   public void keyPressed(KeyEvent event) {
     Object s = event.getSource();
     if (s instanceof JTextField && (JTextField)s == userEntry) {
-       if (event.getKeyCode() == KeyEvent.VK_ENTER) {
+       if (event.getExtendedKeyCode() == KeyEvent.VK_ENTER) {
          endDialog();
         }
     } else if (s instanceof JPasswordField
               && (JPasswordField)s == passwdEntry) {
-        if (event.getKeyCode() == KeyEvent.VK_ENTER) {
+        if (event.getExtendedKeyCode() == KeyEvent.VK_ENTER) {
          endDialog();
         }
     }

--- a/java/com/tigervnc/vncviewer/PasswdDialog.java
+++ b/java/com/tigervnc/vncviewer/PasswdDialog.java
@@ -96,12 +96,12 @@ class PasswdDialog extends Dialog implements UserInfo,
   public void keyPressed(KeyEvent event) {
     Object s = event.getSource();
     if (s instanceof JTextField && (JTextField)s == userEntry) {
-       if (event.getExtendedKeyCode() == KeyEvent.VK_ENTER) {
+       if (KeyMap.get_keycode_fallback_extended(event) == KeyEvent.VK_ENTER) {
          endDialog();
         }
     } else if (s instanceof JPasswordField
               && (JPasswordField)s == passwdEntry) {
-        if (event.getExtendedKeyCode() == KeyEvent.VK_ENTER) {
+        if (KeyMap.get_keycode_fallback_extended(event) == KeyEvent.VK_ENTER) {
          endDialog();
         }
     }

--- a/java/com/tigervnc/vncviewer/ServerDialog.java
+++ b/java/com/tigervnc/vncviewer/ServerDialog.java
@@ -87,7 +87,7 @@ class ServerDialog extends Dialog implements Runnable {
       public void keyTyped(KeyEvent e) {}
       public void keyReleased(KeyEvent e) {}
       public void keyPressed(KeyEvent e) {
-        if (e.getExtendedKeyCode() == KeyEvent.VK_ENTER) {
+        if (KeyMap.get_keycode_fallback_extended(e) == KeyEvent.VK_ENTER) {
           serverName.insertItemAt(editor.getItem(), 0);
           serverName.setSelectedIndex(0);
           handleConnect();

--- a/java/com/tigervnc/vncviewer/ServerDialog.java
+++ b/java/com/tigervnc/vncviewer/ServerDialog.java
@@ -87,7 +87,7 @@ class ServerDialog extends Dialog implements Runnable {
       public void keyTyped(KeyEvent e) {}
       public void keyReleased(KeyEvent e) {}
       public void keyPressed(KeyEvent e) {
-        if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+        if (e.getExtendedKeyCode() == KeyEvent.VK_ENTER) {
           serverName.insertItemAt(editor.getItem(), 0);
           serverName.setSelectedIndex(0);
           handleConnect();

--- a/java/com/tigervnc/vncviewer/Viewport.java
+++ b/java/com/tigervnc/vncviewer/Viewport.java
@@ -507,7 +507,7 @@ class Viewport extends JPanel implements ActionListener {
 
     if (event instanceof KeyEvent) {
       KeyEvent ev = (KeyEvent)event;
-      if (ev.getExtendedKeyCode() == 0) {
+      if (KeyMap.get_keycode_fallback_extended(ev) == 0) {
         // Not much we can do with this...
         vlog.debug("Ignoring KeyEvent with unknown Java keycode");
         return 0;
@@ -518,7 +518,7 @@ class Viewport extends JPanel implements ActionListener {
         // out the proper one.  Java virtual key codes aren't unique 
         // between left/right versions of keys, so we can't use them as
         // indexes to the downKeySym map.
-        long keyCode = ev.getExtendedKeyCode() | ((long)ev.getKeyLocation()<<32);
+        long keyCode = KeyMap.get_keycode_fallback_extended(ev) | ((long)ev.getKeyLocation()<<32);
 
         // Pressing Ctrl wreaks havoc with the symbol lookup, so turn
         // that off. But AltGr shows up as Ctrl_L+Alt_R in Windows, so
@@ -532,9 +532,9 @@ class Viewport extends JPanel implements ActionListener {
             mask &= ~ALT_MASK;
             mask |= ALT_GRAPH_MASK;
             AWTKeyStroke ks =
-              AWTKeyStroke.getAWTKeyStroke(ev.getExtendedKeyCode(), mask);
+              AWTKeyStroke.getAWTKeyStroke(KeyMap.get_keycode_fallback_extended(ev), mask);
             ev = new KeyEvent((JComponent)ev.getSource(), ev.getID(),
-                              ev.getWhen(), mask, ev.getExtendedKeyCode(),
+                              ev.getWhen(), mask, KeyMap.get_keycode_fallback_extended(ev),
                               ks.getKeyChar(), ev.getKeyLocation());
           }
         }
@@ -574,7 +574,7 @@ class Viewport extends JPanel implements ActionListener {
 
         return 1;
       } else if (ev.getID() == KeyEvent.KEY_RELEASED) {
-        long keyCode = ev.getExtendedKeyCode() | ((long)ev.getKeyLocation()<<32);
+        long keyCode = KeyMap.get_keycode_fallback_extended(ev) | ((long)ev.getKeyLocation()<<32);
         handleKeyRelease(keyCode);
         return 1;
       }

--- a/java/com/tigervnc/vncviewer/Viewport.java
+++ b/java/com/tigervnc/vncviewer/Viewport.java
@@ -377,7 +377,7 @@ class Viewport extends JPanel implements ActionListener {
     }
   }
 
-  public void handleKeyPress(int keyCode, int keySym)
+  public void handleKeyPress(long keyCode, int keySym)
   {
     // Prevent recursion if the menu wants to send it's own
     // activation key.
@@ -443,11 +443,11 @@ class Viewport extends JPanel implements ActionListener {
     // and send the same on release.
     downKeySym.put(keyCode, keySym);
 
-    vlog.debug("Key pressed: 0x%04x => 0x%04x", keyCode, keySym);
+    vlog.debug("Key pressed: 0x%016x => 0x%04x", keyCode, keySym);
 
     try {
       // Fake keycode?
-      if (keyCode > 0xffff)
+      if (keyCode > 0xffffffffL)
         cc.writer().writeKeyEvent(keySym, true);
       else
         cc.writer().writeKeyEvent(keySym, true);
@@ -472,7 +472,7 @@ class Viewport extends JPanel implements ActionListener {
     }
   }
 
-  public void handleKeyRelease(int keyCode)
+  public void handleKeyRelease(long keyCode)
   {
     Integer iter;
 
@@ -487,10 +487,10 @@ class Viewport extends JPanel implements ActionListener {
       return;
     }
 
-    vlog.debug("Key released: 0x%04x => 0x%04x", keyCode, iter);
+    vlog.debug("Key released: 0x%016x => 0x%04x", keyCode, iter);
 
     try {
-      if (keyCode > 0xffff)
+      if (keyCode > 0xffffffffL)
         cc.writer().writeKeyEvent(iter, false);
       else
         cc.writer().writeKeyEvent(iter, false);
@@ -507,7 +507,7 @@ class Viewport extends JPanel implements ActionListener {
 
     if (event instanceof KeyEvent) {
       KeyEvent ev = (KeyEvent)event;
-      if (ev.getKeyCode() == 0) {
+      if (ev.getExtendedKeyCode() == 0) {
         // Not much we can do with this...
         vlog.debug("Ignoring KeyEvent with unknown Java keycode");
         return 0;
@@ -517,10 +517,8 @@ class Viewport extends JPanel implements ActionListener {
         // Generate a fake keycode just for tracking if we can't figure
         // out the proper one.  Java virtual key codes aren't unique 
         // between left/right versions of keys, so we can't use them as
-        // indexes to the downKeySym map. There should not be any key 
-        // codes > 0xFFFF so we can use the high nibble to make a unique
-        // pseudo-key code.
-        int keyCode = ev.getKeyCode() | ev.getKeyLocation()<<16;
+        // indexes to the downKeySym map.
+        long keyCode = ev.getExtendedKeyCode() | ((long)ev.getKeyLocation()<<32);
 
         // Pressing Ctrl wreaks havoc with the symbol lookup, so turn
         // that off. But AltGr shows up as Ctrl_L+Alt_R in Windows, so
@@ -534,9 +532,9 @@ class Viewport extends JPanel implements ActionListener {
             mask &= ~ALT_MASK;
             mask |= ALT_GRAPH_MASK;
             AWTKeyStroke ks =
-              AWTKeyStroke.getAWTKeyStroke(ev.getKeyCode(), mask);
+              AWTKeyStroke.getAWTKeyStroke(ev.getExtendedKeyCode(), mask);
             ev = new KeyEvent((JComponent)ev.getSource(), ev.getID(),
-                              ev.getWhen(), mask, ev.getKeyCode(),
+                              ev.getWhen(), mask, ev.getExtendedKeyCode(),
                               ks.getKeyChar(), ev.getKeyLocation());
           }
         }
@@ -544,7 +542,7 @@ class Viewport extends JPanel implements ActionListener {
         int keySym = KeyMap.vkey_to_keysym(ev);
 
         if (keySym == KeyMap.NoSymbol)
-          vlog.error("No symbol for virtual key 0x%02x", keyCode);
+          vlog.error("No symbol for virtual key 0x%016x", keyCode);
 
         if (VncViewer.os.startsWith("linux")) {
           switch (keySym) {
@@ -576,7 +574,7 @@ class Viewport extends JPanel implements ActionListener {
 
         return 1;
       } else if (ev.getID() == KeyEvent.KEY_RELEASED) {
-        int keyCode = keyCode = ev.getKeyCode() | ev.getKeyLocation()<<16;
+        long keyCode = ev.getExtendedKeyCode() | ((long)ev.getKeyLocation()<<32);
         handleKeyRelease(keyCode);
         return 1;
       }
@@ -805,7 +803,7 @@ class Viewport extends JPanel implements ActionListener {
   Point lastPointerPos = new Point(0, 0);
   int lastButtonMask = 0;
 
-  private class DownMap extends HashMap<Integer, Integer> {
+  private class DownMap extends HashMap<Long, Integer> {
     public DownMap(int capacity) {
       super(capacity);
     }


### PR DESCRIPTION
I tried to come up with a patch for #1239.

Basically it replaces calls to `KeyEvent.getKeyCode` with calls to `KeyEvent.getExtendedKeyCode`.
However, this change breaks the assumption that keycodes can't be larger than 65535. At least when using my local JRE, keys corresponding to accented characters have keycodes much bigger. To work around this, the combined "fake" keycode has been extended to a `long`.

As far as my local testing is concerned, it seems to work well with my Italian layout. I also performed basic tests using a US keymap and it also seems to work.