### PR TITLE
Add <url> and <releases> to the metainfo

### DIFF
--- a/vncviewer/org.tigervnc.vncviewer.metainfo.xml.in
+++ b/vncviewer/org.tigervnc.vncviewer.metainfo.xml.in
@@ -13,6 +13,8 @@
   <name>TigerVNC Viewer</name>
   <summary>Connect to VNC server and display remote desktop</summary>
   <content_rating type="oars-1.1"/>
+  <url type="homepage">https://tigervnc.org/</url>
+  <url type="bugtracker">https://github.com/TigerVNC/tigervnc/issues</url>
   <description>
     <p>
       Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network.
@@ -42,4 +44,23 @@
       <image>https://raw.githubusercontent.com/TigerVNC/tigervnc/741d3edbfab65eda6f033078bc06347fe244ea6a/vncviewer/metainfo/tigervnc-connection-windows.jpg</image>
     </screenshot>
   </screenshots>
+
+  <releases>
+    <release version="1.12.0" date="2021-11-10" />
+    <release version="1.11.0" date="2020-09-09" />
+    <release version="1.10.1" date="2019-12-20" />
+    <release version="1.10.0" date="2019-11-20" />
+    <release version="1.9.0" date="2018-07-16" />
+    <release version="1.8.0" date="2017-05-16" />
+    <release version="1.7.1" date="2017-01-20" />
+    <release version="1.7.0" date="2016-09-12" />
+    <release version="1.6.0" date="2015-12-24" />
+    <release version="1.5.0" date="2015-07-12" />
+    <release version="1.4.3" date="2015-03-01" />
+    <release version="1.4.2" date="2015-01-24" />
+    <release version="1.4.1" date="2014-12-26" />
+    <release version="1.4.0" date="2014-12-11" />
+    <release version="1.3.1" date="2014-06-30" />
+    <release version="1.3.0" date="2014-06-30" />
+  </releases>
 </component>


### PR DESCRIPTION
Flathub requires `<url>` and `<releases>` tags in the AppData file.

https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html

The `<releases>` tag can be much more detailed and include descriptions, issues, artifacts, and much more. For now I've only included the minimum required: version and date.

I've included dates of all of the previous versions that were listed on Github, as the information was available, but it would be sufficient to only include the latest release for now.