### PR TITLE
Adjust default directory for configuration file save and load

### DIFF
--- a/common/os/os.h
+++ b/common/os/os.h
@@ -39,4 +39,18 @@
  */
 int getvnchomedir(char **dirp);
 
+/*
+ * Get user home directory.
+ * If HOME environment variable is set then it is used.
+ * Otherwise home directory is obtained via getpwuid function.
+ *
+ * Note for Windows:
+ * This functions returns array of TCHARs, not array of chars.
+ *
+ * Returns:
+ * 0 - Success
+ * -1 - Failure
+ */
+int getuserhomedir(char **dirp);
+
 #endif /* OS_OS_H */

--- a/vncviewer/ServerDialog.h
+++ b/vncviewer/ServerDialog.h
@@ -45,10 +45,12 @@ protected:
 private:
   void loadServerHistory();
   void saveServerHistory();
+  void updateUsedDir(const char* filename);
 
 protected:
   Fl_Input_Choice *serverName;
   std::vector<std::string> serverHistory;
+  char *usedDir;
 };
 
 #endif


### PR DESCRIPTION
As suggested in Issue #1065 The dialog for opening a configuration file could have a better default directory