### PR TITLE
H264Decoder: Fix context reset

### DIFF
--- a/common/rfb/H264Decoder.cxx
+++ b/common/rfb/H264Decoder.cxx
@@ -131,7 +131,7 @@ void H264Decoder::decodeRect(const Rect& r, const uint8_t* buffer,
   if (!ctx->isReady())
     throw Exception("H264Decoder: Context is not ready");
 
-  if (flags & resetContext)
+  if (reset & resetContext)
     ctx->reset();
 
   if (!len)


### PR DESCRIPTION
This fixes a regression introduced by
12b3f4021641537b90727b23d42de5dff59006cd.