### PR TITLE
Allow building with -DBUILD_VIEWER=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,31 +229,33 @@ if(BUILD_JAVA)
   add_subdirectory(java)
 endif()
 
-# Check for FLTK
-set(FLTK_SKIP_FLUID TRUE)
-set(FLTK_SKIP_OPENGL TRUE)
-set(FLTK_SKIP_FORMS TRUE)
-find_package(FLTK)
-
-if(UNIX AND NOT APPLE)
-  # No proper handling for extra X11 libs that FLTK might need...
-  if(X11_Xft_FOUND)
-    # Xft headers include references to fontconfig, so we need
-    # to link to that as well
-    find_library(FONTCONFIG_LIB fontconfig)
-    set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xft_LIB} ${FONTCONFIG_LIB})
-  endif()
-  if(X11_Xinerama_FOUND)
-    set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xinerama_LIB})
-  endif()
-  if(X11_Xfixes_FOUND)
-    set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xfixes_LIB})
-  endif()
-  if(X11_Xcursor_FOUND)
-    set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xcursor_LIB})
-  endif()
-  if(X11_Xrender_FOUND)
-    set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xrender_LIB})
+option(BUILD_VIEWER "Build TigerVNC viewer" ON)
+if(BUILD_VIEWER)
+  # Check for FLTK
+  set(FLTK_SKIP_FLUID TRUE)
+  set(FLTK_SKIP_OPENGL TRUE)
+  set(FLTK_SKIP_FORMS TRUE)
+  find_package(FLTK REQUIRED)
+  if(UNIX AND NOT APPLE)
+    # No proper handling for extra X11 libs that FLTK might need...
+    if(X11_Xft_FOUND)
+      # Xft headers include references to fontconfig, so we need
+      # to link to that as well
+      find_library(FONTCONFIG_LIB fontconfig)
+      set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xft_LIB} ${FONTCONFIG_LIB})
+    endif()
+    if(X11_Xinerama_FOUND)
+      set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xinerama_LIB})
+    endif()
+    if(X11_Xfixes_FOUND)
+      set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xfixes_LIB})
+    endif()
+    if(X11_Xcursor_FOUND)
+      set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xcursor_LIB})
+    endif()
+    if(X11_Xrender_FOUND)
+      set(FLTK_LIBRARIES ${FLTK_LIBRARIES} ${X11_Xrender_LIB})
+    endif()
   endif()
 endif()
 
@@ -303,7 +305,6 @@ if(ENABLE_NLS)
   add_subdirectory(po)
 endif()
 
-option(BUILD_VIEWER "Build TigerVNC viewer" ON)
 if(BUILD_VIEWER)
   add_subdirectory(vncviewer)
   add_subdirectory(media)
@@ -312,7 +313,9 @@ endif()
 add_subdirectory(tests)
 
 
-add_subdirectory(release)
+if(BUILD_VIEWER)
+  add_subdirectory(release)
+endif()
 
 # uninstall
 configure_file("${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -119,7 +119,7 @@ if(BUILD_STATIC)
     string(STRIP ${GNUTLS_LIBRARIES} GNUTLS_LIBRARIES)
   endif()
 
-  if(FLTK_FOUND)
+  if(DEFINED FLTK_LIBRARIES)
     set(FLTK_LIBRARIES "-Wl,-Bstatic -lfltk_images -lpng -ljpeg -lfltk -Wl,-Bdynamic")
 
     if(WIN32)

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(${FLTK_INCLUDE_DIR})
 include_directories(${GETTEXT_INCLUDE_DIR})
 
 include_directories(${CMAKE_SOURCE_DIR}/common)
@@ -14,27 +13,30 @@ target_link_libraries(decperf test_util rfb)
 add_executable(encperf encperf.cxx)
 target_link_libraries(encperf test_util rfb)
 
-set(FBPERF_SOURCES
-  fbperf.cxx
-  ${CMAKE_SOURCE_DIR}/vncviewer/PlatformPixelBuffer.cxx
-  ${CMAKE_SOURCE_DIR}/vncviewer/Surface.cxx)
-if(WIN32)
-  set(FBPERF_SOURCES ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/Surface_Win32.cxx)
-elseif(APPLE)
+if (BUILD_VIEWER)
+  include_directories(${FLTK_INCLUDE_DIR})
   set(FBPERF_SOURCES
-      ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/Surface_OSX.cxx
-      ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/keysym2ucs.c
-      ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/cocoa.mm)
-else()
-  set(FBPERF_SOURCES ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/Surface_X11.cxx)
-endif()
-add_executable(fbperf ${FBPERF_SOURCES})
-target_link_libraries(fbperf test_util rfb ${FLTK_LIBRARIES} ${GETTEXT_LIBRARIES})
-if(WIN32)
-  target_link_libraries(fbperf msimg32)
-endif()
-if(APPLE)
-  target_link_libraries(fbperf "-framework Cocoa")
-  target_link_libraries(fbperf "-framework Carbon")
-  target_link_libraries(fbperf "-framework IOKit")
+    fbperf.cxx
+    ${CMAKE_SOURCE_DIR}/vncviewer/PlatformPixelBuffer.cxx
+    ${CMAKE_SOURCE_DIR}/vncviewer/Surface.cxx)
+  if(WIN32)
+    set(FBPERF_SOURCES ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/Surface_Win32.cxx)
+  elseif(APPLE)
+    set(FBPERF_SOURCES
+        ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/Surface_OSX.cxx
+        ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/keysym2ucs.c
+        ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/cocoa.mm)
+  else()
+    set(FBPERF_SOURCES ${FBPERF_SOURCES} ${CMAKE_SOURCE_DIR}/vncviewer/Surface_X11.cxx)
+  endif()
+  add_executable(fbperf ${FBPERF_SOURCES})
+  target_link_libraries(fbperf test_util rfb ${FLTK_LIBRARIES} ${GETTEXT_LIBRARIES})
+  if(WIN32)
+    target_link_libraries(fbperf msimg32)
+  endif()
+  if(APPLE)
+    target_link_libraries(fbperf "-framework Cocoa")
+    target_link_libraries(fbperf "-framework Carbon")
+    target_link_libraries(fbperf "-framework IOKit")
+  endif()
 endif()


### PR DESCRIPTION
Without this change I get CMake errors due to use of ${FLTK_INCLUDE_DIR}
and references to the non-existent vncviewer target.