### PR TITLE
Allow for alternative user config locations, deprecate `~/.vnc` in favour of XDGBDS paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.mo
 *.la
 *.lo
+*.class
+*.jar
 .deps
 .libs
 
@@ -10,3 +12,18 @@ CMakeCache.txt
 Makefile
 Makefile.in
 config.h
+
+*.xml
+*.man
+*.service
+cmake_install.cmake
+cmake_uninstall.cmake
+install_manifest.txt
+tests/unit/[a-z]*
+!tests/unit/[a-z]*\.
+
+timestamp
+vncserver
+!unix/vncserver
+vncsession
+vncsession-start

--- a/common/os/os.h
+++ b/common/os/os.h
@@ -23,15 +23,6 @@
 namespace os {
 
   /*
-   * Get VNC home directory ($HOME/.vnc or %APPDATA%/vnc/).
-   * If HOME environment variable is set then it is used.
-   * Otherwise home directory is obtained via getpwuid function.
-   *
-   * Returns NULL on failure.
-   */
-  const char* getvnchomedir();
-
-  /*
    * Get user home directory.
    * If HOME environment variable is set then it is used.
    * Otherwise home directory is obtained via getpwuid function.
@@ -39,6 +30,37 @@ namespace os {
    * Returns NULL on failure.
    */
   const char* getuserhomedir();
+
+  /*
+   * Get VNC config directory. On Unix-like systems, this is either:
+   * - $XDG_CONFIG_HOME/tigervnc
+   * - $HOME/.config/tigervnc
+   * On Windows, this is simply %APPDATA%/vnc/.
+   *
+   * Returns NULL on failure.
+   */
+  const char* getvncconfigdir();
+
+  /*
+   * Get VNC state (logs) directory. On Unix-like systems, this is either:
+   * - $XDG_STATE_HOME/tigervnc
+   * - $HOME/.local/state/tigervnc
+   * On Windows, this is simply %APPDATA%/vnc/.
+   *
+   * Returns NULL on failure.
+   */
+  const char* getvncstatedir();
+
+  /*
+   * Get legacy VNC home directory ($HOME/.vnc on Unix-likes).
+   * If HOME environment variable is set then it is used.
+   * Otherwise home directory is obtained via getpwuid function.
+   *
+   * Returns NULL on failure.
+   *
+   * Deprecated.
+   */
+  const char* getvnchomedir();
 
 }
 

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -58,27 +58,27 @@
 
 using namespace rfb;
 
-static const char* homedirfn(const char* fn);
+static const char* configdirfn(const char* fn);
 
 StringParameter CSecurityTLS::X509CA("X509CA", "X509 CA certificate",
-                                     homedirfn("x509_ca.pem"),
+                                     configdirfn("x509_ca.pem"),
                                      ConfViewer);
 StringParameter CSecurityTLS::X509CRL("X509CRL", "X509 CRL file",
-                                     homedirfn("x509_crl.pem"),
+                                     configdirfn("x509_crl.pem"),
                                      ConfViewer);
 
 static LogWriter vlog("TLS");
 
-static const char* homedirfn(const char* fn)
+static const char* configdirfn(const char* fn)
 {
   static char full_path[PATH_MAX];
-  const char* homedir;
+  const char* configdir;
 
-  homedir = os::getvnchomedir();
-  if (homedir == NULL)
+  configdir = os::getvncconfigdir();
+  if (configdir == NULL)
     return "";
 
-  snprintf(full_path, sizeof(full_path), "%s/%s", homedir, fn);
+  snprintf(full_path, sizeof(full_path), "%s/%s", configdir, fn);
 
   return full_path;
 }
@@ -308,7 +308,7 @@ void CSecurityTLS::checkSession()
   int err;
   bool hostname_match;
 
-  const char *homeDir;
+  const char *configDir;
   gnutls_datum_t info;
   size_t len;
 
@@ -385,14 +385,14 @@ void CSecurityTLS::checkSession()
 
   /* Certificate has some user overridable problems, so TOFU time */
 
-  homeDir = os::getvnchomedir();
-  if (homeDir == NULL) {
-    throw AuthFailureException("Could not obtain VNC home directory "
+  configDir = os::getvncconfigdir();
+  if (configDir == NULL) {
+    throw AuthFailureException("Could not obtain VNC config directory "
                                "path for known hosts storage");
   }
 
   std::string dbPath;
-  dbPath = (std::string)homeDir + "/x509_known_hosts";
+  dbPath = (std::string)configDir + "/x509_known_hosts";
 
   err = gnutls_verify_stored_pubkey(dbPath.c_str(), NULL,
                                     client->getServerName(), NULL,

--- a/unix/vncpasswd/vncpasswd.cxx
+++ b/unix/vncpasswd/vncpasswd.cxx
@@ -156,13 +156,13 @@ int main(int argc, char** argv)
   }
 
   if (fname[0] == '\0') {
-    const char *homeDir = os::getvnchomedir();
-    if (homeDir == NULL) {
-      fprintf(stderr, "Can't obtain VNC home directory\n");
+    const char *configDir = os::getvncconfigdir();
+    if (configDir == NULL) {
+      fprintf(stderr, "Can't obtain VNC config directory\n");
       exit(1);
     }
-    mkdir(homeDir, 0777);
-    snprintf(fname, sizeof(fname), "%s/passwd", homeDir);
+    mkdir(configDir, 0777);
+    snprintf(fname, sizeof(fname), "%s/passwd", configDir);
   }
 
   while (true) {

--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -35,7 +35,15 @@
 # your site
 #
 
+# Start with legacy ~/.vnc user dir
 $vncUserDir = "$ENV{HOME}/.vnc";
+if (stat($vncUserDir)) {
+  warn "~/.vnc is deprecated, please migrate to XDGBDS-compliant paths!";
+} else {
+  # Legacy path doesn't exist, start using new XDG-alike path
+  $vncUserDir = "$ENV{HOME}/.config/tigervnc";
+}
+
 $vncUserConfig = "$vncUserDir/config";
 
 $vncSystemConfigDir = "@CMAKE_INSTALL_FULL_SYSCONFDIR@/tigervnc";
@@ -111,8 +119,8 @@ $default_opts{pn} = undef;
 # Load user-overrideable system defaults
 LoadConfig($vncSystemConfigDefaultsFile);
 
-# Then the user's settings
-LoadConfig($vncUserConfig);
+# Then the user's settings (location overrideable by previous system defaults)
+LoadConfig($config{'userconfig'} || $vncUserConfig);
 
 # And then override anything set above if mandatory settings exist.
 # WARNING: "Mandatory" is used loosely here! As the man page says,

--- a/vncviewer/ServerDialog.cxx
+++ b/vncviewer/ServerDialog.cxx
@@ -315,12 +315,12 @@ void ServerDialog::loadServerHistory()
   return;
 #endif
 
-  const char* homeDir = os::getvnchomedir();
-  if (homeDir == NULL)
-    throw Exception(_("Could not obtain the home directory path"));
+  const char* stateDir = os::getvncstatedir();
+  if (stateDir == NULL)
+    throw Exception(_("Could not obtain the state directory path"));
 
   char filepath[PATH_MAX];
-  snprintf(filepath, sizeof(filepath), "%s/%s", homeDir, SERVER_HISTORY);
+  snprintf(filepath, sizeof(filepath), "%s/%s", stateDir, SERVER_HISTORY);
 
   /* Read server history from file */
   FILE* f = fopen(filepath, "r");
@@ -381,12 +381,12 @@ void ServerDialog::saveServerHistory()
   return;
 #endif
 
-  const char* homeDir = os::getvnchomedir();
-  if (homeDir == NULL)
-    throw Exception(_("Could not obtain the home directory path"));
+  const char* stateDir = os::getvncstatedir();
+  if (stateDir == NULL)
+    throw Exception(_("Could not obtain the state directory path"));
 
   char filepath[PATH_MAX];
-  snprintf(filepath, sizeof(filepath), "%s/%s", homeDir, SERVER_HISTORY);
+  snprintf(filepath, sizeof(filepath), "%s/%s", stateDir, SERVER_HISTORY);
 
   /* Write server history to file */
   FILE* f = fopen(filepath, "w+");

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -629,11 +629,11 @@ void saveViewerParameters(const char *filename, const char *servername) {
     return;
 #endif
     
-    const char* homeDir = os::getvnchomedir();
-    if (homeDir == NULL)
-      throw Exception(_("Could not obtain the home directory path"));
+    const char* configDir = os::getvncconfigdir();
+    if (configDir == NULL)
+      throw Exception(_("Could not obtain the config directory path"));
 
-    snprintf(filepath, sizeof(filepath), "%s/default.tigervnc", homeDir);
+    snprintf(filepath, sizeof(filepath), "%s/default.tigervnc", configDir);
   } else {
     snprintf(filepath, sizeof(filepath), "%s", filename);
   }
@@ -733,11 +733,11 @@ char* loadViewerParameters(const char *filename) {
     return loadFromReg();
 #endif
 
-    const char* homeDir = os::getvnchomedir();
-    if (homeDir == NULL)
-      throw Exception(_("Could not obtain the home directory path"));
+    const char* configDir = os::getvncconfigdir();
+    if (configDir == NULL)
+      throw Exception(_("Could not obtain the config directory path"));
 
-    snprintf(filepath, sizeof(filepath), "%s/default.tigervnc", homeDir);
+    snprintf(filepath, sizeof(filepath), "%s/default.tigervnc", configDir);
   } else {
     snprintf(filepath, sizeof(filepath), "%s", filename);
   }

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -429,17 +429,34 @@ static void init_fltk()
 #endif
 }
 
-static void mkvnchomedir()
+static int mkvncdir(const char *dir)
 {
-  // Create .vnc in the user's home directory if it doesn't already exist
-  const char* homeDir = os::getvnchomedir();
-  if (homeDir == NULL) {
-    vlog.error(_("Could not obtain the home directory path"));
-  } else {
-    int result = mkdir(homeDir, 0755);
-    if (result == -1 && errno != EEXIST)
-      vlog.error(_("Could not create VNC home directory: %s"), strerror(errno));
+  int result = mkdir(dir, 0755);
+  if (result == -1 && errno != EEXIST) {
+    vlog.error(_("Could not create VNC directory %s: %s"), dir, strerror(errno));
+    return result;
   }
+  return 0;
+}
+
+static void mkdirrecursive(const char *dir)
+{
+  char *path = strdup(dir);
+  char *p;
+
+  for (p = path + 1; *p; p++) {
+    if (*p == '/') {
+      *p = '\0';
+      if (mkvncdir(path) != 0) {
+        free(path);
+        return;
+      }
+      *p = '/';
+    }
+  }
+
+  mkvncdir(path);
+  free(path);
 }
 
 static void usage(const char *programName)
@@ -728,7 +745,14 @@ int main(int argc, char** argv)
 
   migrateDeprecatedOptions();
 
-  mkvnchomedir();
+#ifndef WIN32
+  // Check if config and state dirs are both the same legacy ~/.vnc dir
+  struct stat st;
+  if (stat(os::getvnchomedir(), &st) == 0)
+    vlog.info(_("~/.vnc is deprecated, please migrate to XDGBDS-compliant paths!"));
+#endif
+  mkdirrecursive(os::getvncconfigdir());
+  mkdirrecursive(os::getvncstatedir());
 
   CSecurity::upg = &dlg;
 #if defined(HAVE_GNUTLS) || defined(HAVE_NETTLE)


### PR DESCRIPTION
This PR aims to fix #1195 by allowing for alternative locations for different TigerVNC configuration files, both for the client and the server, primarily keeping the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) in mind. In cases where `~/.vnc` already exists, both the client and server will continue to use this path to store everything, while warning the user that this path is to be deprecated in favour of XDGBDS-compliant paths. Otherwise, TigerVNC will begin to use either `$XDG_CONFIG_HOME/tigervnc` for configuration and `$XDG_STATE_HOME/tigervnc` for history/logs.

At present, the following changes have been implemented:
- [x] VNC Viewer will initially save the `default.tigervnc` preferences file under the new _config_ directory.
- [x] VNC Viewer's history file will initially be saved under the new _state_ directory.
- [x] `vncpasswd` will generate password files under the new _config_ directory.
- [x] The `vncserver` script will for `vncserver-config-defaults` to specify an alternative `config` file location via the `userconfig` option. If this option is not provided, `vncserver` will read `~/.config/tigervnc/config`* by default.

The following have not yet been fully addressed:
- [ ] `vncsession` still writes log files to `~/.vnc`, forcing this directory to be created. Ideally, this location should instead be configurable somehow and default to a location such as `~/.local/state/tigervnc`.
- [ ] The Java version of VNC Viewer still currently uses the legacy path.
- [ ] Documentation has not yet been updated to reflect the new path changes.

---

*_Will require hard-coded paths as it is not possible for `vncserver` or `vncsession` to read environment variables for other processes such as the user's login shell._