### PR TITLE
Fix shared memory leak

### DIFF
--- a/unix/x0vncserver/Image.cxx
+++ b/unix/x0vncserver/Image.cxx
@@ -312,8 +312,8 @@ void ShmImage::Init(int width, int height, const XVisualInfo *vinfo)
 
 ShmImage::~ShmImage()
 {
-  // FIXME: Destroy image as described in MIT-SHM documentation.
   if (shminfo != NULL) {
+    XShmDetach(dpy, shminfo);
     shmdt(shminfo->shmaddr);
     shmctl(shminfo->shmid, IPC_RMID, 0);
     delete shminfo;


### PR DESCRIPTION
The [MIT-SHM documentation](https://www.x.org/releases/X11R7.7/doc/xextproto/shm.html ) says to run XShmDetach() first, and then to destroy the segment.