### PR TITLE
Store artifacts from Github actions

### DIFF
--- a/.github/containers/bionic/build.sh
+++ b/.github/containers/bionic/build.sh
@@ -53,3 +53,6 @@ docker run --volume ${CURDIR}/build:/home/deb/build --interactive --rm tigervnc/
 	sudo apt-get -f install -y &&
 	cd ~/build/tigervnc-${VERSION} && dpkg-buildpackage
 	"
+
+mkdir -p ${CURDIR}/result
+cp -av ${CURDIR}/build/*.deb ${CURDIR}/result

--- a/.github/containers/centos7/build.sh
+++ b/.github/containers/centos7/build.sh
@@ -39,3 +39,7 @@ docker run --volume ${CURDIR}/rpmbuild:/home/rpm/rpmbuild --interactive --rm tig
         sudo chown 0.0 ~/rpmbuild/SPECS/* &&
 	rpmbuild -ba ~/rpmbuild/SPECS/tigervnc.spec
 	"
+
+mkdir -p ${CURDIR}/result
+cp -av ${CURDIR}/rpmbuild/RPMS ${CURDIR}/result
+cp -av ${CURDIR}/rpmbuild/SRPMS ${CURDIR}/result

--- a/.github/containers/centos8/build.sh
+++ b/.github/containers/centos8/build.sh
@@ -38,3 +38,7 @@ docker run --volume ${CURDIR}/rpmbuild:/home/rpm/rpmbuild --interactive --rm tig
         sudo chown 0.0 ~/rpmbuild/SPECS/* &&
 	rpmbuild -ba ~/rpmbuild/SPECS/tigervnc.spec
 	"
+
+mkdir -p ${CURDIR}/result
+cp -av ${CURDIR}/rpmbuild/RPMS ${CURDIR}/result
+cp -av ${CURDIR}/rpmbuild/SRPMS ${CURDIR}/result

--- a/.github/containers/focal/build.sh
+++ b/.github/containers/focal/build.sh
@@ -53,3 +53,6 @@ docker run --volume ${CURDIR}/build:/home/deb/build --interactive --rm tigervnc/
 	sudo apt-get -f install -y &&
 	cd ~/build/tigervnc-${VERSION} && dpkg-buildpackage
 	"
+
+mkdir -p ${CURDIR}/result
+cp -av ${CURDIR}/build/*.deb ${CURDIR}/result

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Install
         working-directory: build
         run: make tarball
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux (Ubuntu)
+          path: build/tigervnc-*.tar.gz
 
   build-windows:
     runs-on: windows-latest
@@ -44,6 +48,10 @@ jobs:
         env:
           MSYS2_PATH_TYPE: inherit
         run: make installer winvnc_installer
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Windows
+          path: build/release/tigervnc*.exe
 
   build-macos:
     runs-on: macos-latest
@@ -60,6 +68,10 @@ jobs:
       - name: Install
         working-directory: build
         run: make dmg
+      - uses: actions/upload-artifact@v3
+        with:
+          name: macOS
+          path: build/TigerVNC-*.dmg
 
   build-java:
     runs-on: ubuntu-latest
@@ -79,6 +91,10 @@ jobs:
       - name: Build
         working-directory: java/build
         run: make
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Java (${{ matrix.java }})
+          path: java/build/VncViewer.jar
 
   build-packages:
     strategy:
@@ -98,3 +114,7 @@ jobs:
         run: docker build -t tigervnc/$DOCKER .github/containers/$DOCKER
       - name: Build packages
         run: .github/containers/$DOCKER/build.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Packages (${{ matrix.target }})
+          path: .github/containers/${{ matrix.target }}/result


### PR DESCRIPTION
Might be useful for testing in some cases. Note that the Windows and Linux binaries will depend on libraries from the build environment. So the user will need to match those manually.