### PR TITLE
CharArray: pre-fill empty array with zeroes

### DIFF
--- a/common/rfb/util.h
+++ b/common/rfb/util.h
@@ -52,14 +52,17 @@ namespace rfb {
     CharArray(char* str) : buf(str) {} // note: assumes ownership
     CharArray(size_t len) {
       buf = new char[len]();
+      memset(buf, 0, len);
     }
     ~CharArray() {
-      delete [] buf;
+      if (buf) {
+        delete [] buf;
+      }
     }
     void format(const char *fmt, ...) __printf_attr(2, 3);
     // Get the buffer pointer & clear it (i.e. caller takes ownership)
     char* takeBuf() {char* tmp = buf; buf = 0; return tmp;}
-    void replaceBuf(char* b) {delete [] buf; buf = b;}
+    void replaceBuf(char* b) {if (buf) delete [] buf; buf = b;}
     char* buf;
   private:
     CharArray(const CharArray&);


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1637086.

Steps to Reproduce:
1. export MALLOC_CHECK_=2 MALLOC_PERTURB_=204
2. echo "123456" | vncpasswd -f >/tmp/out