### PR TITLE
Support the "%u" username alias in PlainUsers

### DIFF
--- a/common/rfb/SSecurityPlain.cxx
+++ b/common/rfb/SSecurityPlain.cxx
@@ -28,6 +28,8 @@
 #include <rdr/InStream.h>
 #if !defined(WIN32) && !defined(__APPLE__)
 #include <rfb/UnixPasswordValidator.h>
+#include <unistd.h>
+#include <pwd.h>
 #endif
 #ifdef WIN32
 #include <rfb/WinPasswdValidator.h>
@@ -53,6 +55,13 @@ bool PasswordValidator::validUser(const char* username)
   for (size_t i = 0; i < users.size(); i++) {
     if (users[i] == "*")
       return true;
+#if !defined(WIN32) && !defined(__APPLE__)
+    if (users[i] == "%u") {
+      struct passwd *pw = getpwnam(username);
+      if (pw && pw->pw_uid == getuid())
+        return true;
+    }
+#endif
     if (users[i] == username)
       return true;
   }

--- a/unix/x0vncserver/x0vncserver.man
+++ b/unix/x0vncserver/x0vncserver.man
@@ -125,8 +125,9 @@ parameter instead.
 .B \-PlainUsers \fIuser-list\fP
 A comma separated list of user names that are allowed to authenticate via
 any of the "Plain" security types (Plain, TLSPlain, etc.). Specify \fB*\fP
-to allow any user to authenticate using this security type. Default is to
-deny all users.
+to allow any user to authenticate using this security type. Specify \fB%u\fP
+to allow the effective user of the server process. Default is to deny all
+users.
 .
 .TP
 .B \-pam_service \fIname\fP, \-PAMService \fIname\fP

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -200,8 +200,9 @@ parameter instead.
 .B \-PlainUsers \fIuser-list\fP
 A comma separated list of user names that are allowed to authenticate via
 any of the "Plain" security types (Plain, TLSPlain, etc.). Specify \fB*\fP
-to allow any user to authenticate using this security type. Default is to
-deny all users.
+to allow any user to authenticate using this security type. Specify \fB%u\fP
+to allow the effective user of the server process. Default is to deny all
+users.
 .
 .TP
 .B \-pam_service \fIname\fP, \-PAMService \fIname\fP


### PR DESCRIPTION
This permits to enable PAM for the effective user of the Xvnc process by adding this to ~/.vnc/config or /etc/tigervnc/vncserver-config-defaults:

   SecurityTypes=TLSPlain
   PlainUsers=%u

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2233204