### PR TITLE
Add missing FLTK include statements

### DIFF
--- a/tests/perf/fbperf.cxx
+++ b/tests/perf/fbperf.cxx
@@ -26,6 +26,7 @@
 #include <FL/Fl.H>
 #include <FL/Fl_Window.H>
 #include <FL/fl_draw.H>
+#include <FL/x.H>
 
 #include <rdr/Exception.h>
 #include <rfb/util.h>

--- a/vncviewer/MonitorArrangement.cxx
+++ b/vncviewer/MonitorArrangement.cxx
@@ -37,6 +37,7 @@
 #include <FL/Fl.H>
 #include <FL/fl_draw.H>
 #include <FL/Fl_Button.H>
+#include <FL/x.H>
 
 #if defined(HAVE_XRANDR) && !defined(__APPLE__)
 #include <X11/extensions/Xrandr.h>

--- a/vncviewer/MonitorArrangement.h
+++ b/vncviewer/MonitorArrangement.h
@@ -29,7 +29,8 @@
 #include <map>
 #include <set>
 
-class Fl_Group;
+#include <FL/Fl_Group.H>
+
 class Fl_Button;
 
 class MonitorArrangement: public Fl_Group {

--- a/vncviewer/PlatformPixelBuffer.cxx
+++ b/vncviewer/PlatformPixelBuffer.cxx
@@ -21,6 +21,7 @@
 #endif
 
 #include <assert.h>
+#include <stdlib.h>
 
 #if !defined(WIN32) && !defined(__APPLE__)
 #include <sys/ipc.h>

--- a/vncviewer/Surface_X11.cxx
+++ b/vncviewer/Surface_X11.cxx
@@ -21,6 +21,7 @@
 #endif
 
 #include <assert.h>
+#include <stdlib.h>
 
 #include <FL/Fl_RGB_Image.H>
 #include <FL/x.H>

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -73,6 +73,7 @@
 
 #include <FL/Fl_Menu.H>
 #include <FL/Fl_Menu_Button.H>
+#include <FL/x.H>
 
 #if !defined(WIN32) && !defined(__APPLE__)
 #include <X11/XKBlib.h>


### PR DESCRIPTION
This PR is about adding include statements (and one other modification) to make TigerVNC compile with FLTK 1.4 (Git master).

Although FLTK 1.3 and 1.4 are API compatible, some missing headers have been unnecessarily included in other FLTK 1.3 headers such that not including these headers in source files worked by accident. I'm commenting the changes below in the form of pseudo diff statements:
```
+#include <FL/x.H>
```
This one is the header missing most often. It is needed for global FLTK variables and functions like fl_display and similar. Note that this header file has been renamed to <FL/platform.H> in FLTK 1.4.0 and a backwards compatibility header <FL/x.H> was kept (includes platform.H).

OTOH FLTK 1.3.5 and later got an additional header <FL/platform.H> so code can use either one if it targets FLTK 1.3.5 or later. The "safe" version for now is <FL/x.H> but the future proof version is <FL/platform.H> although FLTK 1.4 and later will retain <FL/x.H> for a while.

```
vncviewer/MonitorArrangement.h:
-class Fl_Group;
+#include <FL/Fl_Group.H>
```
It is not possible to derive a class from an incomplete type (forward declaration `class Fl_Group`). In FLTK 1.3 `<FL/Fl_Group.H>` must have been included elsewhere.

```
+#include <malloc.h>
```
Two occurrences show that `malloc.h` has been included elsewhere, supposedly in another FLTK 1.3 header, but not in FLTK 1.4.

Note that reducing of unnecessary FLTK and system header includes was a goal of changes in FLTK 1.4 for better compilation speed. Including these additional headers in the TigerVNC source files should not do any harm because all header files have the usual header guard statements `#ifndef ...`.

I'd appreciate if this PR would be accepted and merged because it makes testing TigerVNC with FLTK 1.4 much easier and this will be needed in the future anyway.