### PR TITLE
Add option to run vncsession without forking and detaching

### DIFF
--- a/unix/vncserver/vncsession.man.in
+++ b/unix/vncserver/vncsession.man.in
@@ -3,6 +3,7 @@
 vncsession \- start a VNC server
 .SH SYNOPSIS
 .B vncsession
+.RI [-D]
 .RI < username >
 .RI <: display# >
 .SH DESCRIPTION
@@ -15,6 +16,15 @@ appropriate options and starts a window manager on the VNC desktop.
 .B vncsession
 is rarely called directly and is normally started by the system service
 manager.
+
+.SH -D OPTION
+.B vncsession
+by default forks and detaches. If the -D option is used, it does not fork and
+detach. This option is provided for use with system service managers that
+require services to run in the foreground. This option is not intended for
+debugging in a login shell from a terminal or for running
+.B vncsession
+from a terminal as an ordinary user.
 
 .SH FILES
 Several VNC-related files are found in the directory $HOME/.vnc:


### PR DESCRIPTION
Option is -D, which is what sshd uses for the same option.

Also added description of the new option to the vncsession man page.

Tested on top of up-to-date version 1.13.80,
commit 094496e (Merge pull request #1648 from TigerVNC/copyright) on Void Linux with runit system service manager.

Also tested on top of Fedora 38 with version 1.13.1 and systemd with Type=exec service and -D option passed to vncsession in vncsession-start.

Resolves #1649