### PR TITLE
Add -interface option to x0vncserver

### DIFF
--- a/unix/x0vncserver/x0vncserver.cxx
+++ b/unix/x0vncserver/x0vncserver.cxx
@@ -68,6 +68,9 @@ StringParameter hostsFile("HostsFile", "File with IP access control rules", "");
 BoolParameter localhostOnly("localhost",
                             "Only allow connections from localhost",
                             false);
+StringParameter interface("interface",
+                          "listen on the specified network address",
+                          "all");
 
 static const char* defaultDesktopName()
 {
@@ -304,11 +307,16 @@ int main(int argc, char** argv)
     }
 
     if ((int)rfbport != -1) {
+      const char *addr = interface;
+      if (strcasecmp(addr, "all") == 0)
+        addr = 0;
       if (localhostOnly)
         createLocalTcpListeners(&listeners, (int)rfbport);
       else
-        createTcpListeners(&listeners, 0, (int)rfbport);
-      vlog.info("Listening on port %d", (int)rfbport);
+        createTcpListeners(&listeners, addr, (int)rfbport);
+      vlog.info("Listening for VNC connections on %s interface(s), port %d",
+                localhostOnly ? "local" : (const char*)interface,
+                (int)rfbport);
     }
 
     const char *hostsData = hostsFile.getData();

--- a/unix/x0vncserver/x0vncserver.man
+++ b/unix/x0vncserver/x0vncserver.man
@@ -178,6 +178,10 @@ Only allow connections from the same machine. Useful if you use SSH and want to
 stop non-SSH connections from any other hosts.
 .
 .TP
+.B \-interface \fIIP address\fP
+Listen on interface. By default x0vncserver listens on all available interfaces.
+.
+.TP
 .B \-AlwaysShared
 Always treat incoming connections as shared, regardless of the client-specified
 setting. Default is off.


### PR DESCRIPTION
This PR adds the "-interface" option found in the vncserver also to the x0vncserver.