### PR TITLE
Fix description of "%u" in manual pages.

### DIFF
--- a/unix/x0vncserver/x0vncserver.man
+++ b/unix/x0vncserver/x0vncserver.man
@@ -126,8 +126,7 @@ parameter instead.
 A comma separated list of user names that are allowed to authenticate via
 any of the "Plain" security types (Plain, TLSPlain, etc.). Specify \fB*\fP
 to allow any user to authenticate using this security type. Specify \fB%u\fP
-to allow the effective user of the server process. Default is to deny all
-users.
+to allow the user of the server process. Default is to deny all users.
 .
 .TP
 .B \-pam_service \fIname\fP, \-PAMService \fIname\fP

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -201,8 +201,7 @@ parameter instead.
 A comma separated list of user names that are allowed to authenticate via
 any of the "Plain" security types (Plain, TLSPlain, etc.). Specify \fB*\fP
 to allow any user to authenticate using this security type. Specify \fB%u\fP
-to allow the effective user of the server process. Default is to deny all
-users.
+to allow the user of the server process. Default is to deny all users.
 .
 .TP
 .B \-pam_service \fIname\fP, \-PAMService \fIname\fP


### PR DESCRIPTION
We user the real, not the effective user ID, to check if the user is allowed to log in with the "Plain" security types. Otherwise it would be necessary to log in as root when Xvnc is installed with the set-user-id bit on.