### PR TITLE
Fix priority string when using newer GnuTLS

### DIFF
--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -238,7 +238,9 @@ void CSecurityTLS::setParam()
     const char *err;
 
 #if GNUTLS_VERSION_NUMBER >= 0x030603
-    ret = gnutls_set_default_priority_append(session, kx_anon_priority, &err, 0);
+    // gnutls_set_default_priority_appends() expects a normal priority string that
+    // doesn't start with ":".
+    ret = gnutls_set_default_priority_append(session, kx_anon_priority + 1, &err, 0);
     if (ret != GNUTLS_E_SUCCESS) {
       if (ret == GNUTLS_E_INVALID_REQUEST)
         vlog.error("GnuTLS priority syntax error at: %s", err);

--- a/common/rfb/SSecurityTLS.cxx
+++ b/common/rfb/SSecurityTLS.cxx
@@ -229,7 +229,9 @@ void SSecurityTLS::setParams(gnutls_session_t session)
     const char *err;
 
 #if GNUTLS_VERSION_NUMBER >= 0x030603
-    ret = gnutls_set_default_priority_append(session, kx_anon_priority, &err, 0);
+    // gnutls_set_default_priority_appends() expects a normal priority string that
+    // doesn't start with ":".
+    ret = gnutls_set_default_priority_append(session, kx_anon_priority + 1, &err, 0);
     if (ret != GNUTLS_E_SUCCESS) {
       if (ret == GNUTLS_E_INVALID_REQUEST)
         vlog.error("GnuTLS priority syntax error at: %s", err);


### PR DESCRIPTION
The call of gnutls_set_default_priority_append() expects a normal priority string, which means it must not start with ':'.

Fixes issue introduced by https://github.com/TigerVNC/tigervnc/pull/1262.