### PR TITLE
fix macos h264 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          brew install fltk pixman ffmpeg
+          brew install fltk pixman ffmpeg libice
       - name: Configure
         run: |
           CFLAGS="-I/usr/local/opt/ffmpeg/include $CFLAGS" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,10 @@ jobs:
         run: |
           brew install fltk pixman ffmpeg
       - name: Configure
-        run: cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build
+        run: |
+          CFLAGS="-I/usr/local/opt/ffmpeg/include $CFLAGS" \
+          CXXFLAGS="-I/usr/local/opt/ffmpeg/include $CXXFLAGS" \
+          cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build
       - name: Build
         working-directory: build
         run: make


### PR DESCRIPTION
This PR includes the correct path for `ffmpeg`, so that `cmake` can find the header files and enable H264.
<img width="562" alt="Screenshot 2022-05-13 at 19 14 34" src="https://user-images.githubusercontent.com/1611001/168343185-f4d42868-b088-42cf-865f-be10fc411741.png">
