### PR TITLE
Change Background color of FullScreen Window Borders to Black

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -465,7 +465,7 @@ void DesktopWindow::draw()
   // Redraw background only on full redraws
   if (redraw) {
     if (offscreen)
-      offscreen->clear(40, 40, 40);
+      offscreen->clear(0, 0, 0);
     else
       fl_rectf(0, 0, W, H, 40, 40, 40);
   }


### PR DESCRIPTION
Hello, I would like to propose a tiny patch. My motivation is having vnc client session screen of source computer smaller than actual screen size of local computer. In this case when I go fullscreen to prevent alt+f4 shortcut to work the border of the vnc session is grey. That's a bit disturbing for my work. This patch is a proposal to enter immersive mode by having the blank borders of smaller screen in full screen in black. Thank You