### PR TITLE
Fix session resize after mirroring on Linux vncviewer

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -21,6 +21,8 @@
 #include <config.h>
 #endif
 
+#include <algorithm>
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -1344,13 +1346,15 @@ void DesktopWindow::remoteResize(int width, int height)
       sx -= viewport_rect.tl.x;
       sy -= viewport_rect.tl.y;
 
-      // Look for perfectly matching existing screen...
+      // Look for perfectly matching existing screen that is not yet present in
+      // in the screen layout...
       for (iter = cc->server.screenLayout().begin();
            iter != cc->server.screenLayout().end(); ++iter) {
         if ((iter->dimensions.tl.x == sx) &&
             (iter->dimensions.tl.y == sy) &&
             (iter->dimensions.width() == sw) &&
-            (iter->dimensions.height() == sh))
+            (iter->dimensions.height() == sh) &&
+            (std::find(layout.begin(), layout.end(), *iter) == layout.end()))
           break;
       }
 

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -1392,15 +1392,17 @@ void DesktopWindow::remoteResize(int width, int height)
       (layout == cc->server.screenLayout()))
     return;
 
-  char buffer[2048];
   vlog.debug("Requesting framebuffer resize from %dx%d to %dx%d",
              cc->server.width(), cc->server.height(), width, height);
-  layout.print(buffer, sizeof(buffer));
-  vlog.debug("%s", buffer);
 
+  char buffer[2048];
+  layout.print(buffer, sizeof(buffer));
   if (!layout.validate(width, height)) {
     vlog.error(_("Invalid screen layout computed for resize request!"));
+    vlog.error("%s", buffer);
     return;
+  } else {
+    vlog.debug("%s", buffer);
   }
 
   cc->writer()->writeSetDesktopSize(width, height, layout);


### PR DESCRIPTION
If monitor mirroring was enabled while in a session with vncviewer
running on Linux, the session would not be properly resized on the
server. This was a consequence of only looking at the size and
coordinates of each screen when matching against existing screens after
the screen layout was changed, when in fact we have two (or more)
monitors with the same coordinates and size (but differing ids). This
led to the same monitor being added twice to the layout which would
later fail layout validation, resulting in no resize request being sent
to the server.

When matching, we now also check if the existing screen is not already
present in the layout before considering it a match.