### PR TITLE
Make SELinux PAM modules `optional`

### DIFF
--- a/unix/vncserver/tigervnc.pam
+++ b/unix/vncserver/tigervnc.pam
@@ -1,8 +1,8 @@
 #%PAM-1.0
 # pam_selinux.so close should be the first session rule
--session   required     pam_selinux.so close
+-session   optional     pam_selinux.so close
 session    required     pam_loginuid.so
--session   required     pam_selinux.so open
+-session   optional     pam_selinux.so open
 session    required     pam_namespace.so
 session    optional     pam_keyinit.so force revoke
 session    required     pam_limits.so


### PR DESCRIPTION
Currently, on Unix systems without SELinux enabled, `vncsession` will consistently fail and exit with status 71 due to the `pam_selinux.so` module being marked as `required`. To get around this, various distributions such as [Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/tigervnc/-/blob/main/remove-selinux.patch) (which doesn't officially support SELinux anyway) and its derivatives such as [Artix Linux](https://gitea.artixlinux.org/packages/tigervnc/src/branch/master/remove-selinux.patch) are forced to apply their own patch at build-time to completely remove the SELinux module from TigerVNC's PAM policy.

This PR eliminates the need for such a patch to be applied by distribution maintainers by simply marking the SELinux module as `optional`.