### PR TITLE
Fix viewer crash when cursor has not been set

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -277,7 +277,7 @@ void Viewport::setCursor(int width, int height, const Point& hotspot,
     }
   }
 
-  if (Fl::belowmouse() == this)
+  if (Fl::belowmouse() == this && cursor)
     window()->cursor(cursor, cursorHotspot.x, cursorHotspot.y);
 }
 


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1038701. This is a patch we have been carrying for a while and it would be probably better to get it upstreamed. Just note I'm not the original author.