### PR TITLE
option -lowspeedfixes, fix random key press repeat

### DIFF
--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -1,9 +1,9 @@
 .TH Xvnc 1 "" "TigerVNC" "Virtual Network Computing"
 .SH NAME
-Xvnc \- the X VNC server 
+Xvnc \- the X VNC server
 .SH SYNOPSIS
 .B Xvnc
-.RI [ options ] 
+.RI [ options ]
 .RI : display#
 .SH DESCRIPTION
 .B Xvnc
@@ -50,9 +50,17 @@ depth 16 is RGB565 and for depth 24 and 32 is RGB888.
 Listen on interface. By default Xvnc listens on all available interfaces.
 .
 .TP
-.B \-inetd 
+.B \-inetd
 This significantly changes Xvnc's behaviour so that it can be launched from
 inetd.  See the section below on usage with inetd.
+.
+.TP
+.B \-lowspeedfixes
+FC37, the problem occurs on low-speed connections, when the time between
+keydown and keyup events is long, the OS starts repeating the keystroke,
+so we need generate the fake keyup event
+for normal keys (not for alt, ctrl, shift) right after receiving
+a keydown event to avoid it
 .
 .TP
 .B \-help

--- a/unix/xserver/hw/vnc/vncExtInit.h
+++ b/unix/xserver/hw/vnc/vncExtInit.h
@@ -34,6 +34,9 @@ void vncAddExtension(void);
 
 int vncNotifyQueryConnect(void);
 
+// xvnc.c
+extern int vncLowSpeedFixes;
+
 // vncExtInit.cc
 extern void* vncFbptr[];
 extern int vncFbstride[];

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -221,6 +221,7 @@ ddxUseMsg(void)
     ErrorF("-depth D               set screen 0's depth\n");
     ErrorF("-pixelformat fmt       set pixel format (rgbNNN or bgrNNN)\n");
     ErrorF("-inetd                 has been launched from inetd\n");
+    ErrorF("-lowspeedfixes         fix random key press repeat, etc.\n");
     ErrorF
         ("-noclipboard           disable clipboard settings modification via vncconfig utility\n");
     ErrorF("-verbose [n]           verbose startup messages\n");
@@ -395,6 +396,11 @@ ddxProcessArgument(int argc, char *argv[], int i)
             sprintf(displayNumStr, "%d", displayNum);
         }
 
+        return 1;
+    }
+
+    if (strcmp(argv[i], "-lowspeedfixes") == 0) {
+        vncLowSpeedFixes = 1;
         return 1;
     }
 


### PR DESCRIPTION
Hi All!

Please accept my pull request.

For many years, I and others have used TigerVNC for work and hobbies, but when the network connection speed is slow, it becomes terrible, because the OS software starts repeating keystrokes at random. When you try to fix it, by pressing backspace, instead of one backspace, you can end up with two, three, or much more. And your whole line in the terminal that you typed for 10 minutes will be destroyed :) I lost a lot of keyboards because I was angry about it :(

Yesterday, I made the decision to find out and fix it, so the problem was very trivial and I don't know why I waited so many years. When we have very slow network speeds and high latency, we have a lot of delay between key press and key release events, so it looks like to the software as the long pressed key and it triggers auto-repeat.

The fix is very simple: if the -lowspeedfixes option is enabled and we have a keypress event for a regular key, we immediately create a fake keyrelease event (we shouldn't do this for modifiers, otherwise they won't be in the pressed state when the regular key event comes)

before:

![image](https://user-images.githubusercontent.com/30770134/226456470-65574f3e-2084-4076-b90f-06124293f44b.png)

after:

![image](https://user-images.githubusercontent.com/30770134/226456715-5115e4e6-3840-406a-ae90-646f8d11e75e.png)


Thank you! Regards, Roman (m0r1k)

