### PR TITLE
vncsession: use /bin/sh if the user shell is not set

### DIFF
--- a/unix/vncserver/vncsession.c
+++ b/unix/vncserver/vncsession.c
@@ -545,7 +545,7 @@ run_script(const char *username, const char *display, char **envp)
 
     // Set up some basic environment for the script
     setenv("HOME", pwent->pw_dir, 1);
-    setenv("SHELL", pwent->pw_shell, 1);
+    setenv("SHELL", *pwent->pw_shell != '\0' ? pwent->pw_shell : "/bin/sh", 1);
     setenv("LOGNAME", pwent->pw_name, 1);
     setenv("USER", pwent->pw_name, 1);
     setenv("USERNAME", pwent->pw_name, 1);


### PR DESCRIPTION
An empty shell field in the password file is valid, although not common. Use /bin/sh in this case, as documented in the passwd(5) man page, since the vncserver script requires a non-empty SHELL environment variable.

Fixes issue #1786.