### PR TITLE
Add vncviewer option to use large cursor instead of dot

### DIFF
--- a/java/com/tigervnc/vncviewer/OptionsDialog.java
+++ b/java/com/tigervnc/vncviewer/OptionsDialog.java
@@ -152,8 +152,10 @@ class OptionsDialog extends Dialog {
 
   /* Misc. */
   JCheckBox sharedCheckbox;
-  JCheckBox dotWhenNoCursorCheckbox;
+  JCheckBox alwaysCursorCheckbox;
   JCheckBox acceptBellCheckbox;
+
+  JComboBox cursorTypeChoice;
 
   /* SSH */
   JCheckBox tunnelCheckbox;
@@ -311,6 +313,7 @@ class OptionsDialog extends Dialog {
     handleAutoselect();
     handleCompression();
     handleJpeg();
+    handleAlwaysCursor();
 
     /* Security */
     Security security = new Security(SecurityClient.secTypes);
@@ -458,7 +461,9 @@ class OptionsDialog extends Dialog {
 
     /* Misc. */
     sharedCheckbox.setSelected(shared.getValue());
-    dotWhenNoCursorCheckbox.setSelected(dotWhenNoCursor.getValue());
+    alwaysCursorCheckbox.setSelected(alwaysCursor.getValue());
+    String cursorTypeStr = cursorType.getValueStr();
+    cursorTypeChoice.setSelectedItem(cursorTypeStr);
     acceptBellCheckbox.setSelected(acceptBell.getValue());
 
     /* SSH */
@@ -613,8 +618,9 @@ class OptionsDialog extends Dialog {
 
     /* Misc. */
     shared.setParam(sharedCheckbox.isSelected());
-    dotWhenNoCursor.setParam(dotWhenNoCursorCheckbox.isSelected());
+    alwaysCursor.setParam(alwaysCursorCheckbox.isSelected());
     acceptBell.setParam(acceptBellCheckbox.isSelected());
+    cursorType.setParam((String)cursorTypeChoice.getSelectedItem());
 
     /* SSH */
     tunnel.setParam(tunnelCheckbox.isSelected());
@@ -1173,31 +1179,54 @@ class OptionsDialog extends Dialog {
     MiscPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 0, 5));
     sharedCheckbox =
       new JCheckBox("Shared (don't disconnect other viewers)");
-    dotWhenNoCursorCheckbox = new JCheckBox("Show dot when no cursor");
+    alwaysCursorCheckbox = new JCheckBox("Show local cursor when not provided by server");
+    alwaysCursorCheckbox.addItemListener(new ItemListener() {
+      public void itemStateChanged(ItemEvent e) {
+        handleAlwaysCursor();
+      }
+    });
+    JLabel cursorTypeLabel = new JLabel("Cursor type:");
+    String[] cursorTypes = {"Dot", "System"};
+    cursorTypeChoice = new MyJComboBox(cursorTypes);
+    cursorTypeChoice.setPrototypeDisplayValue("System.");
     acceptBellCheckbox = new JCheckBox("Beep when requested by the server");
     MiscPanel.add(sharedCheckbox,
                   new GridBagConstraints(0, 0,
-                                         1, 1,
+                                         REMAINDER, 1,
                                          LIGHT, LIGHT,
                                          LINE_START, NONE,
                                          new Insets(0, 0, 4, 0),
                                          NONE, NONE));
-    MiscPanel.add(dotWhenNoCursorCheckbox,
+    MiscPanel.add(alwaysCursorCheckbox,
                   new GridBagConstraints(0, 1,
-                                         1, 1,
+                                         REMAINDER, 1,
                                          LIGHT, LIGHT,
                                          LINE_START, NONE,
                                          new Insets(0, 0, 4, 0),
                                          NONE, NONE));
-    MiscPanel.add(acceptBellCheckbox,
+    MiscPanel.add(cursorTypeLabel,
                   new GridBagConstraints(0, 2,
                                          1, 1,
                                          LIGHT, LIGHT,
                                          LINE_START, NONE,
                                          new Insets(0, 0, 4, 0),
                                          NONE, NONE));
-    MiscPanel.add(Box.createRigidArea(new Dimension(5, 0)),
+    MiscPanel.add(cursorTypeChoice,
+                  new GridBagConstraints(1, 2,
+                                         1, 1,
+                                         LIGHT, LIGHT,
+                                         LINE_START, NONE,
+                                         new Insets(0, 5, 4, 0),
+                                         NONE, NONE));
+    MiscPanel.add(acceptBellCheckbox,
                   new GridBagConstraints(0, 3,
+                                         REMAINDER, 1,
+                                         LIGHT, LIGHT,
+                                         LINE_START, NONE,
+                                         new Insets(0, 0, 4, 0),
+                                         NONE, NONE));
+    MiscPanel.add(Box.createRigidArea(new Dimension(5, 0)),
+                  new GridBagConstraints(0, 4,
                                          REMAINDER, REMAINDER,
                                          HEAVY, HEAVY,
                                          LINE_START, BOTH,
@@ -1631,6 +1660,11 @@ class OptionsDialog extends Dialog {
       for (JComponent c : components)
         c.setEnabled(false);
     }
+  }
+
+  private void handleAlwaysCursor()
+  {
+    cursorTypeChoice.setEnabled(alwaysCursorCheckbox.isSelected());
   }
 
   static LogWriter vlog = new LogWriter("OptionsDialog");

--- a/java/com/tigervnc/vncviewer/UserPreferences.java
+++ b/java/com/tigervnc/vncviewer/UserPreferences.java
@@ -144,6 +144,11 @@ public class UserPreferences {
     }
   }
 
+  public static void delete(String nName, String key) {
+      Preferences node = root.node(nName);
+      node.remove(key);
+  }
+
   static LogWriter vlog = new LogWriter("UserPreferences");
 }
 

--- a/java/com/tigervnc/vncviewer/Viewport.java
+++ b/java/com/tigervnc/vncviewer/Viewport.java
@@ -167,8 +167,15 @@ class Viewport extends JPanel implements ActionListener {
     for (i = 0; i < width*height; i++)
       if (data[i*4 + 3] != 0) break;
 
-    if ((i == width*height) && dotWhenNoCursor.getValue()) {
-      vlog.debug("cursor is empty - using dot");
+    useSystemCursor = false;
+    if ((i == width*height) && alwaysCursor.getValue()) {
+      String cursorTypeStr = cursorType.getValueStr();
+      if (cursorTypeStr.matches("^System$")) {
+        useSystemCursor = true;
+      } else {
+        vlog.debug("cursor is empty - using dot");
+      }
+      // Do this anyway to prevent cursor being null
       cursor = new BufferedImage(5, 5, BufferedImage.TYPE_INT_ARGB_PRE);
       cursor.setRGB(0, 0, 5, 5, dotcursor_xpm, 0, 5);
       cursorHotspot.x = cursorHotspot.y = 3;
@@ -216,7 +223,10 @@ class Viewport extends JPanel implements ActionListener {
 
     hotspot = new java.awt.Point(x, y);
     softCursor = tk.createCustomCursor(img, hotspot, name);
-    setCursor(softCursor);
+    if (useSystemCursor)
+      setCursor(java.awt.Cursor.getDefaultCursor());
+    else
+      setCursor(softCursor);
   }
 
   public void resize(int x, int y, int w, int h) {
@@ -830,6 +840,7 @@ class Viewport extends JPanel implements ActionListener {
   float scaleRatioX, scaleRatioY;
 
   static BufferedImage cursor;
+  static boolean useSystemCursor = false;
   Point cursorHotspot = new Point();
 
 }

--- a/java/com/tigervnc/vncviewer/VncViewer.java
+++ b/java/com/tigervnc/vncviewer/VncViewer.java
@@ -212,6 +212,8 @@ public class VncViewer implements Runnable {
 
     // Check if the server name in reality is a configuration file
     potentiallyLoadConfigurationFile(vncServerName);
+
+    migrateDeprecatedOptions();
   }
 
   public static void usage() {
@@ -446,6 +448,15 @@ public class VncViewer implements Runnable {
           cc.close();
       }
       exit(1);
+    }
+  }
+
+  static void migrateDeprecatedOptions() {
+    if (dotWhenNoCursor.getValue()) {
+      vlog.info("DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead");
+
+      alwaysCursor.setParam(true);
+      cursorType.setParam("Dot");
     }
   }
 

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -352,7 +352,14 @@ void OptionsDialog::loadOptions(void)
   /* Misc. */
   sharedCheckbox->value(shared);
   reconnectCheckbox->value(reconnectOnError);
-  dotCursorCheckbox->value(dotWhenNoCursor);
+  alwaysCursorCheckbox->value(alwaysCursor);
+  if (!strcasecmp(cursorType, "system")) {
+    cursorTypeChoice->value(1);
+  } else {
+    // Default
+    cursorTypeChoice->value(0);
+  }
+  handleAlwaysCursor(alwaysCursorCheckbox, this);
 }
 
 
@@ -486,7 +493,14 @@ void OptionsDialog::storeOptions(void)
   /* Misc. */
   shared.setParam(sharedCheckbox->value());
   reconnectOnError.setParam(reconnectCheckbox->value());
-  dotWhenNoCursor.setParam(dotCursorCheckbox->value());
+  alwaysCursor.setParam(alwaysCursorCheckbox->value());
+
+  if (cursorTypeChoice->value() == 1) {
+    cursorType.setParam("System");
+  } else {
+    // Default
+    cursorType.setParam("Dot");
+  }
 
   std::map<OptionsCallback*, void*>::const_iterator iter;
 
@@ -835,11 +849,21 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
                                                      _("Emulate middle mouse button")));
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
-    dotCursorCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
-                                                    CHECK_MIN_WIDTH,
-                                                    CHECK_HEIGHT,
-                                                    _("Show dot when no cursor")));
+    alwaysCursorCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
+                                                       CHECK_MIN_WIDTH,
+                                                       CHECK_HEIGHT,
+                                                       _("Show local cursor when not provided by server")));
+    alwaysCursorCheckbox->callback(handleAlwaysCursor, this);
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
+
+    /* Cursor type */
+    cursorTypeChoice = new Fl_Choice(LBLLEFT(tx, ty, 150, CHOICE_HEIGHT, _("Cursor type")));
+
+    fltk_menu_add(cursorTypeChoice, _("Dot"), 0, nullptr, nullptr, 0);
+    fltk_menu_add(cursorTypeChoice, _("System"), 0, nullptr, nullptr, 0);
+
+    ty += CHOICE_HEIGHT + TIGHT_MARGIN;
+
   }
   ty -= TIGHT_MARGIN;
 
@@ -1180,4 +1204,15 @@ void OptionsDialog::handleScreenConfigTimeout(void *data)
     assert(self);
 
     self->monitorArrangement->value(fullScreenSelectedMonitors.getParam());
+}
+
+void OptionsDialog::handleAlwaysCursor(Fl_Widget* /*widget*/, void *data)
+{
+  OptionsDialog *dialog = (OptionsDialog*)data;
+
+  if (dialog->alwaysCursorCheckbox->value()) {
+    dialog->cursorTypeChoice->activate();
+  } else {
+    dialog->cursorTypeChoice->deactivate();
+  }
 }

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -60,6 +60,7 @@ protected:
   static void handleAutoselect(Fl_Widget *widget, void *data);
   static void handleCompression(Fl_Widget *widget, void *data);
   static void handleJpeg(Fl_Widget *widget, void *data);
+  static void handleAlwaysCursor(Fl_Widget *widget, void *data);
 
   static void handleX509(Fl_Widget *widget, void *data);
   static void handleRSAAES(Fl_Widget *widget, void *data);
@@ -115,7 +116,8 @@ protected:
   Fl_Check_Button *viewOnlyCheckbox;
   Fl_Group *mouseGroup;
   Fl_Check_Button *emulateMBCheckbox;
-  Fl_Check_Button *dotCursorCheckbox;
+  Fl_Check_Button *alwaysCursorCheckbox;
+  Fl_Choice *cursorTypeChoice;
   Fl_Group *keyboardGroup;
   Fl_Check_Button *systemKeysCheckbox;
   Fl_Choice *menuKeyChoice;

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -77,6 +77,9 @@ private:
 
   unsigned int getModifierMask(unsigned int keysym);
 
+  // Show the currently set (or system) cursor
+  void showCursor();
+
   static void handleClipboardChange(int source, void *data);
 
   void flushPendingClipboard();
@@ -136,6 +139,7 @@ private:
 
   Fl_RGB_Image *cursor;
   rfb::Point cursorHotspot;
+  bool cursorIsBlank;
 };
 
 #endif

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -61,8 +61,15 @@ BoolParameter emulateMiddleButton("EmulateMiddleButton",
                                   "left and right mouse buttons simultaneously",
                                   false);
 BoolParameter dotWhenNoCursor("DotWhenNoCursor",
-                              "Show the dot cursor when the server sends an "
+                              "[DEPRECATED] Show the dot cursor when the server sends an "
                               "invisible cursor", false);
+BoolParameter alwaysCursor("AlwaysCursor",
+                           "Show the local cursor when the server sends an "
+                           "invisible cursor", false);
+StringParameter cursorType("CursorType",
+                           "Specify which cursor type the local cursor should be. "
+                           "Should be either Dot or System",
+                           "Dot");
 
 BoolParameter alertOnFatalError("AlertOnFatalError",
                                 "Give a dialog on connection problems rather "
@@ -198,7 +205,8 @@ static VoidParameter* parameterArray[] = {
   /* Input */
   &viewOnly,
   &emulateMiddleButton,
-  &dotWhenNoCursor,
+  &alwaysCursor,
+  &cursorType,
   &acceptClipboard,
   &sendClipboard,
 #if !defined(WIN32) && !defined(__APPLE__)
@@ -210,7 +218,8 @@ static VoidParameter* parameterArray[] = {
 };
 
 static VoidParameter* readOnlyParameterArray[] = {
-  &fullScreenAllMonitors
+  &fullScreenAllMonitors,
+  &dotWhenNoCursor
 };
 
 // Encoding Table

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -33,7 +33,9 @@
 
 extern rfb::IntParameter pointerEventInterval;
 extern rfb::BoolParameter emulateMiddleButton;
-extern rfb::BoolParameter dotWhenNoCursor;
+extern rfb::BoolParameter dotWhenNoCursor; // deprecated
+extern rfb::BoolParameter alwaysCursor;
+extern rfb::StringParameter cursorType;
 
 extern rfb::StringParameter passwordFile;
 

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -535,6 +535,12 @@ migrateDeprecatedOptions()
 
     fullScreenMode.setParam("all");
   }
+  if (dotWhenNoCursor) {
+    vlog.info(_("DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"));
+
+    alwaysCursor.setParam(true);
+    cursorType.setParam("Dot");
+  }
 }
 
 #ifndef WIN32

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -285,8 +285,19 @@ Use specified lossless compression level. 0 = Low, 9 = High. Default is 2.
 Use custom compression level. Default if \fBCompressLevel\fP is specified.
 .
 .TP
-.B \-DotWhenNoCursor
-Show the dot cursor when the server sends an invisible cursor. Default is off.
+.B \-DotWhenNoCursor (DEPRECATED)
+Show the dot cursor when the server sends an invisible cursor. Replaced by
+\fB-AlwaysCursor\fP and \fB-CursorType=Dot\fP
+.
+.TP
+.B \-AlwaysCursor
+Show a local cursor when the server sends an invisible cursor. Default is off.
+.
+.TP
+.B \-CursorType \fItype\fP
+Specify which cursor type to use when a local cursor is shown. It should be
+either "Dot", or "System". Ignored if AlwaysCursor is off.
+The default is "Dot".
 .
 .TP
 .B \-PointerEventInterval \fItime\fP


### PR DESCRIPTION
This PR adds a large cursor bitmap to both versions of vncviewer
(Java and native) which can be used instead of the previously used dot
cursor, as well as the options and parameters to be able to enable or
disable its use at runtime.

Resolves #1483 