### PR TITLE
Update MonitorArrangement widget to match parameter settings after screen configuration change

### DIFF
--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -135,6 +135,10 @@ protected:
   /* Misc. */
   Fl_Check_Button *sharedCheckbox;
   Fl_Check_Button *reconnectCheckbox;
+
+private:
+  static int fltk_event_handler(int event);
+  static void handleScreenConfigTimeout(void *data);
 };
 
 #endif


### PR DESCRIPTION
If the options dialog was open when a screen configuration happened the widget could get out of sync from the settings. A scenario when this happened was:

 1) 3 monitors, fullscreen selected on the two right-most screens
 2) disconnect the left-most screen (the one not selected)

In this case, using GNOME, vncviewer would appear in fullscreen on the right of the two remaining monitors, but the widget would show both monitors selected. The reason was that the MonitorArragement index doesn't work the same way as FLTK's screen index.

It's debatable how vncviewer should behave here, but the GUI should at least match the actual setting.