### PR TITLE
Deduplicate vncviewer error messages

### DIFF
--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -277,8 +277,7 @@ void CConn::socketEvent(FL_SOCKET fd, void *data)
     }
   } catch (rdr::Exception& e) {
     vlog.error("%s", e.str());
-    abort_connection(_("An unexpected error occurred when communicating "
-                     "with the server:\n\n%s"), e.str());
+    abort_connection_with_unexpected_error(e);
   }
 
   when = FL_READ | FL_EXCEPT;

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -572,9 +572,7 @@ int Viewport::handle(int event)
       cc->sendClipboardData(filtered);
     } catch (rdr::Exception& e) {
       vlog.error("%s", e.str());
-      abort_connection(_("An unexpected error occurred when "
-                         "communicating with the server:\n\n%s"),
-                       e.str());
+      abort_connection_with_unexpected_error(e);
     }
 
     strFree(filtered);
@@ -670,9 +668,7 @@ void Viewport::sendPointerEvent(const rfb::Point& pos, int buttonMask)
       cc->writer()->writePointerEvent(pos, buttonMask);
     } catch (rdr::Exception& e) {
       vlog.error("%s", e.str());
-      abort_connection(_("An unexpected error occurred when "
-                         "communicating with the server:\n\n%s"),
-                       e.str());
+      abort_connection_with_unexpected_error(e);
     }
   } else {
     if (!Fl::has_timeout(handlePointerTimeout, this))
@@ -773,9 +769,7 @@ void Viewport::handleClipboardChange(int source, void *data)
     self->cc->announceClipboard(true);
   } catch (rdr::Exception& e) {
     vlog.error("%s", e.str());
-    abort_connection(_("An unexpected error occurred when "
-                       "communicating with the server:\n\n%s"),
-                     e.str());
+    abort_connection_with_unexpected_error(e);
   }
 }
 
@@ -788,9 +782,7 @@ void Viewport::flushPendingClipboard()
       cc->requestClipboard();
     } catch (rdr::Exception& e) {
       vlog.error("%s", e.str());
-      abort_connection(_("An unexpected error occurred when "
-                         "communicating with the server:\n\n%s"),
-                       e.str());
+      abort_connection_with_unexpected_error(e);
     }
   }
   if (pendingClientClipboard) {
@@ -799,9 +791,7 @@ void Viewport::flushPendingClipboard()
       cc->announceClipboard(true);
     } catch (rdr::Exception& e) {
       vlog.error("%s", e.str());
-      abort_connection(_("An unexpected error occurred when "
-                         "communicating with the server:\n\n%s"),
-                       e.str());
+      abort_connection_with_unexpected_error(e);
     }
   }
 
@@ -827,9 +817,7 @@ void Viewport::handlePointerTimeout(void *data)
                                           self->lastButtonMask);
   } catch (rdr::Exception& e) {
     vlog.error("%s", e.str());
-    abort_connection(_("An unexpected error occurred when "
-                       "communicating with the server:\n\n%s"),
-                     e.str());
+    abort_connection_with_unexpected_error(e);
   }
 }
 
@@ -898,9 +886,7 @@ void Viewport::handleKeyPress(int keyCode, rdr::U32 keySym)
       cc->writer()->writeKeyEvent(keySym, keyCode, true);
   } catch (rdr::Exception& e) {
     vlog.error("%s", e.str());
-    abort_connection(_("An unexpected error occurred when "
-                       "communicating with the server:\n\n%s"),
-                     e.str());
+    abort_connection_with_unexpected_error(e);
   }
 }
 
@@ -934,9 +920,7 @@ void Viewport::handleKeyRelease(int keyCode)
       cc->writer()->writeKeyEvent(iter->second, keyCode, false);
   } catch (rdr::Exception& e) {
     vlog.error("%s", e.str());
-    abort_connection(_("An unexpected error occurred when "
-                       "communicating with the server:\n\n%s"),
-                     e.str());
+    abort_connection_with_unexpected_error(e);
   }
 
   downKeySym.erase(iter);

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -56,6 +56,7 @@
 #include <rfb/LogWriter.h>
 #include <rfb/Timer.h>
 #include <rfb/Exception.h>
+#include <rdr/Exception.h>
 #include <network/TcpSocket.h>
 #include <os/os.h>
 
@@ -155,6 +156,11 @@ void abort_connection(const char *error, ...)
   }
 
   exitMainloop = true;
+}
+
+void abort_connection_with_unexpected_error(const rdr::Exception &e) {
+  abort_connection(_("An unexpected error occurred when communicating "
+                     "with the server:\n\n%s"), e.str());
 }
 
 void disconnect()

--- a/vncviewer/vncviewer.h
+++ b/vncviewer/vncviewer.h
@@ -27,8 +27,14 @@
 #  define __printf_attr(a, b)
 #endif // __GNUC__
 
+namespace rdr {
+  struct Exception;
+};
+
 void abort_vncviewer(const char *error, ...) __printf_attr(1, 2);
 void abort_connection(const char *error, ...) __printf_attr(1, 2);
+void abort_connection_with_unexpected_error(const rdr::Exception &);
+
 void disconnect();
 bool should_disconnect();
 


### PR DESCRIPTION
vncviewer previously had a the same localized error message duplicated
on a bunch of places. Pull these duplicates out into a single function.