### PR TITLE
vncsession-start: Add place admin can drop in args

### DIFF
--- a/unix/vncserver/vncsession-start.in
+++ b/unix/vncserver/vncsession-start.in
@@ -19,11 +19,18 @@
 #
 
 USERSFILE="@CMAKE_INSTALL_FULL_SYSCONFDIR@/tigervnc/vncserver.users"
+SETTINGSFILE="@CMAKE_INSTALL_FULL_SYSCONFDIR@/tigervnc/vncsession"
 
 if [ $# -ne 1 ]; then
 	echo "Syntax:" >&2
 	echo "    $0 <display>" >&2
 	exit 1
+fi
+
+# Load any custom settings for execution
+VNCSESSIONARGS=''
+if [ -e "${SETTINGSFILE}" ]; then
+	source "${SETTINGSFILE}"
 fi
 
 if [ ! -f "${USERSFILE}" ]; then
@@ -40,4 +47,4 @@ if [ -z "${USER}" ]; then
 	exit 1
 fi
 
-exec "@CMAKE_INSTALL_FULL_SBINDIR@/vncsession" "${USER}" "${DISPLAY}"
+exec "@CMAKE_INSTALL_FULL_SBINDIR@/vncsession" ${VNCSESSIONARGS} "${USER}" "${DISPLAY}"


### PR DESCRIPTION
If the system service manager could benefit from calling `vncsession` with `-D`, then there should be an easy way to make it the default for folks.

In this way it is easy for people to quickly select what they would prefer.  They'll still need to set an override for `vncserver@.service` -> `Type=simple` if they want to use systemd, but this could be used to gather more information.