### PR TITLE
Improve error message when `passwd` file has a bad permission

### DIFF
--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -150,8 +150,10 @@ if ($config{'password'} ||
 
 if ((!$securityTypeArgSpecified || $vncAuthEnabled) && !$passwordArgSpecified) {
     ($z,$z,$mode) = stat("$vncUserDir/passwd");
-    if (!(-e "$vncUserDir/passwd") || ($mode & 077)) {
+    if (! -e "$vncUserDir/passwd") {
         die "VNC authentication enabled, but no password file created.\n";
+    } elsif ($mode & 077) {
+        die "$vncUserDir/passwd must NOT be accessible by others. Set permission to 0600.\n";
     }
 }
 


### PR DESCRIPTION
This change prevents potential confusion on `passwd` file permission. Please refer to my comment on issue #1393.

Note that I'm a beginner in Perl and not an English native. Feel free to comment if it's required to change wording or Perl syntax.