### PR TITLE
Provide translations on macOS and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,11 @@ if(WIN32)
   add_definitions(-D_WIN32_WINNT=0x0601)
 endif()
 
+# Legacy macros (macOS 10.12 and older) conflict with our code
+if(APPLE)
+  add_definitions(-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0)
+endif()
+
 if(CMAKE_SIZEOF_VOID_P MATCHES 8)
   message(STATUS "64-bit build")
 else()

--- a/release/makemacapp.in
+++ b/release/makemacapp.in
@@ -67,6 +67,12 @@ fi
 install -m 644 $SRCDIR/release/tigervnc.icns "$APPROOT/Contents/Resources/"
 install -m 644 release/Info.plist "$APPROOT/Contents/"
 
+for lang in `cat "$SRCDIR/po/LINGUAS"`; do
+	mkdir -p "$APPROOT/Contents/Resources/locale/$lang/LC_MESSAGES"
+	install -m 644 po/$lang.mo \
+		"$APPROOT/Contents/Resources/locale/$lang/LC_MESSAGES/tigervnc.mo"
+done
+
 install -m 644 $SRCDIR/LICENCE.TXT $TMPDIR/dmg/
 install -m 644 $SRCDIR/README.rst $TMPDIR/dmg/
 

--- a/release/tigervnc.iss.in
+++ b/release/tigervnc.iss.in
@@ -23,6 +23,14 @@ Source: "@CMAKE_BINARY_DIR@\vncviewer\vncviewer.exe"; DestDir: "{app}"; Flags: i
 Source: "@CMAKE_SOURCE_DIR@\README.rst"; DestDir: "{app}"; Flags: ignoreversion
 Source: "@CMAKE_SOURCE_DIR@\LICENCE.TXT"; DestDir: "{app}"; Flags: ignoreversion
 
+#define LINGUAS
+#define Lang
+#sub AddLanguage
+  #define Lang = FileRead(LINGUAS)
+  Source: "@CMAKE_BINARY_DIR@\po\{#Lang}.mo"; DestDir: "{app}\locale\{#Lang}\LC_MESSAGES"; DestName: "tigervnc.mo"; Flags: ignoreversion
+#endsub
+#for {LINGUAS = FileOpen("@CMAKE_SOURCE_DIR@\po\LINGUAS"); !FileEof(LINGUAS); ""} AddLanguage
+
 [Icons]
 Name: "{group}\TigerVNC Viewer"; FileName: "{app}\vncviewer.exe";
 Name: "{group}\Listening TigerVNC Viewer"; FileName: "{app}\vncviewer.exe"; Parameters: "-listen";


### PR DESCRIPTION
We've forgotten to package our translation files in the macOS bundle and the Windows installer. This PR makes sure those are included and makes sure vncviewer finds them, no matter where it is installed.

This fixes most of #1317.