### PR TITLE
Make TLS work on FIPS systems

### DIFF
--- a/common/rfb/SSecurityTLS.cxx
+++ b/common/rfb/SSecurityTLS.cxx
@@ -37,8 +37,6 @@
 #include <rdr/TLSOutStream.h>
 #include <gnutls/x509.h>
 
-#define DH_BITS 1024 /* XXX This should be configurable! */
-
 using namespace rfb;
 
 StringParameter SSecurityTLS::X509_CertFile
@@ -201,7 +199,8 @@ void SSecurityTLS::setParams(gnutls_session_t session)
   if (gnutls_dh_params_init(&dh_params) != GNUTLS_E_SUCCESS)
     throw AuthFailureException("gnutls_dh_params_init failed");
 
-  if (gnutls_dh_params_generate2(dh_params, DH_BITS) != GNUTLS_E_SUCCESS)
+  if (gnutls_dh_params_generate2(dh_params, gnutls_sec_param_to_pk_bits(GNUTLS_PK_DH, GNUTLS_SEC_PARAM_MEDIUM))
+      != GNUTLS_E_SUCCESS)
     throw AuthFailureException("gnutls_dh_params_generate2 failed");
 
   if (anon) {


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1492107.

Steps to Reproduce:
1. set fips=1 on the kernel cmdline of the system hosting the VNC server 
2. boot with this setting and attempt to use vncviewer to connect to a system running a vnc daemon with FIPS turned on
3. Observe error: