### PR TITLE
Rename Input.h to vncInput.h to fix building on case-insensitive FS 

### DIFF
--- a/unix/xserver/hw/vnc/Makefile.am
+++ b/unix/xserver/hw/vnc/Makefile.am
@@ -13,12 +13,12 @@ noinst_LTLIBRARIES = libvnccommon.la
 HDRS = vncExtInit.h vncHooks.h \
 	vncBlockHandler.h vncSelection.h \
 	XorgGlue.h XserverDesktop.h xorg-version.h \
-	Input.h RFBGlue.h
+	vncInput.h RFBGlue.h
 
 libvnccommon_la_SOURCES = $(HDRS) \
 	vncExt.c vncExtInit.cc vncHooks.c vncSelection.c \
 	vncBlockHandler.c XorgGlue.c RandrGlue.c RFBGlue.cc XserverDesktop.cc \
-	Input.c InputXKB.c qnum_to_xorgevdev.c qnum_to_xorgkbd.c
+	vncInput.c vncInputXKB.c qnum_to_xorgevdev.c qnum_to_xorgkbd.c
 
 libvnccommon_la_CPPFLAGS = -DVENDOR_RELEASE="$(VENDOR_RELEASE)" -I$(TIGERVNC_SRCDIR)/unix/common \
 	-DVENDOR_STRING="\"$(VENDOR_STRING)\"" -I$(TIGERVNC_SRCDIR)/common -UHAVE_CONFIG_H \

--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -46,7 +46,7 @@
 #include "vncHooks.h"
 #include "vncSelection.h"
 #include "XorgGlue.h"
-#include "Input.h"
+#include "vncInput.h"
 
 extern "C" {
 void vncSetGlueContext(int screenIndex);

--- a/unix/xserver/hw/vnc/XserverDesktop.h
+++ b/unix/xserver/hw/vnc/XserverDesktop.h
@@ -36,7 +36,7 @@
 #include <rfb/Configuration.h>
 #include <rfb/Timer.h>
 #include <unixcommon.h>
-#include "Input.h"
+#include "vncInput.h"
 
 namespace rfb {
   class VNCServerST;

--- a/unix/xserver/hw/vnc/vncInput.c
+++ b/unix/xserver/hw/vnc/vncInput.c
@@ -24,7 +24,7 @@
 
 #include "xorg-version.h"
 
-#include "Input.h"
+#include "vncInput.h"
 #include "vncExtInit.h"
 #include "RFBGlue.h"
 

--- a/unix/xserver/hw/vnc/vncInput.h
+++ b/unix/xserver/hw/vnc/vncInput.h
@@ -19,9 +19,8 @@
  * USA.
  */
 
-/* Make sure macro doesn't conflict with macro in include/input.h. */
-#ifndef INPUT_H_
-#define INPUT_H_
+#ifndef __VNCINPUT_H__
+#define __VNCINPUT_H__
 
 #include <stdlib.h>
 #include <X11/X.h>

--- a/unix/xserver/hw/vnc/vncInputXKB.c
+++ b/unix/xserver/hw/vnc/vncInputXKB.c
@@ -36,7 +36,7 @@
 #include "scrnintstr.h"
 #include "mi.h"
 
-#include "Input.h"
+#include "vncInput.h"
 
 #ifndef KEYBOARD_OR_FLOAT
 #define KEYBOARD_OR_FLOAT MASTER_KEYBOARD


### PR DESCRIPTION
I am cross-compiling from macOS for a FreeBSD-derived system so my host
file system is case insensitive but the target isn't. Without this change
I get the following warnings which show that the vnc "Input.h" is being
included from mi/mi.h instead of the xserver "input.h":
```
In file included from /Users/alex/cheri/xvnc-server/hw/vnc/Input.c:33:
/Users/alex/cheri/xvnc-server/mi/mi.h:55:10: warning: non-portable path to file '"Input.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
#include "input.h"
         ^~~~~~~~~
         "Input.h"
```