### PR TITLE
Use RFC7919-2048 group in GnuTLS for FIPS compliance.

### DIFF
--- a/common/rfb/SSecurityTLS.cxx
+++ b/common/rfb/SSecurityTLS.cxx
@@ -38,7 +38,23 @@
 #include <rdr/TLSOutStream.h>
 #include <gnutls/x509.h>
 
-#define DH_BITS 1024 /* XXX This should be configurable! */
+#if defined (SSECURITYTLS__USE_DEPRECATED_DH)
+/* FFDHE (RFC-7919) 2048-bit parameters, PEM-encoded */
+static unsigned char ffdhe2048[] =
+  "-----BEGIN DH PARAMETERS-----\n"
+  "MIIBDAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz\n"
+  "+8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a\n"
+  "87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7\n"
+  "YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi\n"
+  "7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD\n"
+  "ssbzSibBsu/6iGtCOGEoXJf//////////wIBAgICAOE=\n"
+  "-----END DH PARAMETERS-----\n";
+
+static const gnutls_datum_t ffdhe_pkcs3_param = {
+  ffdhe2048,
+  sizeof(ffdhe2048)
+};
+#endif
 
 using namespace rfb;
 
@@ -51,10 +67,14 @@ StringParameter SSecurityTLS::X509_KeyFile
 static LogWriter vlog("TLS");
 
 SSecurityTLS::SSecurityTLS(SConnection* sc, bool _anon)
-  : SSecurity(sc), session(NULL), dh_params(NULL), anon_cred(NULL),
+  : SSecurity(sc), session(NULL), anon_cred(NULL),
     cert_cred(NULL), anon(_anon), tlsis(NULL), tlsos(NULL),
     rawis(NULL), rawos(NULL)
 {
+#if defined (SSECURITYTLS__USE_DEPRECATED_DH)
+  dh_params = NULL;
+#endif
+
   certfile = X509_CertFile.getData();
   keyfile = X509_KeyFile.getData();
 
@@ -73,10 +93,12 @@ void SSecurityTLS::shutdown()
       vlog.error("TLS shutdown failed: %s", gnutls_strerror(ret));
   }
 
+#if defined (SSECURITYTLS__USE_DEPRECATED_DH)
   if (dh_params) {
     gnutls_dh_params_deinit(dh_params);
     dh_params = 0;
   }
+#endif
 
   if (anon_cred) {
     gnutls_anon_free_server_credentials(anon_cred);
@@ -201,17 +223,21 @@ void SSecurityTLS::setParams(gnutls_session_t session)
     throw AuthFailureException("gnutls_set_priority_direct failed");
   }
 
+#if defined (SSECURITYTLS__USE_DEPRECATED_DH)
   if (gnutls_dh_params_init(&dh_params) != GNUTLS_E_SUCCESS)
     throw AuthFailureException("gnutls_dh_params_init failed");
 
-  if (gnutls_dh_params_generate2(dh_params, DH_BITS) != GNUTLS_E_SUCCESS)
-    throw AuthFailureException("gnutls_dh_params_generate2 failed");
+  if (gnutls_dh_params_import_pkcs3(dh_params, &ffdhe_pkcs3_param, GNUTLS_X509_FMT_PEM) != GNUTLS_E_SUCCESS)
+    throw AuthFailureException("gnutls_dh_params_import_pkcs3 failed");
+#endif
 
   if (anon) {
     if (gnutls_anon_allocate_server_credentials(&anon_cred) != GNUTLS_E_SUCCESS)
       throw AuthFailureException("gnutls_anon_allocate_server_credentials failed");
 
+#if defined (SSECURITYTLS__USE_DEPRECATED_DH)
     gnutls_anon_set_server_dh_params(anon_cred, dh_params);
+#endif
 
     if (gnutls_credentials_set(session, GNUTLS_CRD_ANON, anon_cred)
         != GNUTLS_E_SUCCESS)
@@ -223,7 +249,9 @@ void SSecurityTLS::setParams(gnutls_session_t session)
     if (gnutls_certificate_allocate_credentials(&cert_cred) != GNUTLS_E_SUCCESS)
       throw AuthFailureException("gnutls_certificate_allocate_credentials failed");
 
+#if defined (SSECURITYTLS__USE_DEPRECATED_DH)
     gnutls_certificate_set_dh_params(cert_cred, dh_params);
+#endif
 
     switch (gnutls_certificate_set_x509_key_file(cert_cred, certfile, keyfile, GNUTLS_X509_FMT_PEM)) {
     case GNUTLS_E_SUCCESS:

--- a/common/rfb/SSecurityTLS.h
+++ b/common/rfb/SSecurityTLS.h
@@ -36,6 +36,13 @@
 #include <rdr/OutStream.h>
 #include <gnutls/gnutls.h>
 
+/* In GnuTLS 3.6.0 DH parameter generation was deprecated. RFC7919 is used instead.
+ * GnuTLS before 3.6.0 doesn't know about RFC7919 so we will have to import it.
+ */
+#if GNUTLS_VERSION_NUMBER < 0x030600
+#define SSECURITYTLS__USE_DEPRECATED_DH
+#endif
+
 namespace rfb {
 
   class SSecurityTLS : public SSecurity {
@@ -55,7 +62,9 @@ namespace rfb {
 
   private:
     gnutls_session_t session;
+#if defined (SSECURITYTLS__USE_DEPRECATED_DH)
     gnutls_dh_params_t dh_params;
+#endif
     gnutls_anon_server_credentials_t anon_cred;
     gnutls_certificate_credentials_t cert_cred;
     char *keyfile, *certfile;


### PR DESCRIPTION
FIPS 140-3 only allows DH parameters from RFC3526 or RFC7919. Generating parameters randomly is no longer allowed.

GnuTLS starting from version 3.6.0 defaults to using 2048-bit RFC7919 parameters; this is FIPS-compliant. To use it we simply don't specify parameters.

For GnuTLS older than 3.6.0 we need to specify parameters. The same parameters are hard-coded.

The GnuTLS version is checked at compile time to decide which path to take.