### PR TITLE
Update building instructions

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -137,20 +137,17 @@ that the viewer has already been built, per above.)
   > ./configure --with-pic --without-dtrace --disable-static --disable-dri \
       --disable-xinerama --disable-xvfb --disable-xnest --disable-xorg \
       --disable-dmx --disable-xwin --disable-xephyr --disable-kdrive \
-      --disable-config-dbus --disable-config-hal --disable-config-udev \
-      --disable-dri2 --enable-install-libxf86config --enable-glx \
+      --disable-config-hal --disable-config-udev --disable-dri2 --enable-glx \
       --with-default-font-path="catalogue:/etc/X11/fontpath.d,built-ins" \
-      --with-fontdir=/usr/share/X11/fonts \
       --with-xkb-path=/usr/share/X11/xkb \
       --with-xkb-output=/var/lib/xkb \
       --with-xkb-bin-directory=/usr/bin \
-      --with-serverconfig-path=/usr/lib[64]/xorg \
-      --with-dri-driver-path=/usr/lib[64]/dri \
+      --with-serverconfig-path=/usr/lib64/xorg \
       {additional configure options}
     (NOTE: This is merely an example that works with Red Hat Enterprise/CentOS
-    6 and recent Fedora releases.  You should customize it for your particular
-    system.  In particular, it will be necessary to customize the font, XKB,
-    and DRI directories.)
+    9 and recent Fedora releases.  You should customize it for your particular
+    system.  In particular, it will be necessary to customize the XKB
+    directory.)
 
     For a regular, in-tree build:
   > make TIGERVNC_SRCDIR={source_directory}

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -9,6 +9,8 @@ Build Requirements (All Systems)
 
 -- CMake (http://www.cmake.org) v3.10 or later
 
+-- gcc
+
 -- zlib
 
 -- pixman
@@ -36,12 +38,13 @@ Build Requirements (Unix)
 =========================
 
 -- Non-Mac platforms:
-   * X11 development kit
+   * Development kits for all standard X11 libraries
    * PAM
 
 -- If building Xvnc/libvnc.so:
    * Xorg server source code, 1.16 or later
    * All build requirements Xorg imposes (see its documentation)
+   * patch
 
 -- Optional ffmpeg support (libav)
 

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -119,7 +119,6 @@ that the viewer has already been built, per above.)
   > cd {build_directory}
 
     If performing an out-of-tree build:
-  > mkdir unix
   > cp -R {source_directory}/unix/xserver unix/
 
   > cp -R {xorg_source}/* unix/xserver/

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -11,6 +11,8 @@ Build Requirements (All Systems)
 
 -- gcc
 
+Development kits for the following packages:
+
 -- zlib
 
 -- pixman
@@ -46,7 +48,9 @@ Build Requirements (Unix)
    * All build requirements Xorg imposes (see its documentation)
    * patch
 
--- Optional ffmpeg support (libav)
+-- Optional ffmpeg development kit support (libav)
+   * You might have to enable additional repositories for this. E.g.,
+     on RHEL, EPEL and RPMFusion (free + nonfree) need to be enabled.
 
 ============================
 Build Requirements (Windows)


### PR DESCRIPTION
When building the viewer and server on RHEL 9 we noted some requirements were missing. Also clarified some package details where needed.