### PR TITLE
VNCServerST: Add a timeout to pointer button ownership

### DIFF
--- a/common/rfb/VNCServerST.h
+++ b/common/rfb/VNCServerST.h
@@ -191,6 +191,8 @@ namespace rfb {
     std::list<VNCSConnectionST*> clipboardRequestors;
     std::list<network::Socket*> closingSockets;
 
+    time_t pointerClientTime;
+
     ComparingUpdateTracker* comparer;
 
     Point cursorPos;


### PR DESCRIPTION
When one clients holds down a button on the pointer device (probably dragging something), other clients' attempts at pointer operations are denied. This yields a sane user experience, but with limits.

When one clients starts dragging, and then his network connection fails, other clients are denied access to the pointer until the VNC server finally discovers that the connection is dead and closes it. This can take about 15 minutes.

Add a timeout to this policy: If we don't hear from the client for 3 seconds, other clients are allowed to control the pointer once more.

This solves the problem that one failing network could make the server completely deaf to other clients for a long time.