### PR TITLE
SELinux: restore SELinux context in case of different policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,19 @@ if(UNIX AND NOT APPLE)
   endif()
 endif()
 
+# Check for SELinux library
+if(UNIX AND NOT APPLE)
+  check_include_files(selinux/selinux.h HAVE_SELINUX_H)
+  if(HAVE_SELINUX_H)
+    set(CMAKE_REQUIRED_LIBRARIES -lselinux)
+    set(CMAKE_REQUIRED_LIBRARIES)
+    set(SELINUX_LIBS selinux)
+    add_definitions("-DHAVE_SELINUX")
+  else()
+    message(WARNING "Could not find SELinux development files")
+  endif()
+endif()
+
 # Generate config.h and make sure the source finds it
 configure_file(config.h.in config.h)
 add_definitions(-DHAVE_CONFIG_H)

--- a/unix/vncserver/CMakeLists.txt
+++ b/unix/vncserver/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(vncsession vncsession.c)
-target_link_libraries(vncsession ${PAM_LIBS})
+target_link_libraries(vncsession ${PAM_LIBS} ${SELINUX_LIBS})
 
 configure_file(vncserver@.service.in vncserver@.service @ONLY)
 configure_file(vncsession-start.in vncsession-start @ONLY)


### PR DESCRIPTION
Try to restore SELinux context when it doesn't match current SELinux policy, which can happen when upgrading from Tigervnc 1.11.0 to any newer  version.

I have some questions:
1) When testing this, I got following error: `setxattr failed: /home/jgrulich/.vnc/: Operation not permitted`. I don't know if it's harmless or whether it can be avoided, but it successfuly changed the context.
2) Is checking whether the SELinux context `has vnc_home_t` enough? Or should I rather check whether it's equal to `unconfined_u:object_r:vnc_home_t:s0`?

CC: @zpytela 