### PR TITLE
Add vncviewer -UseLocalCursor option to fix UltraVNC invisible cursor problem

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -185,8 +185,9 @@ Viewport::Viewport(int w, int h, const rfb::PixelFormat& serverPF, CConn* cc_)
 
   OptionsDialog::addCallback(handleOptions, this);
 
-  // Make sure we have an initial blank cursor set
-  setCursor(0, 0, rfb::Point(0, 0), NULL);
+  if (!useLocalCursor)
+    // Make sure we have an initial blank cursor set
+    setCursor(0, 0, rfb::Point(0, 0), NULL);
 }
 
 
@@ -582,7 +583,8 @@ int Viewport::handle(int event)
     return 1;
 
   case FL_ENTER:
-    window()->cursor(cursor, cursorHotspot.x, cursorHotspot.y);
+    if (!useLocalCursor || cursor)
+      window()->cursor(cursor, cursorHotspot.x, cursorHotspot.y);
     // Yes, we would like some pointer events please!
     return 1;
 
@@ -1315,7 +1317,7 @@ void Viewport::popupContextMenu()
   handle(FL_FOCUS);
 
   // Back to our proper mouse pointer.
-  if (Fl::belowmouse())
+  if (useLocalCursor ? ((Fl::belowmouse() == this) && cursor) : (Fl::belowmouse() != NULL))
     window()->cursor(cursor, cursorHotspot.x, cursorHotspot.y);
 
   if (m == NULL)

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -64,6 +64,8 @@ BoolParameter emulateMiddleButton("EmulateMiddleButton",
 BoolParameter dotWhenNoCursor("DotWhenNoCursor",
                               "Show the dot cursor when the server sends an "
                               "invisible cursor", false);
+BoolParameter useLocalCursor("UseLocalCursor",
+                              "Force a local cursor", false);
 
 BoolParameter alertOnFatalError("AlertOnFatalError",
                                 "Give a dialog on connection problems rather "
@@ -177,6 +179,7 @@ static VoidParameter* parameterArray[] = {
   &SecurityClient::secTypes,
   &emulateMiddleButton,
   &dotWhenNoCursor,
+  &useLocalCursor,
   &reconnectOnError,
   &autoSelect,
   &fullColour,

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -34,6 +34,7 @@
 extern rfb::IntParameter pointerEventInterval;
 extern rfb::BoolParameter emulateMiddleButton;
 extern rfb::BoolParameter dotWhenNoCursor;
+extern rfb::BoolParameter useLocalCursor;
 
 extern rfb::StringParameter passwordFile;
 

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -285,6 +285,10 @@ Use custom compression level. Default if \fBCompressLevel\fP is specified.
 Show the dot cursor when the server sends an invisible cursor. Default is off.
 .
 .TP
+.B \-UseLocalCursor
+Force a local cursor; needed to work around an UltraVNC interoperability problem. Default is off.
+.
+.TP
 .B \-PointerEventInterval \fItime\fP
 Time in milliseconds to rate-limit successive pointer events. Default is
 17 ms (60 Hz).


### PR DESCRIPTION
Please consider merging this patch to add a -UseLocalCursor option to vncviewer so that it will work again
with the UltraVNC server.