### PR TITLE
x0vncserver: Add support for systemd socket activation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,9 @@ if(UNIX AND NOT APPLE)
   endif()
 endif()
 
+# check for systemd support (socket activation)
+pkg_check_modules(LIBSYSTEMD libsystemd)
+
 # Generate config.h and make sure the source finds it
 configure_file(config.h.in config.h)
 add_definitions(-DHAVE_CONFIG_H)

--- a/unix/x0vncserver/CMakeLists.txt
+++ b/unix/x0vncserver/CMakeLists.txt
@@ -21,6 +21,12 @@ target_include_directories(x0vncserver PUBLIC ${CMAKE_SOURCE_DIR}/unix)
 target_include_directories(x0vncserver PUBLIC ${CMAKE_SOURCE_DIR}/common)
 target_link_libraries(x0vncserver tx rfb network rdr unixcommon)
 
+# systemd support (socket activation)
+if (LIBSYSTEMD_FOUND)
+  add_definitions(-DHAVE_SYSTEMD_H)
+  target_link_libraries(x0vncserver ${LIBSYSTEMD_LIBRARIES})
+endif()
+
 if(X11_FOUND AND X11_XTest_LIB)
   add_definitions(-DHAVE_XTEST)
   target_link_libraries(x0vncserver ${X11_XTest_LIB})

--- a/unix/x0vncserver/x0vncserver.man
+++ b/unix/x0vncserver/x0vncserver.man
@@ -61,7 +61,7 @@ DISPLAY environment variable.
 Specifies the TCP port on which x0vncserver listens for connections from
 viewers (the protocol used in VNC is called RFB - "remote framebuffer").
 The default port is 5900. Specify \fB-1\fP to disable listening on a TCP
-port.
+port. Ignored when activated by a systemd socket.
 .
 .TP
 .B \-UseIPv4
@@ -74,7 +74,7 @@ Use IPv6 for incoming and outgoing connections. Default is on.
 .TP
 .B \-rfbunixpath \fIpath\fP
 Specifies the path of a Unix domain socket on which x0vncserver listens for
-connections from viewers.
+connections from viewers. Ignored when activated by a systemd socket.
 .
 .TP
 .B \-rfbunixmode \fImode\fP


### PR DESCRIPTION
systemd can pass in sockets as file descriptors 3 and beyond. Allows the server to use socket activation.