### PR TITLE
Improve TLS host exception handling

### DIFF
--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -435,6 +435,10 @@ void CSecurityTLS::checkSession()
                            "Unknown certificate issuer",
                            text.c_str()))
         throw AuthFailureException("Unknown certificate issuer");
+
+      status &= ~(GNUTLS_CERT_INVALID |
+                  GNUTLS_CERT_SIGNER_NOT_FOUND |
+                  GNUTLS_CERT_SIGNER_NOT_CA);
     }
 
     if (status & GNUTLS_CERT_EXPIRED) {
@@ -452,6 +456,13 @@ void CSecurityTLS::checkSession()
                            "Expired certificate",
                            text.c_str()))
         throw AuthFailureException("Expired certificate");
+
+      status &= ~GNUTLS_CERT_EXPIRED;
+    }
+
+    if (status != 0) {
+      vlog.error("Unhandled certificate problems: 0x%x", status);
+      throw AuthFailureException("Unhandled certificate problems");
     }
   } else if (err == GNUTLS_E_CERTIFICATE_KEY_MISMATCH) {
     std::string text;
@@ -478,6 +489,10 @@ void CSecurityTLS::checkSession()
                            "Unexpected server certificate",
                            text.c_str()))
         throw AuthFailureException("Unexpected server certificate");
+
+      status &= ~(GNUTLS_CERT_INVALID |
+                  GNUTLS_CERT_SIGNER_NOT_FOUND |
+                  GNUTLS_CERT_SIGNER_NOT_CA);
     }
 
     if (status & GNUTLS_CERT_EXPIRED) {
@@ -497,6 +512,13 @@ void CSecurityTLS::checkSession()
                            "Unexpected server certificate",
                            text.c_str()))
         throw AuthFailureException("Unexpected server certificate");
+
+      status &= ~GNUTLS_CERT_EXPIRED;
+    }
+
+    if (status != 0) {
+      vlog.error("Unhandled certificate problems: 0x%x", status);
+      throw AuthFailureException("Unhandled certificate problems");
     }
   }
 

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -46,21 +46,6 @@
 
 #include <gnutls/x509.h>
 
-/*
- * GNUTLS 2.6.5 and older didn't have some variables defined so don't use them.
- * GNUTLS 1.X.X defined LIBGNUTLS_VERSION_NUMBER so treat it as "old" gnutls as
- * well
- */
-#if (defined(GNUTLS_VERSION_NUMBER) && GNUTLS_VERSION_NUMBER < 0x020606) || \
-    defined(LIBGNUTLS_VERSION_NUMBER)
-#define WITHOUT_X509_TIMES
-#endif
-
-/* Ancient GNUTLS... */
-#if !defined(GNUTLS_VERSION_NUMBER) && !defined(LIBGNUTLS_VERSION_NUMBER)
-#define WITHOUT_X509_TIMES
-#endif
-
 using namespace rfb;
 
 static const char* homedirfn(const char* fn);
@@ -329,7 +314,6 @@ void CSecurityTLS::checkSession()
   if (status & GNUTLS_CERT_REVOKED)
     throw AuthFailureException("server certificate has been revoked");
 
-#ifndef WITHOUT_X509_TIMES
   if (status & GNUTLS_CERT_NOT_ACTIVATED)
     throw AuthFailureException("server certificate has not been activated");
 
@@ -340,7 +324,7 @@ void CSecurityTLS::checkSession()
 			 "do you want to continue?"))
       throw AuthFailureException("server certificate has expired");
   }
-#endif
+
   /* Process other errors later */
 
   cert_list = gnutls_certificate_get_peers(session, &cert_list_size);

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -315,14 +315,6 @@ void CSecurityTLS::checkSession()
   if (status & GNUTLS_CERT_REVOKED)
     throw AuthFailureException("server certificate has been revoked");
 
-  if (status & GNUTLS_CERT_EXPIRED) {
-    vlog.debug("server certificate has expired");
-    if (!msg->showMsgBox(UserMsgBox::M_YESNO, "certificate has expired",
-			 "The certificate of the server has expired, "
-			 "do you want to continue?"))
-      throw AuthFailureException("server certificate has expired");
-  }
-
   /* Process other errors later */
 
   cert_list = gnutls_certificate_get_peers(session, &cert_list_size);

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -417,7 +417,8 @@ void CSecurityTLS::checkSession()
     vlog.debug("Server host not previously known");
     vlog.debug("%s", info.data);
 
-    if (status & (GNUTLS_CERT_SIGNER_NOT_FOUND |
+    if (status & (GNUTLS_CERT_INVALID |
+                  GNUTLS_CERT_SIGNER_NOT_FOUND |
                   GNUTLS_CERT_SIGNER_NOT_CA)) {
       text = format("This certificate has been signed by an unknown "
                     "authority:\n"
@@ -458,7 +459,8 @@ void CSecurityTLS::checkSession()
     vlog.debug("Server host key mismatch");
     vlog.debug("%s", info.data);
 
-    if (status & (GNUTLS_CERT_SIGNER_NOT_FOUND |
+    if (status & (GNUTLS_CERT_INVALID |
+                  GNUTLS_CERT_SIGNER_NOT_FOUND |
                   GNUTLS_CERT_SIGNER_NOT_CA)) {
       text = format("This host is previously known with a different "
                     "certificate, and the new certificate has been "

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -371,7 +371,7 @@ void CSecurityTLS::checkSession()
     throw AuthFailureException("decoding of certificate failed");
 
   if (gnutls_x509_crt_check_hostname(crt, client->getServerName()) == 0) {
-    vlog.debug("hostname mismatch");
+    vlog.info("Server certificate doesn't match given server name");
     hostname_match = false;
   } else {
     hostname_match = true;
@@ -400,7 +400,7 @@ void CSecurityTLS::checkSession()
 
   /* Previously known? */
   if (err == GNUTLS_E_SUCCESS) {
-    vlog.debug("Server certificate found in known hosts file");
+    vlog.info("Server certificate found in known hosts file");
     gnutls_x509_crt_deinit(crt);
     return;
   }
@@ -423,8 +423,8 @@ void CSecurityTLS::checkSession()
   if (err == GNUTLS_E_NO_CERTIFICATE_FOUND) {
     std::string text;
 
-    vlog.debug("Server host not previously known");
-    vlog.debug("%s", info.data);
+    vlog.info("Server host not previously known");
+    vlog.info("%s", info.data);
 
     if (status & (GNUTLS_CERT_INVALID |
                   GNUTLS_CERT_SIGNER_NOT_FOUND |
@@ -532,8 +532,8 @@ void CSecurityTLS::checkSession()
   } else if (err == GNUTLS_E_CERTIFICATE_KEY_MISMATCH) {
     std::string text;
 
-    vlog.debug("Server host key mismatch");
-    vlog.debug("%s", info.data);
+    vlog.info("Server host key mismatch");
+    vlog.info("%s", info.data);
 
     if (status & (GNUTLS_CERT_INVALID |
                   GNUTLS_CERT_SIGNER_NOT_FOUND |
@@ -652,6 +652,8 @@ void CSecurityTLS::checkSession()
   if (gnutls_store_pubkey(dbPath.c_str(), NULL, client->getServerName(),
                           NULL, GNUTLS_CRT_X509, &cert_list[0], 0, 0))
     vlog.error("Failed to store server certificate to known hosts database");
+
+  vlog.info("Exception added for server host");
 
   gnutls_x509_crt_deinit(crt);
   gnutls_free(info.data);


### PR DESCRIPTION
Various fixes to get our exception handling for bad certificates more in line with how browsers behave. Most prominently, it now remembers an exception for when the hostname doesn't match the certificate.