### PR TITLE
Allow "PointerEventInterval" to be set in "~/.vnc/default.tigervnc".

### DIFF
--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -207,7 +207,8 @@ static VoidParameter* parameterArray[] = {
   &setPrimary,
 #endif
   &menuKey,
-  &fullscreenSystemKeys
+  &fullscreenSystemKeys,
+  &pointerEventInterval,
 };
 
 static VoidParameter* readOnlyParameterArray[] = {


### PR DESCRIPTION
```bash
# cat ~/.vnc/default.tigervnc
TigerVNC Configuration file Version 1.0
DotWhenNoCursor=1
PointerEventInterval=1
```

Fixes the issue where "PointerEventInterval" param is not recognized in the configuration:

```
 Parameters:  Failed to read line 3 in file
              /host/home/ziyan/.vnc/default.tigervnc: Unknown parameter
```