### PR TITLE
Remove modal property from ServerDialog

### DIFF
--- a/vncviewer/ServerDialog.cxx
+++ b/vncviewer/ServerDialog.cxx
@@ -112,8 +112,6 @@ ServerDialog::ServerDialog()
   button->callback(this->handleConnect, this);
 
   callback(this->handleCancel, this);
-
-  set_modal();
 }
 
 


### PR DESCRIPTION
Modal windows are meant to be child windows such as menus or popups that are intended to always appear in front of its parent.

Modal FLTK windows without a parent seem to behave strangely on macOS. Such windows can appear in front of their modal children windows. When opening OptionsDialog from ServerDialog, it was easy to get to a broken state by then switching focus back to the ServerDialog. This would cause the ServerDialog to appear in front, but not be useable as the options window would still have control of mouse and keyboard.

Additionally, modal windows without parents appear in front of other normal applications on macOS. This means that the ServerDialog couldn't be put behind Safari for example.

The fact that ServerDialog was a "modal" window was a bit strange, seeing as it doesn't have any parent windows. Removing the modal property from this window causes all the strange-ness to go away.