### PR TITLE
Switch to CentOS Stream 8 for builds

### DIFF
--- a/.github/containers/centos8/Dockerfile
+++ b/.github/containers/centos8/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y install sudo


### PR DESCRIPTION
CentOS 8 is EOL and is now replaced with CentOS Stream 8.