### PR TITLE
VNCSConnectionST: Release mouse button(s) on close

### DIFF
--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -82,6 +82,9 @@ VNCSConnectionST::~VNCSConnectionST()
     vlog.info("closing %s: %s", peerEndpoint.c_str(),
               closeReason.c_str());
 
+  // Release any mouse buttons
+  server->pointerEvent(this, server->getCursorPos(), 0);
+
   // Release any keys the client still had pressed
   while (!pressedKeys.empty()) {
     uint32_t keysym, keycode;


### PR DESCRIPTION
When the connection is severed, release all mouse buttons.

This fixes an issue with x0vncserver where the local display would stop responding to mouse events if the connection closes while the remote user was holding down a mouse button.

To reproduce, start a VNC client, press and hold a mouse button and then kill the connection (e.g. close client, kill server, yank network cable). This caused the local screen to no longer respond to any mouse-down events until a VNC client reconnects and clicks anywhere.

This may inject a "mouse release" event while closing, however, if you click on your screen and then yank the mouse cable, a mouse release event also would not come unexpectedly, so the cure's side effects aren't as bad as the disease.