### PR TITLE
VNCSConnectionST clipboard functions should check state before access.

### DIFF
--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -313,9 +313,9 @@ void VNCSConnectionST::setLEDStateOrClose(unsigned int state)
 void VNCSConnectionST::requestClipboardOrClose()
 {
   try {
+    if (state() != RFBSTATE_NORMAL) return;
     if (!accessCheck(AccessCutText)) return;
     if (!rfb::Server::acceptCutText) return;
-    if (state() != RFBSTATE_NORMAL) return;
     requestClipboard();
   } catch(rdr::Exception& e) {
     close(e.str());
@@ -325,9 +325,9 @@ void VNCSConnectionST::requestClipboardOrClose()
 void VNCSConnectionST::announceClipboardOrClose(bool available)
 {
   try {
+    if (state() != RFBSTATE_NORMAL) return;
     if (!accessCheck(AccessCutText)) return;
     if (!rfb::Server::sendCutText) return;
-    if (state() != RFBSTATE_NORMAL) return;
     announceClipboard(available);
   } catch(rdr::Exception& e) {
     close(e.str());
@@ -337,9 +337,9 @@ void VNCSConnectionST::announceClipboardOrClose(bool available)
 void VNCSConnectionST::sendClipboardDataOrClose(const char* data)
 {
   try {
+    if (state() != RFBSTATE_NORMAL) return;
     if (!accessCheck(AccessCutText)) return;
     if (!rfb::Server::sendCutText) return;
-    if (state() != RFBSTATE_NORMAL) return;
     sendClipboardData(data);
   } catch(rdr::Exception& e) {
     close(e.str());


### PR DESCRIPTION
Clipboard functions may run on connections that are not yet at RFBSTATE_NORMAL. Due to recent hardening of the accessCheck() function, it is important to validate that the state is RFBSTATE_NORMAL before calling accessCheck().

Fixes #1599.