### PR TITLE
Workaround FLTK bug that causes OptionsDialog to appear behind DesktopWindow

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -918,12 +918,11 @@ void DesktopWindow::fullscreen_on()
 {
   bool allMonitors = !strcasecmp(fullScreenMode, "all");
   bool selectedMonitors = !strcasecmp(fullScreenMode, "selected");
+  int top, bottom, left, right;
 
   if (not selectedMonitors and not allMonitors) {
-    int n = Fl::screen_num(x(), y(), w(), h());
-    fullscreen_screens(n, n, n, n);
+    top = bottom = left = right = Fl::screen_num(x(), y(), w(), h());
   } else {
-    int top, bottom, left, right;
     int top_y, bottom_y, left_x, right_x;
 
     int sx, sy, sw, sh;
@@ -983,8 +982,17 @@ void DesktopWindow::fullscreen_on()
       }
     }
 
-    fullscreen_screens(top, bottom, left, right);
   }
+#ifdef __APPLE__
+  // This is a workaround for a bug in FLTK, see: https://github.com/fltk/fltk/pull/277
+  int savedLevel;
+  savedLevel = cocoa_get_level(this);
+#endif
+  fullscreen_screens(top, bottom, left, right);
+#ifdef __APPLE__
+  // This is a workaround for a bug in FLTK, see: https://github.com/fltk/fltk/pull/277
+  cocoa_set_level(this, savedLevel);
+#endif
 
   if (!fullscreen_active())
     fullscreen();

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -21,6 +21,9 @@
 
 class Fl_Window;
 
+int cocoa_get_level(Fl_Window *win);
+void cocoa_set_level(Fl_Window *win, int level);
+
 int cocoa_capture_displays(Fl_Window *win);
 void cocoa_release_displays(Fl_Window *win);
 

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -50,6 +50,20 @@ const int kVK_Menu = 0x6E;
 
 static bool captured = false;
 
+int cocoa_get_level(Fl_Window *win)
+{
+  NSWindow *nsw;
+  nsw = (NSWindow*)fl_xid(win);
+  return [nsw level];
+}
+
+void cocoa_set_level(Fl_Window *win, int level)
+{
+  NSWindow *nsw;
+  nsw = (NSWindow*)fl_xid(win);
+  [nsw setLevel:level];
+}
+
 int cocoa_capture_displays(Fl_Window *win)
 {
   NSWindow *nsw;


### PR DESCRIPTION
Fixes #1345, details can be found in that issue. Regression, mainly after #642.

Tested using macOS 11.6 and built using FLTK 1.3.5, both with and without my suggested FLTK fix.