### PR TITLE
Use compressLevel in ZRLEEncoder

### DIFF
--- a/common/rfb/ZRLEEncoder.cxx
+++ b/common/rfb/ZRLEEncoder.cxx
@@ -28,15 +28,23 @@
 #include <rfb/SConnection.h>
 #include <rfb/ZRLEEncoder.h>
 #include <rfb/Configuration.h>
+#include <rfb/LogWriter.h>
 
 using namespace rfb;
 
-IntParameter zlibLevel("ZlibLevel","Zlib compression level",-1);
+static LogWriter vlog("ZRLEEncoder");
+
+IntParameter zlibLevel("ZlibLevel","[DEPRECATED] Zlib compression level",-1);
 
 ZRLEEncoder::ZRLEEncoder(SConnection* conn)
   : Encoder(conn, encodingZRLE, EncoderPlain, 127),
-  zos(0,zlibLevel), mos(129*1024)
+  zos(0, 2), mos(129*1024)
 {
+  if (zlibLevel != -1) {
+    vlog.info("Warning: The ZlibLevel option is deprecated and is "
+              "ignored by the server. The compression level can be set "
+              "by the client instead.");
+  }
   zos.setUnderlying(&mos);
 }
 
@@ -48,6 +56,11 @@ ZRLEEncoder::~ZRLEEncoder()
 bool ZRLEEncoder::isSupported()
 {
   return conn->client.supportsEncoding(encodingZRLE);
+}
+
+void ZRLEEncoder::setCompressLevel(int level)
+{
+  zos.setCompressionLevel(level);
 }
 
 void ZRLEEncoder::writeRect(const PixelBuffer* pb, const Palette& palette)

--- a/common/rfb/ZRLEEncoder.h
+++ b/common/rfb/ZRLEEncoder.h
@@ -32,6 +32,8 @@ namespace rfb {
 
     virtual bool isSupported();
 
+    virtual void setCompressLevel(int level);
+
     virtual void writeRect(const PixelBuffer* pb, const Palette& palette);
     virtual void writeSolidRect(int width, int height,
                                 const PixelFormat& pf,

--- a/unix/x0vncserver/x0vncserver.man
+++ b/unix/x0vncserver/x0vncserver.man
@@ -287,12 +287,6 @@ Use MIT-SHM extension if available.  Using that extension accelerates reading
 the screen.  Default is on.
 .
 .TP
-.B \-ZlibLevel \fIlevel\fP
-Zlib compression level for ZRLE encoding (it does not affect Tight encoding).
-Acceptable values are between 0 and 9.  Default is to use the standard
-compression level provided by the \fBzlib\fP(3) compression library.
-.
-.TP
 .B \-ImprovedHextile
 Use improved compression algorithm for Hextile encoding which achieves better
 compression ratios by the cost of using slightly more CPU time.  Default is

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -171,12 +171,6 @@ be either \fB0\fP (off), \fB1\fP (always) or \fB2\fP (auto). Default is
 \fB2\fP.
 .
 .TP
-.B \-ZlibLevel \fIlevel\fP
-Zlib compression level for ZRLE encoding (it does not affect Tight encoding).
-Acceptable values are between 0 and 9.  Default is to use the standard
-compression level provided by the \fBzlib\fP(3) compression library.
-.
-.TP
 .B \-ImprovedHextile
 Use improved compression algorithm for Hextile encoding which achieves better
 compression ratios by the cost of using slightly more CPU time.  Default is


### PR DESCRIPTION
Currently, setting a custom compression level in vncviewer only affects the TightEncoder. This change makes the ZRLEEncoder respect a client's desired compressLevel as well.

Tested using x0vncserver, seems to work.
