### PR TITLE
Let user know that a view-only password is not used

### DIFF
--- a/unix/vncpasswd/vncpasswd.cxx
+++ b/unix/vncpasswd/vncpasswd.cxx
@@ -160,6 +160,8 @@ int main(int argc, char** argv)
     char yesno[3];
     if (fgets(yesno, 3, stdin) != NULL && (yesno[0] == 'y' || yesno[0] == 'Y')) {
       obfuscatedReadOnly = readpassword();
+    } else {
+      fprintf(stderr, "A view-only password is not used\n");
     }
 
     FILE* fp = fopen(fname,"w");


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1639169. We have been carrying this in Fedora and RHEL for a while.