### PR TITLE
Be consistent in "full screen" and "full-screen" use

### DIFF
--- a/java/com/tigervnc/vncviewer/Parameters.java
+++ b/java/com/tigervnc/vncviewer/Parameters.java
@@ -117,7 +117,7 @@ public class Parameters {
 
   public static BoolParameter fullScreen
   = new BoolParameter("FullScreen",
-    "Full Screen Mode",
+    "Enable full screen",
     false);
 
   public static BoolParameter fullScreenAllMonitors

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -613,7 +613,7 @@ void DesktopWindow::resize(int x, int y, int w, int h)
         Fl::screen_xywh(sx, sy, sw, sh, i);
 
         if ((sx == x) && (sy == y) && (sw == w) && (sh == h)) {
-          vlog.info(_("Adjusting window size to avoid accidental full screen request"));
+          vlog.info(_("Adjusting window size to avoid accidental full-screen request"));
           // Assume a panel of some form and adjust the height
           y += 20;
           h -= 40;

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -806,7 +806,7 @@ void OptionsDialog::createScreenPage(int tx, int ty, int tw, int th)
   fullScreenCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,
-                                                  _("Enable full-screen")));
+                                                  _("Enable full screen")));
   ty += CHECK_HEIGHT + INNER_MARGIN;
 
   width = tw - OUTER_MARGIN * 2;

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -160,7 +160,7 @@ StringParameter menuKey("MenuKey", "The key which brings up the popup menu",
 
 BoolParameter fullscreenSystemKeys("FullscreenSystemKeys",
                                    "Pass special keys (like Alt+Tab) directly "
-                                   "to the server when in full screen mode.",
+                                   "to the server when in full-screen mode.",
                                    true);
 
 #ifndef WIN32

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -96,7 +96,7 @@ By default, key presses in the popup menu get sent to the VNC server and
 dismiss the popup.  So to get an F8 through to the VNC server simply press it
 twice.
 
-.SH FULL SCREEN MODE
+.SH FULL-SCREEN MODE
 A full-screen mode is supported.  This is particularly useful when connecting
 to a remote screen which is the same size as your local one. If the remote
 screen is bigger, you can scroll by bumping the mouse against the edge of the


### PR DESCRIPTION
Previously, there were a number of inconsistencies in the use of
"full-screen" and "full screen" in logs, documentation, and user
interfaces. The consensus seems to be that "full screen" is correct when
used as a noun while "full-screen" is correct when used as an
adjective. These inconsistencies have now been adjusted to follow
consensus.