### PR TITLE
vncconfig: add option to force view-only remote client connections, round 2

### DIFF
--- a/common/network/Socket.h
+++ b/common/network/Socket.h
@@ -121,7 +121,9 @@ namespace network {
     //   outgoing is set to true if the socket was created by connecting out
     //   to another host, or false if the socket was created by accept()ing
     //   an incoming connection.
-    virtual void addSocket(network::Socket* sock, bool outgoing=false) = 0;
+    //   viewOnly is set to true if the server must ignore all keyboard or
+    //   mouse events sent by the client.
+    virtual void addSocket(network::Socket* sock, bool outgoing=false, bool viewOnly=false) = 0;
 
     // removeSocket() tells the server to stop serving the Socket.  The
     //   caller retains ownership of the Socket - the server must NOT

--- a/common/rfb/CMakeLists.txt
+++ b/common/rfb/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(rfb STATIC
   Security.cxx
   SecurityServer.cxx
   SecurityClient.cxx
+  SSecurity.cxx
   SSecurityPlain.cxx
   SSecurityStack.cxx
   SSecurityVncAuth.cxx

--- a/common/rfb/SConnection.cxx
+++ b/common/rfb/SConnection.cxx
@@ -44,6 +44,7 @@ using namespace rfb;
 static LogWriter vlog("SConnection");
 
 // AccessRights values
+const SConnection::AccessRights SConnection::AccessNone           = 0x0000;
 const SConnection::AccessRights SConnection::AccessView           = 0x0001;
 const SConnection::AccessRights SConnection::AccessKeyEvents      = 0x0002;
 const SConnection::AccessRights SConnection::AccessPtrEvents      = 0x0004;
@@ -60,7 +61,7 @@ SConnection::SConnection()
     is(0), os(0), reader_(0), writer_(0), ssecurity(0),
     authFailureTimer(this, &SConnection::handleAuthFailureTimeout),
     state_(RFBSTATE_UNINITIALISED), preferredEncoding(encodingRaw),
-    accessRights(0x0000), hasRemoteClipboard(false),
+    accessRights(AccessNone), hasRemoteClipboard(false),
     hasLocalClipboard(false),
     unsolicitedClipboardAttempt(false)
 {

--- a/common/rfb/SConnection.h
+++ b/common/rfb/SConnection.h
@@ -180,6 +180,7 @@ namespace rfb {
     // is up to the derived class.
 
     typedef uint16_t AccessRights;
+    static const AccessRights AccessNone;           // No rights at all
     static const AccessRights AccessView;           // View display contents
     static const AccessRights AccessKeyEvents;      // Send key events
     static const AccessRights AccessPtrEvents;      // Send pointer events

--- a/common/rfb/SConnection.h
+++ b/common/rfb/SConnection.h
@@ -42,7 +42,7 @@ namespace rfb {
   class SConnection : public SMsgHandler {
   public:
 
-    SConnection();
+    SConnection(bool viewOnly);
     virtual ~SConnection();
 
     // Methods to initialise the connection
@@ -256,7 +256,7 @@ namespace rfb {
     SMsgReader* reader_;
     SMsgWriter* writer_;
 
-    SecurityServer security;
+    SecurityServer *security;
     SSecurity* ssecurity;
 
     MethodTimer<SConnection> authFailureTimer;

--- a/common/rfb/SSecurity.cxx
+++ b/common/rfb/SSecurity.cxx
@@ -1,0 +1,39 @@
+/* Copyright (C) 2023 TigerVNC Team
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <rfb/SSecurity.h>
+
+using namespace rfb;
+
+SSecurity::SSecurity(SConnection* sc)
+  : sc(sc), accessRights(SConnection::AccessDefault)
+{
+}
+
+SSecurity::~SSecurity()
+{
+}
+
+SConnection::AccessRights SSecurity::getAccessRights() const
+{
+  return accessRights;
+}

--- a/common/rfb/SSecurity.cxx
+++ b/common/rfb/SSecurity.cxx
@@ -24,8 +24,9 @@
 
 using namespace rfb;
 
-SSecurity::SSecurity(SConnection* sc)
-  : sc(sc), accessRights(SConnection::AccessDefault)
+SSecurity::SSecurity(SConnection* sc, bool viewOnly)
+  : sc(sc),
+    accessRights(viewOnly ? SConnection::AccessView : SConnection::AccessDefault)
 {
 }
 

--- a/common/rfb/SSecurity.h
+++ b/common/rfb/SSecurity.h
@@ -51,7 +51,7 @@ namespace rfb {
 
   class SSecurity {
   public:
-    SSecurity(SConnection* sc);
+    SSecurity(SConnection* sc, bool viewOnly);
     virtual ~SSecurity();
     virtual bool processMsg() = 0;
     virtual int getType() const = 0;

--- a/common/rfb/SSecurity.h
+++ b/common/rfb/SSecurity.h
@@ -51,8 +51,8 @@ namespace rfb {
 
   class SSecurity {
   public:
-    SSecurity(SConnection* sc_) : sc(sc_) {}
-    virtual ~SSecurity() {}
+    SSecurity(SConnection* sc);
+    virtual ~SSecurity();
     virtual bool processMsg() = 0;
     virtual int getType() const = 0;
 
@@ -62,10 +62,11 @@ namespace rfb {
     // for this security type.
     virtual const char* getUserName() const = 0;
 
-    virtual SConnection::AccessRights getAccessRights() const { return SConnection::AccessDefault; }
+    virtual SConnection::AccessRights getAccessRights() const;
 
   protected:
     SConnection* sc;
+    SConnection::AccessRights accessRights;
   };
 
 }

--- a/common/rfb/SSecurityNone.h
+++ b/common/rfb/SSecurityNone.h
@@ -28,7 +28,7 @@ namespace rfb {
 
   class SSecurityNone : public SSecurity {
   public:
-    SSecurityNone(SConnection* sc) : SSecurity(sc) {}
+    SSecurityNone(SConnection* sc, bool viewOnly) : SSecurity(sc, viewOnly) {}
     virtual bool processMsg() { return true; }
     virtual int getType() const {return secTypeNone;}
     virtual const char* getUserName() const {return 0;}

--- a/common/rfb/SSecurityPlain.cxx
+++ b/common/rfb/SSecurityPlain.cxx
@@ -68,7 +68,8 @@ bool PasswordValidator::validUser(const char* username)
   return false;
 }
 
-SSecurityPlain::SSecurityPlain(SConnection* sc) : SSecurity(sc)
+SSecurityPlain::SSecurityPlain(SConnection* sc, bool viewOnly)
+  : SSecurity(sc, viewOnly)
 {
 #ifdef WIN32
   valid = new WinPasswdValidator();

--- a/common/rfb/SSecurityPlain.h
+++ b/common/rfb/SSecurityPlain.h
@@ -42,7 +42,7 @@ namespace rfb {
 
   class SSecurityPlain : public SSecurity {
   public:
-    SSecurityPlain(SConnection* sc);
+    SSecurityPlain(SConnection* sc, bool viewOnly);
     virtual bool processMsg();
     virtual int getType() const { return secTypePlain; };
     virtual const char* getUserName() const { return username; }

--- a/common/rfb/SSecurityRSAAES.cxx
+++ b/common/rfb/SSecurityRSAAES.cxx
@@ -76,7 +76,6 @@ SSecurityRSAAES::SSecurityRSAAES(SConnection* sc, uint32_t _secType,
     keySize(_keySize), isAllEncrypted(_isAllEncrypted), secType(_secType),
     serverKey(), clientKey(),
     serverKeyN(NULL), serverKeyE(NULL), clientKeyN(NULL), clientKeyE(NULL),
-    accessRights(SConnection::AccessDefault),
     rais(NULL), raos(NULL), rawis(NULL), rawos(NULL)
 {
   assert(keySize == 128 || keySize == 256);

--- a/common/rfb/SSecurityRSAAES.cxx
+++ b/common/rfb/SSecurityRSAAES.cxx
@@ -70,9 +70,9 @@ BoolParameter SSecurityRSAAES::requireUsername
 ("RequireUsername", "Require username for the RSA-AES security types",
  false, ConfServer);
 
-SSecurityRSAAES::SSecurityRSAAES(SConnection* sc, uint32_t _secType,
+SSecurityRSAAES::SSecurityRSAAES(SConnection* sc, bool viewOnly, uint32_t _secType,
                                  int _keySize, bool _isAllEncrypted)
-  : SSecurity(sc), state(SendPublicKey),
+  : SSecurity(sc, viewOnly), state(SendPublicKey),
     keySize(_keySize), isAllEncrypted(_isAllEncrypted), secType(_secType),
     serverKey(), clientKey(),
     serverKeyN(NULL), serverKeyE(NULL), clientKeyN(NULL), clientKeyE(NULL),

--- a/common/rfb/SSecurityRSAAES.h
+++ b/common/rfb/SSecurityRSAAES.h
@@ -33,7 +33,7 @@ namespace rfb {
 
   class SSecurityRSAAES : public SSecurity {
   public:
-    SSecurityRSAAES(SConnection* sc, uint32_t secType,
+    SSecurityRSAAES(SConnection* sc, bool viewOnly, uint32_t secType,
                     int keySize, bool isAllEncrypted);
     virtual ~SSecurityRSAAES();
     virtual bool processMsg();

--- a/common/rfb/SSecurityRSAAES.h
+++ b/common/rfb/SSecurityRSAAES.h
@@ -39,10 +39,6 @@ namespace rfb {
     virtual bool processMsg();
     virtual const char* getUserName() const;
     virtual int getType() const { return secType; }
-    virtual SConnection::AccessRights getAccessRights() const
-    {
-      return accessRights;
-    }
 
     static StringParameter keyFile;
     static BoolParameter requireUsername;
@@ -82,7 +78,6 @@ namespace rfb {
 
     char username[256];
     char password[256];
-    SConnection::AccessRights accessRights;
 
     rdr::InStream* rais;
     rdr::OutStream* raos;

--- a/common/rfb/SSecurityStack.cxx
+++ b/common/rfb/SSecurityStack.cxx
@@ -73,17 +73,17 @@ const char* SSecurityStack::getUserName() const
 
 SConnection::AccessRights SSecurityStack::getAccessRights() const
 {
-  SConnection::AccessRights accessRights;
+  SConnection::AccessRights rights;
 
   if (!state0 && !state1)
     return SSecurity::getAccessRights();
 
-  accessRights = SConnection::AccessFull;
+  rights = SConnection::AccessFull;
 
   if (state0)
-    accessRights &= state0->getAccessRights();
+    rights &= state0->getAccessRights();
   if (state1)
-    accessRights &= state1->getAccessRights();
+    rights &= state1->getAccessRights();
 
-  return accessRights;
+  return rights;
 }

--- a/common/rfb/SSecurityStack.cxx
+++ b/common/rfb/SSecurityStack.cxx
@@ -24,9 +24,9 @@
 
 using namespace rfb;
 
-SSecurityStack::SSecurityStack(SConnection* sc, int Type,
+SSecurityStack::SSecurityStack(SConnection* sc, bool viewOnly, int Type,
                                SSecurity* s0, SSecurity* s1)
-  : SSecurity(sc), state(0), state0(s0), state1(s1), type(Type)
+  : SSecurity(sc, viewOnly), state(0), state0(s0), state1(s1), type(Type)
 {
 }
 

--- a/common/rfb/SSecurityStack.h
+++ b/common/rfb/SSecurityStack.h
@@ -26,7 +26,7 @@ namespace rfb {
 
   class SSecurityStack : public SSecurity {
   public:
-    SSecurityStack(SConnection* sc, int Type,
+    SSecurityStack(SConnection* sc, bool viewOnly, int Type,
                    SSecurity* s0 = NULL, SSecurity* s1 = NULL);
     ~SSecurityStack();
     virtual bool processMsg();

--- a/common/rfb/SSecurityTLS.cxx
+++ b/common/rfb/SSecurityTLS.cxx
@@ -66,8 +66,8 @@ StringParameter SSecurityTLS::X509_KeyFile
 
 static LogWriter vlog("TLS");
 
-SSecurityTLS::SSecurityTLS(SConnection* sc, bool _anon)
-  : SSecurity(sc), session(NULL), anon_cred(NULL),
+SSecurityTLS::SSecurityTLS(SConnection* sc, bool viewOnly, bool _anon)
+  : SSecurity(sc, viewOnly), session(NULL), anon_cred(NULL),
     cert_cred(NULL), anon(_anon), tlsis(NULL), tlsos(NULL),
     rawis(NULL), rawos(NULL)
 {

--- a/common/rfb/SSecurityTLS.h
+++ b/common/rfb/SSecurityTLS.h
@@ -43,7 +43,7 @@ namespace rfb {
 
   class SSecurityTLS : public SSecurity {
   public:
-    SSecurityTLS(SConnection* sc, bool _anon);
+    SSecurityTLS(SConnection* sc, bool viewOnly, bool _anon);
     virtual ~SSecurityTLS();
     virtual bool processMsg();
     virtual const char* getUserName() const {return 0;}

--- a/common/rfb/SSecurityVeNCrypt.cxx
+++ b/common/rfb/SSecurityVeNCrypt.cxx
@@ -38,8 +38,8 @@ using namespace std;
 
 static LogWriter vlog("SVeNCrypt");
 
-SSecurityVeNCrypt::SSecurityVeNCrypt(SConnection* sc, SecurityServer *sec)
-  : SSecurity(sc), security(sec)
+SSecurityVeNCrypt::SSecurityVeNCrypt(SConnection* sc, bool viewOnly, SecurityServer *sec)
+  : SSecurity(sc, viewOnly), security(sec)
 {
   ssecurity = NULL;
   haveSentVersion = false;

--- a/common/rfb/SSecurityVeNCrypt.h
+++ b/common/rfb/SSecurityVeNCrypt.h
@@ -32,7 +32,7 @@ namespace rfb {
 
   class SSecurityVeNCrypt : public SSecurity {
   public:
-    SSecurityVeNCrypt(SConnection* sc, SecurityServer *sec);
+    SSecurityVeNCrypt(SConnection* sc, bool viewOnly, SecurityServer *sec);
     ~SSecurityVeNCrypt();
     virtual bool processMsg();
     virtual int getType() const { return chosenType; }

--- a/common/rfb/SSecurityVncAuth.cxx
+++ b/common/rfb/SSecurityVncAuth.cxx
@@ -54,7 +54,7 @@ VncAuthPasswdParameter SSecurityVncAuth::vncAuthPasswd
 
 SSecurityVncAuth::SSecurityVncAuth(SConnection* sc)
   : SSecurity(sc), sentChallenge(false),
-    pg(&vncAuthPasswd), accessRights(SConnection::AccessNone)
+    pg(&vncAuthPasswd)
 {
 }
 

--- a/common/rfb/SSecurityVncAuth.cxx
+++ b/common/rfb/SSecurityVncAuth.cxx
@@ -52,8 +52,8 @@ VncAuthPasswdParameter SSecurityVncAuth::vncAuthPasswd
 ("Password", "Obfuscated binary encoding of the password which clients must supply to "
  "access the server", &SSecurityVncAuth::vncAuthPasswdFile);
 
-SSecurityVncAuth::SSecurityVncAuth(SConnection* sc)
-  : SSecurity(sc), sentChallenge(false),
+SSecurityVncAuth::SSecurityVncAuth(SConnection* sc, bool viewOnly)
+  : SSecurity(sc, viewOnly), sentChallenge(false),
     pg(&vncAuthPasswd)
 {
 }

--- a/common/rfb/SSecurityVncAuth.cxx
+++ b/common/rfb/SSecurityVncAuth.cxx
@@ -54,7 +54,7 @@ VncAuthPasswdParameter SSecurityVncAuth::vncAuthPasswd
 
 SSecurityVncAuth::SSecurityVncAuth(SConnection* sc)
   : SSecurity(sc), sentChallenge(false),
-    pg(&vncAuthPasswd), accessRights(0)
+    pg(&vncAuthPasswd), accessRights(SConnection::AccessNone)
 {
 }
 

--- a/common/rfb/SSecurityVncAuth.h
+++ b/common/rfb/SSecurityVncAuth.h
@@ -55,7 +55,6 @@ namespace rfb {
     virtual bool processMsg();
     virtual int getType() const {return secTypeVncAuth;}
     virtual const char* getUserName() const {return 0;}
-    virtual SConnection::AccessRights getAccessRights() const { return accessRights; }
     static StringParameter vncAuthPasswdFile;
     static VncAuthPasswdParameter vncAuthPasswd;
   private:
@@ -65,7 +64,6 @@ namespace rfb {
     uint8_t response[vncAuthChallengeSize];
     bool sentChallenge;
     VncAuthPasswdGetter* pg;
-    SConnection::AccessRights accessRights;
   };
 }
 #endif

--- a/common/rfb/SSecurityVncAuth.h
+++ b/common/rfb/SSecurityVncAuth.h
@@ -51,7 +51,7 @@ namespace rfb {
 
   class SSecurityVncAuth : public SSecurity {
   public:
-    SSecurityVncAuth(SConnection* sc);
+    SSecurityVncAuth(SConnection* sc, bool viewOnly);
     virtual bool processMsg();
     virtual int getType() const {return secTypeVncAuth;}
     virtual const char* getUserName() const {return 0;}

--- a/common/rfb/SecurityServer.cxx
+++ b/common/rfb/SecurityServer.cxx
@@ -60,33 +60,33 @@ SSecurity* SecurityServer::GetSSecurity(SConnection* sc, uint32_t secType)
     goto bail;
 
   switch (secType) {
-  case secTypeNone: return new SSecurityNone(sc);
-  case secTypeVncAuth: return new SSecurityVncAuth(sc);
-  case secTypeVeNCrypt: return new SSecurityVeNCrypt(sc, this);
-  case secTypePlain: return new SSecurityPlain(sc);
+  case secTypeNone: return new SSecurityNone(sc, viewOnly);
+  case secTypeVncAuth: return new SSecurityVncAuth(sc, viewOnly);
+  case secTypeVeNCrypt: return new SSecurityVeNCrypt(sc, viewOnly, this);
+  case secTypePlain: return new SSecurityPlain(sc, viewOnly);
 #ifdef HAVE_GNUTLS
   case secTypeTLSNone:
-    return new SSecurityStack(sc, secTypeTLSNone, new SSecurityTLS(sc, true));
+    return new SSecurityStack(sc, viewOnly, secTypeTLSNone, new SSecurityTLS(sc, viewOnly, true));
   case secTypeTLSVnc:
-    return new SSecurityStack(sc, secTypeTLSVnc, new SSecurityTLS(sc, true), new SSecurityVncAuth(sc));
+    return new SSecurityStack(sc, viewOnly, secTypeTLSVnc, new SSecurityTLS(sc, viewOnly, true), new SSecurityVncAuth(sc, viewOnly));
   case secTypeTLSPlain:
-    return new SSecurityStack(sc, secTypeTLSPlain, new SSecurityTLS(sc, true), new SSecurityPlain(sc));
+    return new SSecurityStack(sc, viewOnly, secTypeTLSPlain, new SSecurityTLS(sc, viewOnly, true), new SSecurityPlain(sc, viewOnly));
   case secTypeX509None:
-    return new SSecurityStack(sc, secTypeX509None, new SSecurityTLS(sc, false));
+    return new SSecurityStack(sc, viewOnly, secTypeX509None, new SSecurityTLS(sc, viewOnly, false));
   case secTypeX509Vnc:
-    return new SSecurityStack(sc, secTypeX509None, new SSecurityTLS(sc, false), new SSecurityVncAuth(sc));
+    return new SSecurityStack(sc, viewOnly, secTypeX509None, new SSecurityTLS(sc, viewOnly, false), new SSecurityVncAuth(sc, viewOnly));
   case secTypeX509Plain:
-    return new SSecurityStack(sc, secTypeX509Plain, new SSecurityTLS(sc, false), new SSecurityPlain(sc));
+    return new SSecurityStack(sc, viewOnly, secTypeX509Plain, new SSecurityTLS(sc, viewOnly, false), new SSecurityPlain(sc, viewOnly));
 #endif
 #ifdef HAVE_NETTLE
   case secTypeRA2:
-    return new SSecurityRSAAES(sc, secTypeRA2, 128, true);
+    return new SSecurityRSAAES(sc, viewOnly, secTypeRA2, 128, true);
   case secTypeRA2ne:
-    return new SSecurityRSAAES(sc, secTypeRA2ne, 128, false);
+    return new SSecurityRSAAES(sc, viewOnly, secTypeRA2ne, 128, false);
   case secTypeRA256:
-    return new SSecurityRSAAES(sc, secTypeRA256, 256, true);
+    return new SSecurityRSAAES(sc, viewOnly, secTypeRA256, 256, true);
   case secTypeRAne256:
-    return new SSecurityRSAAES(sc, secTypeRAne256, 256, false);
+    return new SSecurityRSAAES(sc, viewOnly, secTypeRAne256, 256, false);
 #endif
   }
 

--- a/common/rfb/SecurityServer.h
+++ b/common/rfb/SecurityServer.h
@@ -30,12 +30,15 @@ namespace rfb {
 
   class SecurityServer : public Security {
   public:
-    SecurityServer(void) : Security(secTypes) {}
+    SecurityServer(bool viewOnly) : Security(secTypes), viewOnly(viewOnly) {}
 
     /* Create server side SSecurity class instance */
     SSecurity* GetSSecurity(SConnection* sc, uint32_t secType);
 
     static StringParameter secTypes;
+
+  private:
+    bool viewOnly;
   };
 
 }

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -50,8 +50,9 @@ static LogWriter vlog("VNCSConnST");
 static Cursor emptyCursor(0, 0, Point(0, 0), NULL);
 
 VNCSConnectionST::VNCSConnectionST(VNCServerST* server_, network::Socket *s,
-                                   bool reverse)
-  : sock(s), reverseConnection(reverse),
+                                   bool reverse, bool viewOnly)
+  : SConnection(viewOnly),
+    sock(s), reverseConnection(reverse),
     inProcessMessages(false),
     pendingSyncFence(false), syncFence(false), fenceFlags(0),
     fenceDataLen(0), fenceData(NULL), congestionTimer(this),

--- a/common/rfb/VNCSConnectionST.h
+++ b/common/rfb/VNCSConnectionST.h
@@ -40,7 +40,8 @@ namespace rfb {
   class VNCSConnectionST : private SConnection,
                            public Timer::Callback {
   public:
-    VNCSConnectionST(VNCServerST* server_, network::Socket* s, bool reverse);
+    VNCSConnectionST(VNCServerST* server_, network::Socket* s, bool reverse,
+                     bool viewOnly);
     virtual ~VNCSConnectionST();
 
     // SConnection methods

--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -128,7 +128,7 @@ VNCServerST::~VNCServerST()
 
 // SocketServer methods
 
-void VNCServerST::addSocket(network::Socket* sock, bool outgoing)
+void VNCServerST::addSocket(network::Socket* sock, bool outgoing, bool viewOnly)
 {
   // - Check the connection isn't black-marked
   // *** do this in getSecurity instead?
@@ -159,7 +159,7 @@ void VNCServerST::addSocket(network::Socket* sock, bool outgoing)
     connectTimer.start(secsToMillis(rfb::Server::maxConnectionTime));
   disconnectTimer.stop();
 
-  VNCSConnectionST* client = new VNCSConnectionST(this, sock, outgoing);
+  VNCSConnectionST* client = new VNCSConnectionST(this, sock, outgoing, viewOnly);
   clients.push_front(client);
   client->init();
 }

--- a/common/rfb/VNCServerST.h
+++ b/common/rfb/VNCServerST.h
@@ -56,7 +56,7 @@ namespace rfb {
     // addSocket
     //   Causes the server to allocate an RFB-protocol management
     //   structure for the socket & initialise it.
-    virtual void addSocket(network::Socket* sock, bool outgoing=false);
+    virtual void addSocket(network::Socket* sock, bool outgoing=false, bool viewOnly=false);
 
     // removeSocket
     //   Clean up any resources associated with the Socket

--- a/tests/perf/encperf.cxx
+++ b/tests/perf/encperf.cxx
@@ -303,6 +303,7 @@ void Manager::getStats(double& ratio, unsigned long long& encodedBytes,
 }
 
 SConn::SConn()
+: SConnection(false)
 {
   out = new DummyOutStream;
   setStreams(NULL, out);

--- a/unix/vncconfig/vncExt.c
+++ b/unix/vncconfig/vncExt.c
@@ -228,7 +228,7 @@ Bool XVncExtSelectInput(Display* dpy, Window w, int mask)
   return True;
 }
 
-Bool XVncExtConnect(Display* dpy, const char* hostAndPort)
+Bool XVncExtConnect(Display* dpy, const char* hostAndPort, Bool viewOnly)
 {
   xVncExtConnectReq* req;
   xVncExtConnectReply rep;
@@ -243,6 +243,7 @@ Bool XVncExtConnect(Display* dpy, const char* hostAndPort)
   req->vncExtReqType = X_VncExtConnect;
   req->length += (strLen + 3) >> 2;
   req->strLen = strLen;
+  req->viewOnly = (CARD8)viewOnly;
   Data(dpy, hostAndPort, strLen);
   if (!_XReply(dpy, (xReply *)&rep, 0, xFalse)) {
     UnlockDisplay(dpy);

--- a/unix/vncconfig/vncExt.h
+++ b/unix/vncconfig/vncExt.h
@@ -46,7 +46,7 @@ char* XVncExtGetParamDesc(Display* dpy, const char* param);
 char** XVncExtListParams(Display* dpy, int* nParams);
 void XVncExtFreeParamList(char** list);
 Bool XVncExtSelectInput(Display* dpy, Window w, int mask);
-Bool XVncExtConnect(Display* dpy, const char* hostAndPort);
+Bool XVncExtConnect(Display* dpy, const char* hostAndPort, Bool viewOnly);
 Bool XVncExtGetQueryConnect(Display* dpy, char** addr,
                             char** user, int* timeout, void** opaqueId);
 Bool XVncExtApproveConnect(Display* dpy, void* opaqueId, int approve);
@@ -181,7 +181,7 @@ typedef struct {
   CARD8 vncExtReqType; /* always VncExtConnect */
   CARD16 length B16;
   CARD8 strLen;
-  CARD8 pad0;
+  CARD8 viewOnly;
   CARD16 pad1 B16;
 } xVncExtConnectReq;
 #define sz_xVncExtConnectReq 8

--- a/unix/vncconfig/vncconfig.cxx
+++ b/unix/vncconfig/vncconfig.cxx
@@ -177,8 +177,8 @@ static void usage()
 {
   fprintf(stderr,"usage: %s [parameters]\n",
           programName);
-  fprintf(stderr,"       %s [parameters] -connect <host>[:<port>]\n",
-          programName);
+  fprintf(stderr,"       %s [parameters] -connect "
+          "[-viewOnly|-view-only] <host>[:<port>]\n", programName);
   fprintf(stderr,"       %s [parameters] -disconnect\n", programName);
   fprintf(stderr,"       %s [parameters] [-set] <Xvnc-param>=<value> ...\n",
           programName);
@@ -240,13 +240,19 @@ int main(int argc, char** argv)
   if (i < argc) {
     for (; i < argc; i++) {
       if (strcmp(argv[i], "-connect") == 0) {
+        Bool viewOnly = False;
         i++;
+        if (strcmp(argv[i], "-viewOnly") == 0 ||
+            strcmp(argv[i], "-view-only") == 0) {
+          viewOnly = True;
+          i++;
+        }
         if (i >= argc) usage();
-        if (!XVncExtConnect(dpy, argv[i])) {
+        if (!XVncExtConnect(dpy, argv[i], viewOnly)) {
           fprintf(stderr,"connecting to %s failed\n",argv[i]);
         }
       } else if (strcmp(argv[i], "-disconnect") == 0) {
-        if (!XVncExtConnect(dpy, "")) {
+        if (!XVncExtConnect(dpy, "", False)) {
           fprintf(stderr,"disconnecting all clients failed\n");
         }
       } else if (strcmp(argv[i], "-get") == 0) {

--- a/unix/vncconfig/vncconfig.man
+++ b/unix/vncconfig/vncconfig.man
@@ -7,7 +7,7 @@ vncconfig \- configure and control a VNC server
 .br
 .B vncconfig
 .RI [ parameters ] 
-.B \-connect
+.B \-connect \fP[\fB-viewOnly\fP|\fB-view-only\fP]
 .IR host [: port ]
 .br
 .B vncconfig
@@ -55,12 +55,13 @@ is no VNC extension.
 
 .SH OPTIONS
 .TP
-.B \-connect \fIhost\fP[:\fIport\fP]
+.B \-connect \fP[\fB-viewOnly\fP|\fB-view-only\fP] \fIhost\fP[:\fIport\fP]
 Tells an Xvnc server to make a "reverse" connection to a listening VNC viewer
 (normally connections are made the other way round - the viewer connects to the
 server). \fIhost\fP is the host where the listening viewer is running. If it's
 not listening on the default port of 5500, you can specify \fIhost:port\fP
-instead.
+instead. The \fB-viewOnly\fP (or \fB-view-Only\fP) option specifies that
+the server must ignore all keyboard or mouse events sent by the client.
 .
 .TP
 .B \-disconnect

--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -402,10 +402,10 @@ void XserverDesktop::blockHandler(int* timeout)
   }
 }
 
-void XserverDesktop::addClient(Socket* sock, bool reverse)
+void XserverDesktop::addClient(Socket* sock, bool reverse, bool viewOnly)
 {
   vlog.debug("new client, sock %d reverse %d",sock->getFd(),reverse);
-  server->addSocket(sock, reverse);
+  server->addSocket(sock, reverse, viewOnly);
   vncSetNotifyFd(sock->getFd(), screenIndex, true, false);
 }
 

--- a/unix/xserver/hw/vnc/XserverDesktop.h
+++ b/unix/xserver/hw/vnc/XserverDesktop.h
@@ -72,7 +72,7 @@ public:
   void add_copied(const rfb::Region &dest, const rfb::Point &delta);
   void handleSocketEvent(int fd, bool read, bool write);
   void blockHandler(int* timeout);
-  void addClient(network::Socket* sock, bool reverse);
+  void addClient(network::Socket* sock, bool reverse, bool viewOnly);
   void disconnectClients();
 
   // QueryConnect methods called from X server code

--- a/unix/xserver/hw/vnc/vncExt.c
+++ b/unix/xserver/hw/vnc/vncExt.c
@@ -348,7 +348,7 @@ static int ProcVncExtConnect(ClientPtr client)
   address[stuff->strLen] = 0;
 
   rep.success = 0;
-  if (vncConnectClient(address) == 0)
+  if (vncConnectClient(address, (int)stuff->viewOnly) == 0)
         rep.success = 1;
 
   rep.type = X_Reply;

--- a/unix/xserver/hw/vnc/vncExtInit.cc
+++ b/unix/xserver/hw/vnc/vncExtInit.cc
@@ -267,7 +267,7 @@ void vncExtensionInit(void)
 
         if (scr == 0 && vncInetdSock != -1 && listeners.empty()) {
           network::Socket* sock = new network::TcpSocket(vncInetdSock);
-          desktop[scr]->addClient(sock, false);
+          desktop[scr]->addClient(sock, false, false);
           vlog.info("added inetd sock");
         }
       }
@@ -343,7 +343,7 @@ void vncSendClipboardData(const char* data)
     desktop[scr]->sendClipboardData(data);
 }
 
-int vncConnectClient(const char *addr)
+int vncConnectClient(const char *addr, int viewOnly)
 {
   if (strlen(addr) == 0) {
     try {
@@ -362,7 +362,9 @@ int vncConnectClient(const char *addr)
 
   try {
     network::Socket* sock = new network::TcpSocket(host.c_str(), port);
-    desktop[0]->addClient(sock, true);
+    vlog.info("Reverse connection: %s:%d%s", host.c_str(), port,
+              viewOnly ? " (view only)" : "");
+    desktop[0]->addClient(sock, true, (bool)viewOnly);
   } catch (rdr::Exception& e) {
     vlog.error("Reverse connection: %s",e.str());
     return -1;

--- a/unix/xserver/hw/vnc/vncExtInit.h
+++ b/unix/xserver/hw/vnc/vncExtInit.h
@@ -57,7 +57,7 @@ void vncRequestClipboard(void);
 void vncAnnounceClipboard(int available);
 void vncSendClipboardData(const char* data);
 
-int vncConnectClient(const char *addr);
+int vncConnectClient(const char *addr, int viewOnly);
 
 void vncGetQueryConnect(uint32_t *opaqueId, const char**username,
                         const char **address, int *timeout);

--- a/win/vncconfig/Authentication.h
+++ b/win/vncconfig/Authentication.h
@@ -44,7 +44,7 @@ namespace rfb {
     public:
       SecPage(const RegKey& rk)
         : SecurityPage(NULL), regKey(rk) {
-        security = new SecurityServer();
+        security = new SecurityServer(false);
       }
 
       void initDialog() {


### PR DESCRIPTION
This is an alternative implementation of https://github.com/TigerVNC/tigervnc/pull/1670.Quite frankly I don't like it, since it's too intrusive and affects all SSecurity subclasses.