### PR TITLE
vncserver: recognize environment variables in configuration files

### DIFF
--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -285,6 +285,7 @@ sub LoadConfig {
           if ($warnoverride && $config{$k}) {
             print("Warning: $configFile is overriding previously defined '$k' to be '$v'\n");
           }
+          $v =~ s/\$(\w+)/$ENV{$1}/g;
           $config{$k} = $v;
         } elsif ($_ =~ m/^\s*(\S+)/) {
           # We can't reasonably warn on override of toggles (e.g. AlwaysShared)


### PR DESCRIPTION
Since commit c67a5f25 (Start the sessions using xinit), vncserver runs Xvnc via exec(), instead of via system(). Before that, it was possible to enable PAM authentication for the user who owned the Xvnc process by adding this to /etc/tigervnc/vncserver-config-defaults:

    SecurityTypes=TLSPlain
    PlainUsers=$USER

This does not work anymore because with exec() the command line is not parsed by the user shell.

A simple workaround would be to use "PlainUsers=*" but this creates a security vulnerability, since it allows any user to have access to the VNC session, not only the owner of the Xvnc process.

Another workaround is to create a per-user ~/.vnc/config containing

   PlainUsers=<actual-user-name>

but this is inconvenient when there is a large number of VNC users to configure.

This commits partially restores the old behavior by replacing any $FOO in a parameter value by the contents of the corresponding environment variable.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2233204