### PR TITLE
Improve unknown keysym handling by reusing keycodes

### DIFF
--- a/unix/x0vncserver/XDesktop.h
+++ b/unix/x0vncserver/XDesktop.h
@@ -35,6 +35,12 @@
 class Geometry;
 class XPixelBuffer;
 
+struct AddedKeySym
+{
+  KeySym keysym;
+  KeyCode keycode;
+};
+
 // number of XKb indicator leds to handle
 #define XDESKTOP_N_LEDS 3
 
@@ -78,7 +84,7 @@ protected:
   bool haveXtest;
   bool haveDamage;
   int maxButtons;
-  std::map<KeySym, KeyCode> addedKeysyms;
+  std::list<AddedKeySym> addedKeysyms;
   std::map<KeySym, KeyCode> pressedKeys;
   bool running;
 #ifdef HAVE_XDAMAGE
@@ -102,6 +108,7 @@ protected:
 protected:
 #ifdef HAVE_XTEST
   KeyCode XkbKeysymToKeycode(KeySym keysym);
+  KeyCode getReusableKeycode(XkbDescPtr xkb);
   KeyCode addKeysym(KeySym keysym);
   void deleteAddedKeysyms();
   KeyCode keysymToKeycode(KeySym keysym);

--- a/unix/xserver/hw/vnc/vncInput.c
+++ b/unix/xserver/hw/vnc/vncInput.c
@@ -612,6 +612,9 @@ static void vncKeysymKeyboardEvent(KeySym keysym, int down)
 	/* Now press the actual key */
 	pressKey(vncKeyboardDev, keycode, TRUE, "keycode");
 
+	if(down)
+		vncOnKeyUsed(keycode);
+
 	/* And store the mapping so that we can do a proper release later */
 	for (i = 0;i < 256;i++) {
 		if (i == keycode)

--- a/unix/xserver/hw/vnc/vncInput.h
+++ b/unix/xserver/hw/vnc/vncInput.h
@@ -55,6 +55,7 @@ KeyCode vncKeysymToKeycode(KeySym keysym, unsigned state, unsigned *new_state);
 int vncIsAffectedByNumLock(KeyCode keycode);
 
 KeyCode vncAddKeysym(KeySym keysym, unsigned state);
+void vncOnKeyUsed(KeyCode usedKeycode);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is still a work in progress, but I am kinda stuck on how to handle Xvnc. Atleast x0vncserver works correctly. As proposed in https://github.com/TigerVNC/tigervnc/issues/93#issuecomment-1472362126, when all free keys has been used, it will start reusing the oldest key assigned by TigerVNC.

For Xvnc, I have tried a few things:
- Tried to compile common source files as part of Xvnc. But internal xserver header files don't seem to be compatible with C++. This also complicates the build process even more as the common header file needs to know if it is being compiled with Xvnc or x0vncserver.
- Tried to separate server specific parts to something like `InputGlue.h`. This can work, but becomes very clunky.  Control flow will be Xvnc/x0vncserver => common code => glue code in Xvnc/x0vncserver => and back again.
- We could of course implement this separately in Xvnc & x0vncserver, without worrying too much about duplication. (I would still like to keep the custom key list in `common` to avoid having to implement a linked list in Xvnc.) 
 


Issue: #93 