### PR TITLE
Workaround for MFT cropping in H264 decoding

### DIFF
--- a/common/rfb/H264WinDecoderContext.h
+++ b/common/rfb/H264WinDecoderContext.h
@@ -41,6 +41,12 @@ namespace rfb {
 
     private:
       LONG stride;
+      rdr::U32 full_width = 0;
+      rdr::U32 full_height = 0;
+      rdr::U32 crop_width = 0;
+      rdr::U32 crop_height = 0;
+      rdr::U32 offset_x = 0;
+      rdr::U32 offset_y = 0;
       IMFTransform *decoder = NULL;
       IMFTransform *converter = NULL;
       IMFSample *input_sample = NULL;
@@ -49,6 +55,8 @@ namespace rfb {
       IMFMediaBuffer *input_buffer = NULL;
       IMFMediaBuffer *decoded_buffer = NULL;
       IMFMediaBuffer *converted_buffer = NULL;
+
+      void ParseSPS(const rdr::U8* buffer, int length);
   };
 }
 


### PR DESCRIPTION
It seems MFT h264 decoder does not support frame cropping in h264 bitstream. So in cases when frame width or height is not multiple of 16 then decoded output can potentially be used with wrong offset.

This code adds explicit parsing of SPS to extract cropping information to use, and will apply cropping if reported size differs from
expected.

Good example to test is with pikvm's vnc server on 1920x1080 resolution. rpi hardware h264 encoder encodes it as 1920x1088 resolution with offset from top and bottom set to 4. This means that without this patch there are 4 black rows on top, and 4 missing rows on bottom. See the following images:

original code:
![bad](https://user-images.githubusercontent.com/1665010/172535930-cd3c4646-8f22-427e-979a-a7f192491bf2.png)

with this PR:
![fixed](https://user-images.githubusercontent.com/1665010/172535938-f8744827-069e-459d-a3bc-470f876631fe.png)

