### PR TITLE
Add support for fullscreen over multiple, but not all monitors

### DIFF
--- a/vncviewer/CMakeLists.txt
+++ b/vncviewer/CMakeLists.txt
@@ -63,6 +63,11 @@ elseif(APPLE)
   target_link_libraries(vncviewer "-framework IOKit")
 else()
   target_link_libraries(vncviewer ${X11_Xi_LIB})
+
+  if(X11_Xrandr_LIB)
+    add_definitions(-DHAVE_XRANDR)
+    target_link_libraries(vncviewer ${X11_Xrandr_LIB})
+  endif()
 endif()
 
 install(TARGETS vncviewer DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})

--- a/vncviewer/CMakeLists.txt
+++ b/vncviewer/CMakeLists.txt
@@ -17,6 +17,8 @@ set(VNCVIEWER_SOURCES
   parameters.cxx
   keysym2ucs.c
   touch.cxx
+  MonitorArrangement.cxx
+  MonitorIndicesParameter.cxx
   vncviewer.cxx)
 
 if(WIN32)

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -932,7 +932,7 @@ void DesktopWindow::grabKeyboard()
 #elif defined(__APPLE__)
   int ret;
   
-  ret = cocoa_capture_display(this, fullScreenAllMonitors);
+  ret = cocoa_capture_displays(this);
   if (ret != 0) {
     vlog.error(_("Failure grabbing keyboard"));
     return;
@@ -988,7 +988,7 @@ void DesktopWindow::ungrabKeyboard()
 #if defined(WIN32)
   win32_disable_lowlevel_keyboard(fl_xid(this));
 #elif defined(__APPLE__)
-  cocoa_release_display(this);
+  cocoa_release_displays(this);
 #else
   // FLTK has a grab so lets not mess with it
   if (Fl::grab())

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -885,9 +885,10 @@ void DesktopWindow::fullscreen_on()
   bool all_monitors = !strcasecmp(fullScreenMode, "all");
   bool selected_monitors = !strcasecmp(fullScreenMode, "selected");
 
-  if (not selected_monitors and not all_monitors)
-    fullscreen_screens(-1, -1, -1, -1);
-  else {
+  if (not selected_monitors and not all_monitors) {
+    int n = Fl::screen_num(x(), y(), w(), h());
+    fullscreen_screens(n, n, n, n);
+  } else {
     int top, bottom, left, right;
     int top_y, bottom_y, left_x, right_x;
 

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -880,10 +880,11 @@ int DesktopWindow::fltkHandle(int event, Fl_Window *win)
   return ret;
 }
 
-
 void DesktopWindow::fullscreen_on()
 {
-  if (not fullScreenAllMonitors)
+  bool all_monitors = !strcasecmp(fullScreenMode, "all");
+
+  if (not all_monitors)
     fullscreen_screens(-1, -1, -1, -1);
   else {
     int top, bottom, left, right;
@@ -1377,7 +1378,7 @@ void DesktopWindow::handleOptions(void *data)
     self->ungrabKeyboard();
 
   // Call fullscreen_on even if active since it handles
-  // fullScreenAllMonitors
+  // fullScreenMode
   if (fullScreen)
     self->fullscreen_on();
   else if (!fullScreen && self->fullscreen_active())

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -608,6 +608,11 @@ void DesktopWindow::resize(int x, int y, int w, int h)
 
     repositionWidgets();
   }
+
+  // Some systems require a grab after the window size has been changed.
+  // Otherwise they might hold on to displays, resulting in them being unusable.
+  if (fullscreen_active() && fullscreenSystemKeys)
+    grabKeyboard();
 }
 
 

--- a/vncviewer/MonitorArrangement.cxx
+++ b/vncviewer/MonitorArrangement.cxx
@@ -1,0 +1,303 @@
+/* Copyright 2021 Hugo Lundin <huglu@cendio.se> for Cendio AB.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#include <set>
+#include <vector>
+#include <string>
+#include <utility>
+#include <sstream>
+#include <assert.h>
+#include <algorithm>
+
+#include <FL/Fl.H>
+#include <FL/fl_draw.H>
+#include <FL/Fl_Button.H>
+
+#include <rfb/Rect.h>
+
+#include "MonitorArrangement.h"
+
+static const Fl_Boxtype FL_CHECKERED_BOX = FL_FREE_BOXTYPE;
+
+MonitorArrangement::MonitorArrangement(
+   int x, int y, int w, int h)
+:  Fl_Group(x, y, w, h),
+   SELECTION_COLOR(fl_lighter(FL_BLUE)),
+   AVAILABLE_COLOR(fl_lighter(fl_lighter(fl_lighter(FL_BACKGROUND_COLOR)))),
+   m_monitors()
+{
+  // Used for required monitors.
+  Fl::set_boxtype(FL_CHECKERED_BOX, checkered_pattern_draw, 0, 0, 0, 0);
+
+  box(FL_DOWN_BOX);
+  color(fl_lighter(FL_BACKGROUND_COLOR));
+  layout();
+  end();
+}
+
+MonitorArrangement::~MonitorArrangement()
+{
+
+}
+
+std::set<int> MonitorArrangement::get()
+{
+  std::set<int> indices;
+
+  for (int i = 0; i < (int) m_monitors.size(); i++) {
+    if (m_monitors[i]->value() == 1)
+      indices.insert(i);
+  }
+
+  return indices;
+}
+
+void MonitorArrangement::set(std::set<int> indices)
+{
+  for (int i = 0; i < (int) m_monitors.size(); i++) {
+    bool selected = std::find(indices.begin(), indices.end(), i) != indices.end();
+    m_monitors[i]->value(selected ? 1 : 0);
+  }
+}
+
+void MonitorArrangement::draw()
+{
+  for (int i = 0; i < (int) m_monitors.size(); i++) {
+    Fl_Button * monitor = m_monitors[i];
+
+    if (is_required(i)) {
+      monitor->box(FL_CHECKERED_BOX);
+      monitor->color(SELECTION_COLOR);
+    } else {
+      monitor->box(FL_BORDER_BOX);
+      monitor->color(AVAILABLE_COLOR);
+      monitor->selection_color(SELECTION_COLOR);
+    }
+  }
+
+  Fl_Group::draw();
+}
+
+void MonitorArrangement::layout()
+{
+  int x, y, w, h;
+  double scale = this->scale();
+  const double MARGIN_SCALE_FACTOR = 0.99;
+  std::pair<int, int> offset = this->offset();
+
+  for (int i = 0; i < Fl::screen_count(); i++) {
+    Fl::screen_xywh(x, y, w, h, i);
+
+    Fl_Button *monitor = new Fl_Button(
+      /* x = */ this->x() + offset.first + x*scale + (1 - MARGIN_SCALE_FACTOR)*x*scale,
+      /* y = */ this->y() + offset.second +  y*scale + (1 - MARGIN_SCALE_FACTOR)*y*scale,
+      /* w = */ w*scale*MARGIN_SCALE_FACTOR,
+      /* h = */ h*scale*MARGIN_SCALE_FACTOR
+    );
+
+    monitor->clear_visible_focus();
+    monitor->callback(monitor_pressed, this);
+    monitor->type(FL_TOGGLE_BUTTON);
+    monitor->when(FL_WHEN_CHANGED);
+    m_monitors.push_back(monitor);
+  }
+}
+
+bool MonitorArrangement::is_required(int m)
+{
+  // A selected monitor is never required.
+  if (m_monitors[m]->value() == 1)
+    return false;
+
+  // If no monitors are selected, none are required.
+  std::set<int> selected = get();
+  if (selected.size() <= 0)
+    return false;
+
+
+  // Go through all selected monitors and find the monitor
+  // indices that bounds the fullscreen frame buffer. If
+  // the given monitor's coordinates are inside the bounds,
+  // while not being selected, it is instead required.
+
+  int x, y, w, h;
+  int top_y, bottom_y, left_x, right_x;
+  std::set<int>::iterator it = selected.begin();
+
+  // Base the rest of the calculations on the dimensions
+  // obtained for the first monitor.
+  Fl::screen_xywh(x, y, w, h, *it);
+  top_y = y;
+  bottom_y = y + h;
+  left_x = x;
+  right_x = x + w;
+
+  // Go through the rest of the monitors,
+  // exhausting the rest of the iterator.
+  for (; it != selected.end(); it++) {
+    Fl::screen_xywh(x, y, w, h, *it);
+
+    if (y < top_y) {
+      top_y = y;
+    }
+
+    if ((y + h) > bottom_y) {
+      bottom_y = y + h;
+    }
+
+    if (x < left_x) {
+      left_x = x;
+    }
+
+    if ((x + w) > right_x) {
+      right_x = x + w;
+    }
+  }
+
+  rfb::Rect viewport, monitor;
+  viewport.setXYWH(left_x, top_y, right_x - left_x, bottom_y - top_y);
+
+  Fl::screen_xywh(x, y, w, h, m);
+  monitor.setXYWH(x, y, w, h);
+
+  return monitor.enclosed_by(viewport);
+}
+
+double MonitorArrangement::scale()
+{
+  const int MARGIN = 20;
+  std::pair<int, int> size = this->size();
+
+  double s_w = static_cast<double>(this->w()-MARGIN) / static_cast<double>(size.first);
+  double s_h = static_cast<double>(this->h()-MARGIN) / static_cast<double>(size.second);
+
+  // Choose the one that scales the least, in order to
+  // maximize our use of the given bounding area.
+  if (s_w > s_h)
+    return s_h;
+  else
+    return s_w;
+}
+
+std::pair<int, int> MonitorArrangement::size()
+{
+  int x, y, w, h;
+  int top, bottom, left, right;
+  int x_min, x_max, y_min, y_max;
+  x_min = x_max = y_min = y_max = 0;
+
+  for (int i = 0; i < Fl::screen_count(); i++) {
+    Fl::screen_xywh(x, y, w, h, i);
+
+    top = y;
+    bottom = y + h;
+    left = x;
+    right = x + w;
+
+    if (top < y_min)
+      y_min = top;
+
+    if (bottom > y_max)
+      y_max = bottom;
+
+    if (left < x_min)
+      x_min = left;
+
+    if (right > x_max)
+      x_max = right;
+  }
+
+  return std::make_pair(x_max - x_min, y_max - y_min);
+}
+
+std::pair<int, int> MonitorArrangement::offset()
+{
+  double scale = this->scale();
+  std::pair<int, int> size = this->size();
+  std::pair<int, int> origin = this->origin();
+
+  int offset_x = (this->w()/2) - (size.first/2 * scale);
+  int offset_y = (this->h()/2) - (size.second/2 * scale);
+
+  return std::make_pair(offset_x + abs(origin.first)*scale, offset_y + abs(origin.second)*scale);
+}
+
+std::pair<int, int> MonitorArrangement::origin()
+{
+  int x, y, w, h, ox, oy;
+  ox = oy = 0;
+
+  for (int i = 0; i < Fl::screen_count(); i++) {
+    Fl::screen_xywh(x, y, w, h, i);
+
+    if (x < ox)
+      ox = x;
+
+    if (y < oy)
+      oy = y;
+  }
+
+  return std::make_pair(ox, oy);
+}
+
+void MonitorArrangement::monitor_pressed(Fl_Widget *widget, void *user_data)
+{
+  MonitorArrangement *self = (MonitorArrangement *) user_data;
+
+  // When a monitor is selected, FLTK changes the state of it for us.
+  // However, selecting a monitor might implicitly change the state of
+  // others (if they become required). FLTK only redraws the selected
+  // monitor. Therefore, we must trigger a redraw of the whole widget
+  // manually.
+  self->redraw();
+}
+
+void MonitorArrangement::checkered_pattern_draw(
+  int x, int y, int width, int height, Fl_Color color)
+{
+  bool draw_checker = false;
+  const int CHECKER_SIZE = 8;
+
+  fl_color(fl_lighter(fl_lighter(fl_lighter(color))));
+  fl_rectf(x, y, width, height);
+
+  fl_color(Fl::draw_box_active() ? color : fl_inactive(color));
+
+  // Round up the square count. Later on, we remove square area that are
+  // outside the given bounding area.
+  const int count = (width + CHECKER_SIZE - 1) / CHECKER_SIZE;
+
+  for (int i = 0; i < count; i++) {
+    for (int j = 0; j < count; j++) {
+
+      draw_checker = (i + j) % 2 == 0;
+
+      if (draw_checker) {
+        fl_rectf(
+          /* x = */ x + i * CHECKER_SIZE,
+          /* y = */ y + j * CHECKER_SIZE,
+          /* w = */ CHECKER_SIZE - std::max(0, ((i + 1) * CHECKER_SIZE) - width),
+          /* h = */ CHECKER_SIZE - std::max(0, ((j + 1) * CHECKER_SIZE) - height)
+        );
+      }
+    }
+  }
+
+  fl_color(Fl::draw_box_active() ? FL_BLACK : fl_inactive(FL_BLACK));
+  fl_rect(x, y, width, height);
+}

--- a/vncviewer/MonitorArrangement.h
+++ b/vncviewer/MonitorArrangement.h
@@ -64,6 +64,10 @@ private:
   // Return the origin of the monitor arrangement (top left corner).
   std::pair<int, int> origin();
 
+  // Get a textual description of the given monitor.
+  std::string description(int m);
+  int get_monitor_name(int m, char name[], size_t name_len);
+
   static void monitor_pressed(Fl_Widget *widget, void *user_data);
   static void checkered_pattern_draw(
     int x, int y, int width, int height, Fl_Color color);

--- a/vncviewer/MonitorArrangement.h
+++ b/vncviewer/MonitorArrangement.h
@@ -1,0 +1,72 @@
+/* Copyright 2021 Hugo Lundin <huglu@cendio.se> for Cendio AB.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifndef __MONITOR_ARRANGEMENT_H__
+#define __MONITOR_ARRANGEMENT_H__
+
+#include <string>
+
+class Fl_Group;
+class Fl_Button;
+
+class MonitorArrangement: public Fl_Group {
+public:
+  MonitorArrangement(int x, int y, int w, int h);
+  ~MonitorArrangement();
+
+  // Get selected indices.
+  std::set<int> get();
+
+  // Set selected indices.
+  void set(std::set<int> indices);
+
+protected:
+  virtual void draw();
+
+private:
+  const Fl_Color SELECTION_COLOR;
+  const Fl_Color AVAILABLE_COLOR;
+  std::vector<Fl_Button *> m_monitors;
+
+  // Layout the monitor arrangement.
+  void layout();
+
+  // Return true if the given monitor is required to be part of the configuration
+  // for it to be valid. A configuration is only valid if the framebuffer created
+  // from is rectangular.
+  bool is_required(int m);
+
+  // Calculate the scale of the monitor arrangement.
+  double scale();
+
+  // Return the size of the monitor arrangement.
+  std::pair<int, int> size();
+
+  // Return the offset required for centering the monitor
+  // arrangement in the given bounding area.
+  std::pair<int, int> offset();
+
+  // Return the origin of the monitor arrangement (top left corner).
+  std::pair<int, int> origin();
+
+  static void monitor_pressed(Fl_Widget *widget, void *user_data);
+  static void checkered_pattern_draw(
+    int x, int y, int width, int height, Fl_Color color);
+};
+
+#endif

--- a/vncviewer/MonitorIndicesParameter.cxx
+++ b/vncviewer/MonitorIndicesParameter.cxx
@@ -1,0 +1,229 @@
+/* Copyright 2021 Hugo Lundin <huglu@cendio.se> for Cendio AB.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#include <algorithm>
+#include <vector>
+#include <string>
+#include <limits>
+#include <set>
+#include <stdlib.h>
+#include <stdexcept>
+
+#include "i18n.h"
+#include <FL/Fl.H>
+#include <rfb/LogWriter.h>
+
+#include "MonitorIndicesParameter.h"
+
+using namespace rfb;
+static LogWriter vlog("MonitorIndicesParameter");
+
+MonitorIndicesParameter::MonitorIndicesParameter(const char* name_, const char* desc_, const char* v)
+: StringParameter(name_, desc_, v) {}
+
+std::set<int> MonitorIndicesParameter::getParam()
+{
+    bool valid = false;
+    std::set<int> indices;
+    std::set<int> config_indices;
+    std::vector<MonitorIndicesParameter::Monitor> monitors = this->monitors();
+
+    if (monitors.size() <= 0) {
+        vlog.error(_("Failed to get monitors."));
+        return indices;
+    }
+
+    valid = parse_indices(value, &config_indices);
+    if (!valid) {
+        return indices;
+    }
+
+    if (config_indices.size() <= 0) {
+        return indices;
+    }
+
+    // Go through the monitors and see what indices are present in the config.
+    for (int i = 0; i < ((int) monitors.size()); i++) {
+        if (std::find(config_indices.begin(), config_indices.end(), i) != config_indices.end())
+            indices.insert(monitors[i].fltk_index);
+    }
+
+    return indices;
+}
+
+bool MonitorIndicesParameter::setParam(const char* value)
+{
+    int index;
+    std::set<int> indices;
+
+    if (strlen(value) < 0)
+        return false;
+
+    if (!parse_indices(value, &indices)) {
+        vlog.error(_("Invalid FullScreenSelectedMonitors configuration."));
+        return false;
+    }
+
+    for (std::set<int>::iterator it = indices.begin(); it != indices.end(); it++) {
+        index = *it + 1;
+
+        if (index <= 0 || index > Fl::screen_count())
+            vlog.error(_("Monitor index %d does not exist."), index);
+    }
+
+    return StringParameter::setParam(value);
+}
+
+bool MonitorIndicesParameter::setParam(std::set<int> indices)
+{
+    static const int BUF_MAX_LEN = 1024;
+    char buf[BUF_MAX_LEN] = {0};
+    std::set<int> config_indices;
+    std::vector<MonitorIndicesParameter::Monitor> monitors = this->monitors();
+
+    if (monitors.size() <=  0) {
+        vlog.error(_("Failed to get monitors."));
+        // Don't return, store the configuration anyways.
+    }
+
+    for (int i = 0; i < ((int) monitors.size()); i++) {
+        if (std::find(indices.begin(), indices.end(), monitors[i].fltk_index) != indices.end())
+            config_indices.insert(i);
+    }
+
+    int bytes_written = 0;
+    char const * separator = "";
+
+    for (std::set<int>::iterator index = config_indices.begin();
+         index != config_indices.end();
+         index++)
+    {
+        bytes_written += snprintf(
+            buf+bytes_written,
+            BUF_MAX_LEN-bytes_written,
+            "%s%u",
+            separator,
+            (*index)+1
+        );
+
+        separator = ",";
+    }
+
+    return setParam(buf);
+}
+
+static bool parse_number(std::string number, std::set<int> *indices)
+{
+    if (number.size() <= 0)
+        return false;
+
+    int v = strtol(number.c_str(), NULL, 0);
+
+    if (v <= 0) {
+        vlog.error(_("The given monitor index(%s) is too small to be valid."), number.c_str());
+        return false;
+    }
+
+    if (v > INT_MAX) {
+        vlog.error(_("The given monitor index (%s) is too large to be valid."), number.c_str());
+        return false;
+    }
+
+    indices->insert(v-1);
+    return true;
+}
+
+bool MonitorIndicesParameter::parse_indices(const char* value, std::set<int> *indices)
+{
+    char d;
+    std::string current;
+
+    for (size_t i = 0; i < strlen(value); i++) {
+        d = value[i];
+
+        if (d == ' ')
+            continue;
+        else if (d >= '0' && d <= '9')
+            current.push_back(d);
+        else if (d == ',') {
+            if (!parse_number(current, indices)) {
+                vlog.error(_("Invalid monitor index '%s' in FullScreenSelectedMonitors"), current.c_str());
+                return false;
+            }
+
+            current.clear();
+        } else {
+            vlog.error(_("Unexpected character '%c' in FullScreenSelectedMonitors"), d);
+            return false;
+        }
+    }
+
+    // If we have nothing left to parse we are in a valid state.
+    if (current.size() == 0)
+        return true;
+
+    // Parsing anything we have left.
+    if (!parse_number(current, indices))
+        return false;
+
+    return true;
+}
+
+std::vector<MonitorIndicesParameter::Monitor> MonitorIndicesParameter::monitors()
+{
+    std::vector<Monitor> monitors;
+
+    // Start by creating a struct for every monitor.
+    for (int i = 0; i < Fl::screen_count(); i++) {
+        Monitor monitor = {0};
+
+        // Get the properties of the monitor at the current index;
+        Fl::screen_xywh(
+            monitor.x,
+            monitor.y,
+            monitor.w,
+            monitor.h,
+            i
+        );
+
+        monitor.fltk_index = i;
+        monitors.push_back(monitor);
+    }
+
+    // Sort the monitors according to the specification in the vncviewer manual.
+    qsort(&monitors[0], monitors.size(), sizeof(*(&monitors[0])), sort_cb);
+    return monitors;
+}
+
+int MonitorIndicesParameter::sort_cb(const void *a, const void *b)
+{
+    MonitorIndicesParameter::Monitor * monitor1 = (MonitorIndicesParameter::Monitor *) a;
+    MonitorIndicesParameter::Monitor * monitor2 = (MonitorIndicesParameter::Monitor *) b;
+
+    if (monitor1->x < monitor2->x)
+        return -1;
+
+    if (monitor1->y < monitor2->y)
+        return -1;
+
+    if (monitor1->x == monitor2->x)
+        if (monitor1->y == monitor2->y)
+            return 0;
+
+    return 1;
+}

--- a/vncviewer/MonitorIndicesParameter.h
+++ b/vncviewer/MonitorIndicesParameter.h
@@ -1,0 +1,44 @@
+/* Copyright 2021 Hugo Lundin <huglu@cendio.se> for Cendio AB.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifndef __MONITOR_INDEX_PARAMETER_H
+#define __MONITOR_INDEX_PARAMETER_H
+
+#include <set>
+#include <vector>
+
+#include <rfb/Configuration.h>
+
+class MonitorIndicesParameter: public rfb::StringParameter {
+public:
+    MonitorIndicesParameter(const char* name_, const char* desc_, const char* v);
+    std::set<int> getParam();
+    bool setParam(std::set<int> indices);
+    bool setParam(const char* value);
+private:
+    typedef struct {
+        int x, y, w, h;
+        int fltk_index;
+    } Monitor;
+
+    bool parse_indices(const char* value, std::set<int> *indices);
+    std::vector<MonitorIndicesParameter::Monitor> monitors();
+    static int sort_cb(const void*, const void*);
+};
+
+#endif // __MONITOR_INDEX_PARAMETER_H

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -297,7 +297,12 @@ void OptionsDialog::loadOptions(void)
   }
   remoteResizeCheckbox->value(remoteResize);
   fullScreenCheckbox->value(fullScreen);
-  fullScreenAllMonitorsCheckbox->value(fullScreenAllMonitors);
+
+  if (!strcasecmp(fullScreenMode, "all")) {
+    allMonitorsButton->setonly();
+  } else {
+    currentMonitorButton->setonly();
+  }
 
   handleDesktopSize(desktopSizeCheckbox, this);
 
@@ -407,7 +412,12 @@ void OptionsDialog::storeOptions(void)
   }
   remoteResize.setParam(remoteResizeCheckbox->value());
   fullScreen.setParam(fullScreenCheckbox->value());
-  fullScreenAllMonitors.setParam(fullScreenAllMonitorsCheckbox->value());
+
+  if (allMonitorsButton->value()) {
+    fullScreenMode.setParam("All");
+  } else {
+    fullScreenMode.setParam("Current");
+  }
 
   /* Misc. */
   shared.setParam(sharedCheckbox->value());
@@ -755,6 +765,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 void OptionsDialog::createScreenPage(int tx, int ty, int tw, int th)
 {
   int x;
+  int width, height;
 
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Screen"));
 
@@ -783,15 +794,35 @@ void OptionsDialog::createScreenPage(int tx, int ty, int tw, int th)
   fullScreenCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,
-                                                  _("Full-screen mode")));
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+                                                  _("Enable full-screen")));
+  ty += CHECK_HEIGHT + INNER_MARGIN;
 
-  fullScreenAllMonitorsCheckbox = new Fl_Check_Button(LBLRIGHT(tx + INDENT, ty,
-                                                      CHECK_MIN_WIDTH,
-                                                      CHECK_HEIGHT,
-                                                      _("Enable full-screen mode over all monitors")));
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+  width = tw - OUTER_MARGIN * 2;
+  height = th - ty + OUTER_MARGIN * 3;
+    Fl_Group *fullScreenModeGroup = new Fl_Group(tx,
+                                     ty,
+                                     width,
+                                     height);
 
+  {
+    tx += INDENT;
+
+    currentMonitorButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
+                                                        RADIO_MIN_WIDTH,
+                                                        RADIO_HEIGHT,
+                                                        _("Use current monitor")));
+    currentMonitorButton->type(FL_RADIO_BUTTON);
+    ty += RADIO_HEIGHT + TIGHT_MARGIN;
+
+    allMonitorsButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
+                                            RADIO_MIN_WIDTH,
+                                            RADIO_HEIGHT,
+                                            _("Use all monitors")));
+    allMonitorsButton->type(FL_RADIO_BUTTON);
+    ty += RADIO_HEIGHT + TIGHT_MARGIN;
+  }
+
+  fullScreenModeGroup->end();
   group->end();
 }
 

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -125,7 +125,9 @@ protected:
   Fl_Int_Input *desktopHeightInput;
   Fl_Check_Button *remoteResizeCheckbox;
   Fl_Check_Button *fullScreenCheckbox;
-  Fl_Check_Button *fullScreenAllMonitorsCheckbox;
+
+  Fl_Round_Button *currentMonitorButton;
+  Fl_Round_Button *allMonitorsButton;
 
   /* Misc. */
   Fl_Check_Button *sharedCheckbox;

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -30,6 +30,7 @@ class Fl_Round_Button;
 class Fl_Input;
 class Fl_Int_Input;
 class Fl_Choice;
+class MonitorArrangement;
 
 typedef void (OptionsCallback)(void*);
 
@@ -65,6 +66,8 @@ protected:
   static void handleDesktopSize(Fl_Widget *widget, void *data);
 
   static void handleClipboard(Fl_Widget *widget, void *data);
+
+  static void handleFullScreenMode(Fl_Widget *widget, void *data);
 
   static void handleCancel(Fl_Widget *widget, void *data);
   static void handleOK(Fl_Widget *widget, void *data);
@@ -128,6 +131,8 @@ protected:
 
   Fl_Round_Button *currentMonitorButton;
   Fl_Round_Button *allMonitorsButton;
+  Fl_Round_Button *selectedMonitorsButton;
+  MonitorArrangement *monitorArrangement;
 
   /* Misc. */
   Fl_Check_Button *sharedCheckbox;

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -19,8 +19,10 @@
 #ifndef __VNCVIEWER_COCOA_H__
 #define __VNCVIEWER_COCOA_H__
 
-int cocoa_capture_display(Fl_Window *win, bool all_displays);
-void cocoa_release_display(Fl_Window *win);
+class Fl_Window;
+
+int cocoa_capture_displays(Fl_Window *win);
+void cocoa_release_displays(Fl_Window *win);
 
 typedef struct CGColorSpace *CGColorSpaceRef;
 

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -103,11 +103,15 @@ IntParameter qualityLevel("QualityLevel",
 BoolParameter maximize("Maximize", "Maximize viewer window", false);
 BoolParameter fullScreen("FullScreen", "Enable full screen", false);
 StringParameter fullScreenMode("FullScreenMode", "Specify which monitors to use when in full screen. "
-                                                 "Should be either Current or All",
+                                                 "Should be either Current, Selected or All",
                                                  "Current");
 BoolParameter fullScreenAllMonitors("FullScreenAllMonitors",
                                     "[DEPRECATED] Enable full screen over all monitors",
                                     false);
+MonitorIndicesParameter fullScreenSelectedMonitors("FullScreenSelectedMonitors",
+                                         "Use the given list of monitors in full screen"
+                                         " when -FullScreenMode=Selected.",
+                                         "1");
 StringParameter desktopSize("DesktopSize",
                             "Reconfigure desktop size on the server on "
                             "connect (if possible)", "");
@@ -179,6 +183,7 @@ static VoidParameter* parameterArray[] = {
   &qualityLevel,
   &fullScreen,
   &fullScreenMode,
+  &fullScreenSelectedMonitors,
   &desktopSize,
   &remoteResize,
   &viewOnly,

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -21,6 +21,7 @@
 #define __PARAMETERS_H__
 
 #include <rfb/Configuration.h>
+#include "MonitorIndicesParameter.h"
 
 #ifdef _WIN32
 #include <vector>
@@ -51,6 +52,7 @@ extern rfb::BoolParameter maximize;
 extern rfb::BoolParameter fullScreen;
 extern rfb::StringParameter fullScreenMode;
 extern rfb::BoolParameter fullScreenAllMonitors; // deprecated
+extern MonitorIndicesParameter fullScreenSelectedMonitors;
 extern rfb::StringParameter desktopSize;
 extern rfb::StringParameter geometry;
 extern rfb::BoolParameter remoteResize;

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -49,7 +49,8 @@ extern rfb::IntParameter qualityLevel;
 
 extern rfb::BoolParameter maximize;
 extern rfb::BoolParameter fullScreen;
-extern rfb::BoolParameter fullScreenAllMonitors;
+extern rfb::StringParameter fullScreenMode;
+extern rfb::BoolParameter fullScreenAllMonitors; // deprecated
 extern rfb::StringParameter desktopSize;
 extern rfb::StringParameter geometry;
 extern rfb::BoolParameter remoteResize;

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -435,6 +435,16 @@ potentiallyLoadConfigurationFile(char *vncServerName)
   }
 }
 
+static void
+migrateDeprecatedOptions()
+{
+  if (fullScreenAllMonitors) {
+    vlog.info(_("FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead."));
+
+    fullScreenMode.setParam("all");
+  }
+}
+
 #ifndef WIN32
 static int
 interpretViaParam(char *remoteHost, int *remotePort, int localPort)
@@ -612,6 +622,8 @@ int main(int argc, char** argv)
 
   // Check if the server name in reality is a configuration file
   potentiallyLoadConfigurationFile(vncServerName);
+
+  migrateDeprecatedOptions();
 
   mkvnchomedir();
 

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -211,9 +211,17 @@ full-screen mode. Replaced by \fB-FullScreenMode=all\fP
 .
 .TP
 .B \-FullScreenMode \fImode\fP
-Specify which monitors to use when in full screen. It should be either "Current" or "All". 
+Specify which monitors to use when in full screen. It should be either "Current",
+"Selected" (specified by \fB-FullScreenSelectedMonitors\fP) or "All". 
 The default is "Current".
 .
+.TP
+.B \-FullScreenSelectedMonitors \fImonitors\fP
+This option specifies the monitors to use with \fB-FullScreenMode=selected\fP.
+Monitors are ordered according to the system configuration from left to right,
+and in case of a conflict, from top to bottom. So, for example, "1,2,3" means
+that the first, second and third monitor counting from the left should be used.
+The default is "1".
 .
 .TP
 .B \-FullscreenSystemKeys

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -205,9 +205,15 @@ Maximize viewer window.
 Start in full-screen mode.
 .
 .TP
-.B \-FullScreenAllMonitors
+.B \-FullScreenAllMonitors (DEPRECATED)
 Use all local monitors and not just the current one when switching to
-full-screen mode.
+full-screen mode. Replaced by \fB-FullScreenMode=all\fP
+.
+.TP
+.B \-FullScreenMode \fImode\fP
+Specify which monitors to use when in full screen. It should be either "Current" or "All". 
+The default is "Current".
+.
 .
 .TP
 .B \-FullscreenSystemKeys

--- a/vncviewer/win32.c
+++ b/vncviewer/win32.c
@@ -18,6 +18,7 @@
  */
 
 #include <windows.h>
+#include <stdio.h>
 
 #define XK_MISCELLANY
 #define XK_XKB_KEYS
@@ -417,4 +418,55 @@ int win32_has_altgr(void)
   current_layout = GetKeyboardLayout(0);
 
   return has_altgr;
+}
+
+typedef struct {
+	int x, y, w, h;
+    char* name;
+	size_t name_len;
+	int bytes_written;
+} EnumCallbackData;
+
+static BOOL CALLBACK EnumDisplayMonitorsCallback(
+	HMONITOR monitor, HDC deviceContext, LPRECT rect, LPARAM userData)
+{
+	EnumCallbackData *data = (EnumCallbackData *)userData;
+	MONITORINFOEX info;
+	info.cbSize = sizeof(info);
+	GetMonitorInfo(monitor, (LPMONITORINFO)&info);
+
+	int x = info.rcMonitor.left;
+	int y = info.rcMonitor.top;
+	int w = info.rcMonitor.right - info.rcMonitor.left;
+	int h = info.rcMonitor.bottom - info.rcMonitor.top;
+
+	if ((data->x == x) && (data->y == y) && (data->w == w) && (data->h == h)) {
+		data->bytes_written = snprintf(data->name, data->name_len,
+			"%.*s", (int)(data->name_len - 1), info.szDevice);
+
+		if (data->bytes_written < 0)
+			return FALSE;
+
+		// Stop the iteration.
+		return FALSE;
+	}
+
+	// Keep iterating.
+	return TRUE;
+}
+
+int win32_get_monitor_name(int x, int y, int w, int h, char name[], size_t name_len)
+{
+	EnumCallbackData data = {
+		.x = x,
+		.y = y,
+		.w = w,
+		.h = h,
+		.name = name,
+		.name_len = name_len,
+		.bytes_written = -1
+	};
+
+	EnumDisplayMonitors(NULL, NULL, EnumDisplayMonitorsCallback, (LPARAM) &data);
+	return data.bytes_written;
 }

--- a/vncviewer/win32.h
+++ b/vncviewer/win32.h
@@ -34,6 +34,7 @@ int win32_vkey_to_keysym(UINT vkey, int extended);
 
 int win32_has_altgr(void);
 
+int win32_get_monitor_name(int x, int y, int w, int h, char name[], size_t name_len);
 };
 
 #endif


### PR DESCRIPTION
This pull request adds support to TigerVNC’s vncviewer for managing and using fullscreen over multiple, but not all monitors, as requested by issue #91. I would like to thank @ercanal for their work on this feature, giving me hints for how to implement this. 

# Overview

The implementation adds support for configuring what monitors to use in fullscreen, either via a configuration file, command line or the graphical options menu (`Options > Screen`). The aim is to make a robust solution that will be understandable for both regular and technical users. I have researched how other applications solve this problem and will present what I have done below. I will also describe parts of the implementation and what is left to be done before this can be considered ready. 

# Configuration

No matter the experience or technical knowledge, it should be convenient and easy for a user to configure what monitors they want to use. We also want to maintain the previously existing settings behaviour to not neglect any existing use-cases (full screen over the current monitor and full screen over all monitors). 

## Monitor identification

With the motivation that it should be easy to configure what monitors that are selected, we want to have a simple and robust way to identify monitors. In the GUI I have chosen to do it visually - the user simply clicks on the monitor they want to use.

In the configuration file and on the command line, I do not think we want to use the index that is provided by FLTK. Its stability relies on the implementation details of window managers and the library itself and might break a user configuration if it were to change. Instead, I propose that we have our own mapping that corresponds to the coordinates of the system monitor arrangement. 

The solution I have chosen is that the monitors should always be enumerated (starting at 1) from left to right, and if there is a conflict, from top to bottom. This index is entered into the configuration file or on the command line and is also the representation stored from what is configured in the GUI. 

## Graphical User Interface

A new widget (`MonitorArrangementWidget`) has been added to the bottom of `Options > Screen`. It allows the user to select which monitors to use. Additional information about a particular monitor can be obtained by hovering over the monitor. 

Because TigerVNC is a cross-platform application, I wanted to make sure that the user reliably can identify a display no matter what API:s are available. Position and size can be obtained from FLTK on all platforms, which is the primary way the user can identify a monitor graphically. The information displayed when hovering, varies depending on what platform the user is on. 

Both Windows, macOS and Gnome use blue color to indicate a selected state. Therefore, I think it might be reasonable to argue that it should be the case here as well. 

The position and size of a monitor *should* always correspond to what has been configured on the system. See for example my configuration in GNOME Settings and the screenshots of my implementation below: 

---

<img src="https://user-images.githubusercontent.com/9110669/123925208-fab7dd00-d98a-11eb-8737-0d3f0082852a.png" alt="gnome" width="400">

**Image 1**: My GNOME Settings display arrangement. 

---

![selected_monitors](https://user-images.githubusercontent.com/9110669/123925784-892c5e80-d98b-11eb-894f-9139fd5dd14f.png)

**Image 2**: An example of how the implemented GUI looks. Two monitors are selected. 

---

![required_monitors](https://user-images.githubusercontent.com/9110669/123925916-a95c1d80-d98b-11eb-9e51-03e406ef9dd3.png)

**Image 3**: The frame buffer is required to be *a* rectangle. Therefore, if the two monitors to the left and right are selected, the one in the middle will be implicitly included in fullscreen. In order to communicate to the user that this isn't a bug, but a requirement, we add a checkered pattern to that monitor. 

---

![hover_mouse](https://user-images.githubusercontent.com/9110669/123926189-ef18e600-d98b-11eb-9fca-637b143957e0.png)

**Image 4**: Further information that can be used to identify a monitor is shown when hovering over it. The information varies depending on the operating system and whether XRANDR is available (Linux). The resolution and coordinates should always be there, because it comes directly from FLTK. 

---

![all_monitors](https://user-images.githubusercontent.com/9110669/123926464-2f786400-d98c-11eb-86ae-9ee67392031c.png)

**Image 5**: When another mode is used,  the monitor selection configuration is disabled. 

---

![disabled_state](https://user-images.githubusercontent.com/9110669/123926657-63ec2000-d98c-11eb-92e2-a725a079fcb9.png)

**Image 6**: When fullscreen is not  used, the configuration panel also disabled. It could be argued that this shouldn't be the case, because the user might want to configure what settings should be used when they enter full screen mode later on. 

## CLI and config file 

Two new flags have been added; `FullScreenSelectedMonitors` and `FullScreenMode`. 

`FullScreenSelectedMonitors` can be set to a list of monitors that should be selected. Indices that are invalid or non-existent will be ignored. If the same index is repeated, the duplicates will be ignored. 

`FullScreenMode` can either be `Current`, `All` or `Selected`. The default mode is `Current`, corresponding to the old default fullscreen mode. `All` deprecates the existing flag `FullScreenAllMonitors=1`, to avoid invalid states, such as having enabled `FullScreenAllMonitors` and fullscreen on selected monitors simultaneously. 

Examples: 

```bash
$ vncviewer --FullScreenMode=Selected --FullScreenSelectedMonitors=1,3
$ vncviewer --FullScreenMode=Current
$ vncviewer --FullScreenMode=All
```

# TODO

- [x] Maintain the behaviour of existing configuration options. 
    - [x] `fullScreen = 1`
    - [x] `fullScreenAllMonitors`
- [x] Additional information on hover
    - [x] Linux 
    - [x] macOS
    - [x] Windows
- [x] Test the sorting of monitor indices, to make sure that it is correct with different configurations and operating systems.
- [x] Add documentation of new flags to the man pages.
- [x] Add default value for `fullScreenSelectedMonitors`.
- [x] Verify that all strings are localized. 
...

## Known issues

- [x] Grabbing will probably not work on macOS (due to `vncviewer/DesktopWindow.cxx:908`).
- [x] The “Press F8 to open the context menu”-overlay, displayed after connecting, is off-center (due to `vncviewer/DesktopWindow.cxx:467-501`).
- [x] `DesktopWindow: Failure grabbing keyboard`
- [x] ~~`XRequest.131: BadWindow (invalid Window parameter) 0x4a00079`~~ (also happens on the master branch, triggered by exiting vncviewer by pressing F8 and then enter with the mouse on a different screen than the active session).
- [x] ~~`Touch:       Unable to get X Input 2 event mask for window 0x04a00079`~~
- [x] macOS have negative monitor coordinates, which breaks the GUI

# Testing and verification

Acceptance criterias that can be useful for testing and verification can be found here:  [Bug 7006 - full screen over multiple, but not all monitors](https://www.cendio.com/bugzilla/show_bug.cgi?id=7006).

- [x] Linux
    - [x] Gnome
    - [x] KDE (probably not supported due to missing fullscreen features?)
    - [x] X11
    - [x] Wayland
- [x] Windows
- [x] macOS
…

---

The lists will be continuously updated as I continue my work. I gladly accept thoughts, feedback and code review of the implementation! :) 




