### PR TITLE
Fix compilation; AVCodec should be const

### DIFF
--- a/common/rfb/H264LibavDecoderContext.cxx
+++ b/common/rfb/H264LibavDecoderContext.cxx
@@ -47,7 +47,7 @@ bool H264LibavDecoderContext::initCodec() {
   h264WorkBuffer = NULL;
   h264WorkBufferLength = 0;
 
-  AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+  const AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
   if (!codec)
   {
     vlog.error("Codec not found");


### PR DESCRIPTION
Ubuntu 20.04
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
libx264-dev:amd64 2:0.155.2917+git0a84d98-2

[ 11%] Building CXX object common/rfb/CMakeFiles/rfb.dir/H264LibavDecoderContext.cxx.o
tigervnc/common/rfb/H264LibavDecoderContext.cxx: In member function ‘virtual bool rfb::H264LibavDecoderContext::initCodec()’:
tigervnc/common/rfb/H264LibavDecoderContext.cxx:50:40: error: invalid conversion from ‘const AVCodec*’ to ‘AVCodec*’ [-fpermissive]
   50 |   AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
      |                    ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        const AVCodec*
make[2]: *** [common/rfb/CMakeFiles/rfb.dir/build.make:895: common/rfb/CMakeFiles/rfb.dir/H264LibavDecoderContext.cxx.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:597: common/rfb/CMakeFiles/rfb.dir/all] Error 2
make: *** [Makefile:130: all] Error 2