### PR TITLE
Refresh MonitorArrangement on configuration change

### DIFF
--- a/vncviewer/MonitorArrangement.h
+++ b/vncviewer/MonitorArrangement.h
@@ -46,6 +46,9 @@ private:
   // Layout the monitor arrangement.
   void layout();
 
+  // Refresh the monitor arrangement.
+  void refresh();
+
   // Return true if the given monitor is required to be part of the configuration
   // for it to be valid. A configuration is only valid if the framebuffer created
   // from is rectangular.
@@ -68,6 +71,7 @@ private:
   std::string description(int m);
   int get_monitor_name(int m, char name[], size_t name_len);
 
+  static int fltk_event_handler(int event);
   static void monitor_pressed(Fl_Widget *widget, void *user_data);
   static void checkered_pattern_draw(
     int x, int y, int width, int height, Fl_Color color);


### PR DESCRIPTION
MonitorArrangement (in the options dialog) never changes when the system
monitor configuration changes. Therefore, the user can get into a state
where the reality doesn't match what is shown (when a monitor is
added/removed, resolution or position changed etc).

All these changes triggers an event in FLTK
(`FL_SCREEN_CONFIGURATION_CHANGED`). This commit adds an event handler in
MonitorArrangement and refreshes the widget whenever that event occurs.

Because `Fl_Handler` does not have a `void*`-argument (and we must be able
to access the widget from our handler callback) a static set of
instances have been added, which all will receive the events.