### PR TITLE
Reorganise options dialog

### DIFF
--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -55,7 +55,7 @@ using namespace rfb;
 std::map<OptionsCallback*, void*> OptionsDialog::callbacks;
 
 OptionsDialog::OptionsDialog()
-  : Fl_Window(450, 450, _("VNC Viewer: Connection Options"))
+  : Fl_Window(450, 460, _("VNC Viewer: Connection Options"))
 {
   int x, y;
   Fl_Button *button;
@@ -689,8 +689,13 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 {
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Input"));
 
+  int orig_tx;
+  int width;
+
   tx += OUTER_MARGIN;
   ty += OUTER_MARGIN;
+
+  width = tw - OUTER_MARGIN * 2;
 
   viewOnlyCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                   CHECK_MIN_WIDTH,
@@ -698,55 +703,129 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
                                                   _("View only (ignore mouse and keyboard)")));
   ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
-  emulateMBCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
-                                                   CHECK_MIN_WIDTH,
-                                                   CHECK_HEIGHT,
-                                                   _("Emulate middle mouse button")));
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+  orig_tx = tx;
 
-  acceptClipboardCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
-                                                         CHECK_MIN_WIDTH,
-                                                         CHECK_HEIGHT,
-                                                         _("Accept clipboard from server")));
-  acceptClipboardCheckbox->callback(handleClipboard, this);
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+  /* Mouse */
+  ty += GROUP_LABEL_OFFSET;
+  mouseGroup = new Fl_Group(tx, ty, width, 0, _("Mouse"));
+  mouseGroup->box(FL_ENGRAVED_BOX);
+  mouseGroup->align(FL_ALIGN_LEFT | FL_ALIGN_TOP);
 
-#if !defined(WIN32) && !defined(__APPLE__)
-  setPrimaryCheckbox = new Fl_Check_Button(LBLRIGHT(tx + INDENT, ty,
-                                                    CHECK_MIN_WIDTH,
-                                                    CHECK_HEIGHT,
-                                                    _("Also set primary selection")));
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
-#endif
+  /* Needed for final resize to work sanely */
+  mouseGroup->resizable(NULL);
 
-  sendClipboardCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
-                                                       CHECK_MIN_WIDTH,
-                                                       CHECK_HEIGHT,
-                                                       _("Send clipboard to server")));
-  sendClipboardCheckbox->callback(handleClipboard, this);
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+  {
+    tx += GROUP_MARGIN;
+    ty += GROUP_MARGIN;
 
-#if !defined(WIN32) && !defined(__APPLE__)
-  sendPrimaryCheckbox = new Fl_Check_Button(LBLRIGHT(tx + INDENT, ty,
+    emulateMBCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                      CHECK_MIN_WIDTH,
                                                      CHECK_HEIGHT,
-                                                     _("Send primary selection as clipboard")));
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
-#endif
+                                                     _("Emulate middle mouse button")));
+    ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
-  systemKeysCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
+    dotCursorCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                     CHECK_MIN_WIDTH,
                                                     CHECK_HEIGHT,
-                                                    _("Pass system keys directly to server (full screen)")));
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+                                                    _("Show dot when no cursor")));
+    ty += CHECK_HEIGHT + TIGHT_MARGIN;
+  }
+  ty += GROUP_MARGIN - TIGHT_MARGIN;
 
-  menuKeyChoice = new Fl_Choice(LBLLEFT(tx, ty, 150, CHOICE_HEIGHT, _("Menu key")));
+  mouseGroup->end();
+  mouseGroup->size(mouseGroup->w(), ty - mouseGroup->y());
 
-  fltk_menu_add(menuKeyChoice, _("None"), 0, NULL, (void*)0, FL_MENU_DIVIDER);
-  for (int i = 0; i < getMenuKeySymbolCount(); i++)
-    fltk_menu_add(menuKeyChoice, getMenuKeySymbols()[i].name, 0, NULL, 0, 0);
+  /* Back to normal */
+  tx = orig_tx;
+  ty += INNER_MARGIN;
 
-  ty += CHOICE_HEIGHT + TIGHT_MARGIN;
+  /* Keyboard */
+  ty += GROUP_LABEL_OFFSET;
+  keyboardGroup = new Fl_Group(tx, ty, width, 0, _("Keyboard"));
+  keyboardGroup->box(FL_ENGRAVED_BOX);
+  keyboardGroup->align(FL_ALIGN_LEFT | FL_ALIGN_TOP);
+
+  /* Needed for final resize to work sanely */
+  keyboardGroup->resizable(NULL);
+
+  {
+    tx += GROUP_MARGIN;
+    ty += GROUP_MARGIN;
+
+    systemKeysCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
+                                                      CHECK_MIN_WIDTH,
+                                                      CHECK_HEIGHT,
+                                                      _("Pass system keys directly to server (full screen)")));
+    ty += CHECK_HEIGHT + TIGHT_MARGIN;
+
+    menuKeyChoice = new Fl_Choice(LBLLEFT(tx, ty, 150, CHOICE_HEIGHT, _("Menu key")));
+
+    fltk_menu_add(menuKeyChoice, _("None"), 0, NULL, (void*)0, FL_MENU_DIVIDER);
+    for (int i = 0; i < getMenuKeySymbolCount(); i++)
+      fltk_menu_add(menuKeyChoice, getMenuKeySymbols()[i].name, 0, NULL, 0, 0);
+
+    ty += CHOICE_HEIGHT + TIGHT_MARGIN;
+  }
+  ty += GROUP_MARGIN - TIGHT_MARGIN;
+
+  keyboardGroup->end();
+  keyboardGroup->size(keyboardGroup->w(), ty - keyboardGroup->y());
+
+  /* Back to normal */
+  tx = orig_tx;
+  ty += INNER_MARGIN;
+
+  /* Clipboard */
+  ty += GROUP_LABEL_OFFSET;
+  clipboardGroup = new Fl_Group(tx, ty, width, 0, _("Clipboard"));
+  clipboardGroup->box(FL_ENGRAVED_BOX);
+  clipboardGroup->align(FL_ALIGN_LEFT | FL_ALIGN_TOP);
+
+  /* Needed for final resize to work sanely */
+  clipboardGroup->resizable(NULL);
+
+  {
+    tx += GROUP_MARGIN;
+    ty += GROUP_MARGIN;
+
+    acceptClipboardCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
+                                                           CHECK_MIN_WIDTH,
+                                                           CHECK_HEIGHT,
+                                                           _("Accept clipboard from server")));
+    acceptClipboardCheckbox->callback(handleClipboard, this);
+    ty += CHECK_HEIGHT + TIGHT_MARGIN;
+
+#if !defined(WIN32) && !defined(__APPLE__)
+    setPrimaryCheckbox = new Fl_Check_Button(LBLRIGHT(tx + INDENT, ty,
+                                                      CHECK_MIN_WIDTH,
+                                                      CHECK_HEIGHT,
+                                                      _("Also set primary selection")));
+    ty += CHECK_HEIGHT + TIGHT_MARGIN;
+#endif
+
+    sendClipboardCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
+                                                         CHECK_MIN_WIDTH,
+                                                         CHECK_HEIGHT,
+                                                         _("Send clipboard to server")));
+    sendClipboardCheckbox->callback(handleClipboard, this);
+    ty += CHECK_HEIGHT + TIGHT_MARGIN;
+
+#if !defined(WIN32) && !defined(__APPLE__)
+    sendPrimaryCheckbox = new Fl_Check_Button(LBLRIGHT(tx + INDENT, ty,
+                                                       CHECK_MIN_WIDTH,
+                                                       CHECK_HEIGHT,
+                                                       _("Send primary selection as clipboard")));
+    ty += CHECK_HEIGHT + TIGHT_MARGIN;
+#endif
+  }
+  ty += GROUP_MARGIN - TIGHT_MARGIN;
+
+  clipboardGroup->end();
+  clipboardGroup->size(clipboardGroup->w(), ty - clipboardGroup->y());
+
+  /* Back to normal */
+  tx = orig_tx;
+  ty += INNER_MARGIN;
 
   group->end();
 }
@@ -756,57 +835,77 @@ void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
 {
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Display"));
 
+  int orig_tx;
+  int width;
+
   tx += OUTER_MARGIN;
   ty += OUTER_MARGIN;
 
-  windowedButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
-                                                RADIO_MIN_WIDTH,
-                                                RADIO_HEIGHT,
-                                                _("Windowed")));
-  windowedButton->type(FL_RADIO_BUTTON);
-  windowedButton->callback(handleFullScreenMode, this);
-  ty += RADIO_HEIGHT + TIGHT_MARGIN;
+  width = tw - OUTER_MARGIN * 2;
 
-  currentMonitorButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
-                                                      RADIO_MIN_WIDTH,
-                                                      RADIO_HEIGHT,
-                                                      _("Full screen on current monitor")));
-  currentMonitorButton->type(FL_RADIO_BUTTON);
-  currentMonitorButton->callback(handleFullScreenMode, this);
-  ty += RADIO_HEIGHT + TIGHT_MARGIN;
+  orig_tx = tx;
 
-  allMonitorsButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
-                                          RADIO_MIN_WIDTH,
-                                          RADIO_HEIGHT,
-                                          _("Full screen on all monitors")));
-  allMonitorsButton->type(FL_RADIO_BUTTON);
-  allMonitorsButton->callback(handleFullScreenMode, this);
-  ty += RADIO_HEIGHT + TIGHT_MARGIN;
+  /* Display mode */
+  ty += GROUP_LABEL_OFFSET;
+  displayModeGroup = new Fl_Group(tx, ty, width, 0, _("Display mode"));
+  displayModeGroup->box(FL_ENGRAVED_BOX);
+  displayModeGroup->align(FL_ALIGN_LEFT | FL_ALIGN_TOP);
 
-  selectedMonitorsButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
-                                               RADIO_MIN_WIDTH,
-                                               RADIO_HEIGHT,
-                                               _("Full screen on selected monitor(s)")));
-  selectedMonitorsButton->type(FL_RADIO_BUTTON);
-  selectedMonitorsButton->callback(handleFullScreenMode, this);
-  ty += RADIO_HEIGHT + TIGHT_MARGIN;
+  /* Needed for final resize to work sanely */
+  displayModeGroup->resizable(NULL);
 
-  /*
-   * Right now these occupy all remaining space, but that can probably
-   * be reduced if we add more stuff to this page.
-   */
-  int full_width = tw - OUTER_MARGIN * 2;
-  int margin_width = full_width - INDENT;
-  int full_height = th;
-  int margin_height = full_height - ty + INNER_MARGIN;
+  {
+    tx += GROUP_MARGIN;
+    ty += GROUP_MARGIN;
+    width -= GROUP_MARGIN * 2;
 
-  monitorArrangement = new MonitorArrangement(
-                            tx + INDENT,
-                            ty,
-                            margin_width,
-                            margin_height);
+    windowedButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
+                                                  RADIO_MIN_WIDTH,
+                                                  RADIO_HEIGHT,
+                                                  _("Windowed")));
+    windowedButton->type(FL_RADIO_BUTTON);
+    windowedButton->callback(handleFullScreenMode, this);
+    ty += RADIO_HEIGHT + TIGHT_MARGIN;
 
-  ty += CHECK_HEIGHT + margin_height;
+    currentMonitorButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
+                                                        RADIO_MIN_WIDTH,
+                                                        RADIO_HEIGHT,
+                                                        _("Full screen on current monitor")));
+    currentMonitorButton->type(FL_RADIO_BUTTON);
+    currentMonitorButton->callback(handleFullScreenMode, this);
+    ty += RADIO_HEIGHT + TIGHT_MARGIN;
+
+    allMonitorsButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
+                                            RADIO_MIN_WIDTH,
+                                            RADIO_HEIGHT,
+                                            _("Full screen on all monitors")));
+    allMonitorsButton->type(FL_RADIO_BUTTON);
+    allMonitorsButton->callback(handleFullScreenMode, this);
+    ty += RADIO_HEIGHT + TIGHT_MARGIN;
+
+    selectedMonitorsButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
+                                                 RADIO_MIN_WIDTH,
+                                                 RADIO_HEIGHT,
+                                                 _("Full screen on selected monitor(s)")));
+    selectedMonitorsButton->type(FL_RADIO_BUTTON);
+    selectedMonitorsButton->callback(handleFullScreenMode, this);
+    ty += RADIO_HEIGHT + TIGHT_MARGIN;
+
+    monitorArrangement = new MonitorArrangement(
+                              tx + INDENT, ty,
+                              width - INDENT, 150);
+    ty += 150 + TIGHT_MARGIN;
+  }
+  ty += GROUP_MARGIN - TIGHT_MARGIN;
+
+  displayModeGroup->end();
+  displayModeGroup->size(displayModeGroup->w(),
+                         ty - displayModeGroup->y());
+
+  /* Back to normal */
+  tx = orig_tx;
+  ty += INNER_MARGIN;
+  width = tw - OUTER_MARGIN * 2;
 
   group->end();
 }
@@ -829,12 +928,6 @@ void OptionsDialog::createMiscPage(int tx, int ty, int tw, int th)
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,
                                                   _("Ask to reconnect on connection errors")));
-  ty += CHECK_HEIGHT + TIGHT_MARGIN;
-
-  dotCursorCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
-                                                  CHECK_MIN_WIDTH,
-                                                  CHECK_HEIGHT,
-                                                  _("Show dot when no cursor")));
   ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
   group->end();

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -72,7 +72,7 @@ OptionsDialog::OptionsDialog()
     createCompressionPage(tx, ty, tw, th);
     createSecurityPage(tx, ty, tw, th);
     createInputPage(tx, ty, tw, th);
-    createScreenPage(tx, ty, tw, th);
+    createDisplayPage(tx, ty, tw, th);
     createMiscPage(tx, ty, tw, th);
   }
 
@@ -281,7 +281,7 @@ void OptionsDialog::loadOptions(void)
     if (!strcmp(getMenuKeySymbols()[i].name, menuKeyBuf))
       menuKeyChoice->value(i + 1);
 
-  /* Screen */
+  /* Display */
   if (!fullScreen) {
     windowedButton->setonly();
   } else {
@@ -391,7 +391,7 @@ void OptionsDialog::storeOptions(void)
     menuKey.setParam(menuKeyChoice->text());
   }
 
-  /* Screen */
+  /* Display */
   if (windowedButton->value()) {
     fullScreen.setParam(false);
   } else {
@@ -752,9 +752,9 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 }
 
 
-void OptionsDialog::createScreenPage(int tx, int ty, int tw, int th)
+void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
 {
-  Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Screen"));
+  Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Display"));
 
   tx += OUTER_MARGIN;
   ty += OUTER_MARGIN;

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -108,7 +108,13 @@ protected:
 
   /* Input */
   Fl_Check_Button *viewOnlyCheckbox;
+  Fl_Group *mouseGroup;
   Fl_Check_Button *emulateMBCheckbox;
+  Fl_Check_Button *dotCursorCheckbox;
+  Fl_Group *keyboardGroup;
+  Fl_Check_Button *systemKeysCheckbox;
+  Fl_Choice *menuKeyChoice;
+  Fl_Group *clipboardGroup;
   Fl_Check_Button *acceptClipboardCheckbox;
 #if !defined(WIN32) && !defined(__APPLE__)
   Fl_Check_Button *setPrimaryCheckbox;
@@ -117,10 +123,9 @@ protected:
 #if !defined(WIN32) && !defined(__APPLE__)
   Fl_Check_Button *sendPrimaryCheckbox;
 #endif
-  Fl_Check_Button *systemKeysCheckbox;
-  Fl_Choice *menuKeyChoice;
 
   /* Display */
+  Fl_Group *displayModeGroup;
   Fl_Round_Button *windowedButton;
   Fl_Round_Button *currentMonitorButton;
   Fl_Round_Button *allMonitorsButton;
@@ -130,7 +135,6 @@ protected:
   /* Misc. */
   Fl_Check_Button *sharedCheckbox;
   Fl_Check_Button *reconnectCheckbox;
-  Fl_Check_Button *dotCursorCheckbox;
 };
 
 #endif

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -54,7 +54,7 @@ protected:
   void createCompressionPage(int tx, int ty, int tw, int th);
   void createSecurityPage(int tx, int ty, int tw, int th);
   void createInputPage(int tx, int ty, int tw, int th);
-  void createScreenPage(int tx, int ty, int tw, int th);
+  void createDisplayPage(int tx, int ty, int tw, int th);
   void createMiscPage(int tx, int ty, int tw, int th);
 
   static void handleAutoselect(Fl_Widget *widget, void *data);
@@ -120,7 +120,7 @@ protected:
   Fl_Check_Button *systemKeysCheckbox;
   Fl_Choice *menuKeyChoice;
 
-  /* Screen */
+  /* Display */
   Fl_Round_Button *windowedButton;
   Fl_Round_Button *currentMonitorButton;
   Fl_Round_Button *allMonitorsButton;

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -1,4 +1,4 @@
-/* Copyright 2011 Pierre Ossman <ossman@cendio.se> for Cendio AB
+/* Copyright 2011-2021 Pierre Ossman <ossman@cendio.se> for Cendio AB
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -63,8 +63,6 @@ protected:
 
   static void handleX509(Fl_Widget *widget, void *data);
 
-  static void handleDesktopSize(Fl_Widget *widget, void *data);
-
   static void handleClipboard(Fl_Widget *widget, void *data);
 
   static void handleFullScreenMode(Fl_Widget *widget, void *data);
@@ -123,12 +121,7 @@ protected:
   Fl_Choice *menuKeyChoice;
 
   /* Screen */
-  Fl_Check_Button *desktopSizeCheckbox;
-  Fl_Int_Input *desktopWidthInput;
-  Fl_Int_Input *desktopHeightInput;
-  Fl_Check_Button *remoteResizeCheckbox;
-  Fl_Check_Button *fullScreenCheckbox;
-
+  Fl_Round_Button *windowedButton;
   Fl_Round_Button *currentMonitorButton;
   Fl_Round_Button *allMonitorsButton;
   Fl_Round_Button *selectedMonitorsButton;

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -197,8 +197,6 @@ static VoidParameter* parameterArray[] = {
   &fullScreen,
   &fullScreenMode,
   &fullScreenSelectedMonitors,
-  &desktopSize,
-  &remoteResize,
   /* Input */
   &viewOnly,
   &emulateMiddleButton,

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -169,15 +169,22 @@ StringParameter via("via", "Gateway to tunnel via", "");
 
 static const char* IDENTIFIER_STRING = "TigerVNC Configuration file Version 1.0";
 
+/*
+ * We only save the sub set of parameters that can be modified from
+ * the graphical user interface
+ */
 static VoidParameter* parameterArray[] = {
+  /* Security */
 #ifdef HAVE_GNUTLS
   &CSecurityTLS::X509CA,
   &CSecurityTLS::X509CRL,
 #endif // HAVE_GNUTLS
   &SecurityClient::secTypes,
-  &emulateMiddleButton,
+  /* Misc. */
   &dotWhenNoCursor,
   &reconnectOnError,
+  &shared,
+  /* Compression */
   &autoSelect,
   &fullColour,
   &lowColourLevel,
@@ -186,13 +193,15 @@ static VoidParameter* parameterArray[] = {
   &compressLevel,
   &noJpeg,
   &qualityLevel,
+  /* Screen */
   &fullScreen,
   &fullScreenMode,
   &fullScreenSelectedMonitors,
   &desktopSize,
   &remoteResize,
+  /* Input */
   &viewOnly,
-  &shared,
+  &emulateMiddleButton,
   &acceptClipboard,
   &sendClipboard,
 #if !defined(WIN32) && !defined(__APPLE__)

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -181,7 +181,6 @@ static VoidParameter* parameterArray[] = {
 #endif // HAVE_GNUTLS
   &SecurityClient::secTypes,
   /* Misc. */
-  &dotWhenNoCursor,
   &reconnectOnError,
   &shared,
   /* Compression */
@@ -200,6 +199,7 @@ static VoidParameter* parameterArray[] = {
   /* Input */
   &viewOnly,
   &emulateMiddleButton,
+  &dotWhenNoCursor,
   &acceptClipboard,
   &sendClipboard,
 #if !defined(WIN32) && !defined(__APPLE__)

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -193,7 +193,7 @@ static VoidParameter* parameterArray[] = {
   &compressLevel,
   &noJpeg,
   &qualityLevel,
-  /* Screen */
+  /* Display */
   &fullScreen,
   &fullScreenMode,
   &fullScreenSelectedMonitors,


### PR DESCRIPTION
Some cleanup of the options dialog to hopefully make things more understandable. The major functional difference is presenting a simpler choice for the display mode. Special cases will now need to provide command line options to change the defaults.