### PR TITLE
Fix inconsistent line endings in vncviewer configuration file

### DIFF
--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -585,8 +585,8 @@ void saveViewerParameters(const char *filename, const char *servername) {
     throw Exception(_("Failed to write configuration file, can't open %s: %s"),
                     filepath, strerror(errno));
   
-  fprintf(f, "%s\r\n", IDENTIFIER_STRING);
-  fprintf(f, "\r\n");
+  fprintf(f, "%s\n", IDENTIFIER_STRING);
+  fprintf(f, "\n");
 
   if (encodeValue(servername, encodingBuffer, buffersize))
     fprintf(f, "ServerName=%s\n", encodingBuffer);


### PR DESCRIPTION
This may be trivial, but it is a bit annoying seeing `^M` in first two lines of `default.tigervnc` in vim.