### PR TITLE
Fix java.lang.IndexOutOfBoundsException: invalid hotSpot when using scaling

### DIFF
--- a/java/com/tigervnc/vncviewer/Viewport.java
+++ b/java/com/tigervnc/vncviewer/Viewport.java
@@ -188,32 +188,23 @@ class Viewport extends JPanel implements ActionListener {
       }
     }
 
-    int cw = (int)Math.floor((float)cursor.getWidth() * scaleRatioX);
-    int ch = (int)Math.floor((float)cursor.getHeight() * scaleRatioY);
-
-    int x = (int)Math.floor((float)cursorHotspot.x * scaleRatioX);
-    int y = (int)Math.floor((float)cursorHotspot.y * scaleRatioY);
-
-    Dimension cs = tk.getBestCursorSize(cw, ch);
-    if (cs.width != cw && cs.height != ch) {
-      cw = Math.min(cw, cs.width);
-      ch = Math.min(ch, cs.height);
-      x = (int)Math.min(x, Math.max(cs.width - 1, 0));
-      y = (int)Math.min(y, Math.max(cs.height - 1, 0));
-      BufferedImage tmp =
-        new BufferedImage(cs.width, cs.height, BufferedImage.TYPE_INT_ARGB_PRE);
-      Graphics2D g2 = tmp.createGraphics();
-      g2.drawImage(cursor, 0, 0, cw, ch, 0, 0, width, height, null);
-      g2.dispose();
-      cursor = tmp;
-    }
-    
-	if (x >= cursor.getWidth()) {
-		x = cursor.getWidth() - 1;
-	}
-
-	if (y >= cursor.getHeight()) {
-		y = cursor.getHeight() -1;
+	int cw = (int) Math.floor((float) cursor.getWidth() * scaleRatioX);
+	int ch = (int) Math.floor((float) cursor.getHeight() * scaleRatioY);
+	int x = cursorHotspot.x;
+	int y = cursorHotspot.y;
+	Dimension cs = tk.getBestCursorSize(cw, ch);
+	if (cs.width != cursor.getWidth() || cs.height != cursor.getHeight()) {
+		width = cursor.getWidth();
+		height = cursor.getHeight();
+		cw = cs.width;
+		ch = cs.height;
+		BufferedImage tmp = new BufferedImage(cs.width, cs.height, BufferedImage.TYPE_INT_ARGB_PRE);
+		Graphics2D g2 = tmp.createGraphics();
+		g2.drawImage(cursor, 0, 0, cw, ch, 0, 0, width, height, null);
+		g2.dispose();
+		x = (int) Math.min(Math.floor((float) x * (float) cw / (float) width), cw - 1);
+		y = (int) Math.min(Math.floor((float) y * (float) ch / (float) height), ch - 1);
+		cursor = tmp;
 	}
     
     setCursor(cursor, x, y);

--- a/java/com/tigervnc/vncviewer/Viewport.java
+++ b/java/com/tigervnc/vncviewer/Viewport.java
@@ -207,7 +207,15 @@ class Viewport extends JPanel implements ActionListener {
       g2.dispose();
       cursor = tmp;
     }
+    
+	if (x >= cursor.getWidth()) {
+		x = cursor.getWidth() - 1;
+	}
 
+	if (y >= cursor.getHeight()) {
+		y = cursor.getHeight() -1;
+	}
+    
     setCursor(cursor, x, y);
   }
 


### PR DESCRIPTION
Fix java.lang.IndexOutOfBoundsException: invalid hotSpot when using scaling

reported in https://github.com/TigerVNC/tigervnc/issues/843

full exception:
java.lang.IndexOutOfBoundsException: invalid hotSpot
at java.desktop/sun.awt.CustomCursor.(CustomCursor.java:80)
at java.desktop/sun.awt.X11CustomCursor.(X11CustomCursor.java:44)
at java.desktop/sun.awt.X11.XCustomCursor.(XCustomCursor.java:43)
at java.desktop/sun.awt.X11.XToolkit.createCustomCursor(XToolkit.java:1171)
at com.tigervnc.vncviewer.Viewport.setCursor(Viewport.java:221)
at com.tigervnc.vncviewer.Viewport.setCursor(Viewport.java:211)
at com.tigervnc.vncviewer.DesktopWindow.setCursor(DesktopWindow.java:281)
at com.tigervnc.vncviewer.CConn.setCursor(CConn.java:336)
at com.tigervnc.rfb.CMsgReader.readSetXCursor(CMsgReader.java:271)
at com.tigervnc.rfb.CMsgReader.readMsg(CMsgReader.java:99)
at com.tigervnc.rfb.CConnection.processMsg(CConnection.java:149)
at com.tigervnc.vncviewer.VncViewer.run(VncViewer.java:430)
at java.base/java.lang.Thread.run(Thread.java:833)