### PR TITLE
Add option allowing to connect only the user owning the running session

### DIFF
--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -720,13 +720,6 @@ void VNCServerST::queryConnection(VNCSConnectionST* client,
     return;
   }
 
-  // - Are we configured to do queries?
-  if (!rfb::Server::queryConnect &&
-      !client->getSock()->requiresQuery()) {
-    approveConnection(client->getSock(), true, nullptr);
-    return;
-  }
-
   // - Does the client have the right to bypass the query?
   if (client->accessCheck(AccessNoQuery))
   {

--- a/unix/x0vncserver/XDesktop.cxx
+++ b/unix/x0vncserver/XDesktop.cxx
@@ -33,6 +33,7 @@
 #include <network/Socket.h>
 
 #include <rfb/ScreenSet.h>
+#include <rfb/ServerCore.h>
 
 #include <x0vncserver/XDesktop.h>
 
@@ -323,6 +324,13 @@ void XDesktop::queryConnection(network::Socket* sock,
                                const char* userName)
 {
   assert(isRunning());
+
+  // - Are we configured to do queries?
+  if (!rfb::Server::queryConnect &&
+      !sock->requiresQuery()) {
+    server->approveConnection(sock, true, nullptr);
+    return;
+  }
 
   // Someone already querying?
   if (queryConnectSock) {

--- a/unix/xserver/hw/vnc/XserverDesktop.h
+++ b/unix/xserver/hw/vnc/XserverDesktop.h
@@ -111,6 +111,13 @@ public:
   void grabRegion(const core::Region& r) override;
 
 protected:
+#ifdef HAVE_SYSTEMD_DAEMON
+  // - Check whether user is logged into a session
+  //   Returns true if user is already logged or there is no
+  //   user session at all.
+  bool checkUserLogged(const char* userName);
+#endif
+
   bool handleListenerEvent(int fd,
                            std::list<network::SocketListener*>* sockets,
                            rfb::VNCServer* sockserv);

--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -200,6 +200,13 @@ Never treat incoming connections as shared, regardless of the client-specified
 setting. Default is off.
 .
 .TP
+B \-ApproveLoggedUserOnly
+Approve only the user who is currently logged into the session.
+This is expected to be combined with "Plain" security type and with
+"PlainUsers=*" option allowing everyone to connect to the session.
+Default is off.
+.
+.TP
 .B \-pam_service \fIname\fP, \-PAMService \fIname\fP
 PAM service name to use when authentication users using any of the "Plain"
 security types. Default is \fBvnc\fP.


### PR DESCRIPTION
Checks, whether the user who is trying to authenticate is already logged into the running session in order to allow or reject the connection. This is expected to be used with 'plain' security type in combination with 'PlainUsers=*' option allowing everyone to connect to the session.