### PR TITLE
Include DLL when compiling installer in MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,8 @@ add_subdirectory(common)
 
 if(WIN32)
   add_subdirectory(win)
+  find_path(TEMP_PATH libunistring-5.dll)
+  set(WIN_DLL_PATH "${TEMP_PATH}" CACHE PATH "Path where Windows DLL files are located for installer.")
 else()
   # No interest in building x related parts on Apple
   if(NOT APPLE)

--- a/release/CMakeLists.txt
+++ b/release/CMakeLists.txt
@@ -13,6 +13,13 @@ if(CMAKE_SIZEOF_VOID_P MATCHES 8)
   set(INST_DEFS -DWIN64)
 endif()
 
+# Set BUILD_STATIC definition for Inno Setup
+if(BUILD_STATIC)
+  set(BUILD_STATIC_DEFINE "#define BUILD_STATIC_ENABLED")
+else()
+  set(BUILD_STATIC_DEFINE "")
+endif()
+
 configure_file(tigervnc.iss.in tigervnc.iss)
 
 add_custom_target(installer

--- a/release/tigervnc.iss.in
+++ b/release/tigervnc.iss.in
@@ -10,11 +10,33 @@ AppPublisherURL=https://tigervnc.org
 DefaultDirName={pf}\TigerVNC
 DefaultGroupName=TigerVNC
 LicenseFile=@CMAKE_SOURCE_DIR@\LICENCE.TXT
+@BUILD_STATIC_DEFINE@
 
 [Files]
 Source: "@CMAKE_BINARY_DIR@\vncviewer\vncviewer.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; 
 Source: "@CMAKE_SOURCE_DIR@\README.rst"; DestDir: "{app}"; Flags: ignoreversion
 Source: "@CMAKE_SOURCE_DIR@\LICENCE.TXT"; DestDir: "{app}"; Flags: ignoreversion
+Source: "@WIN_DLL_PATH@/libffi-8.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libiconv-2.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libintl-8.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libp11-kit-0.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libunistring-5.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+
+#ifndef BUILD_STATIC_ENABLED
+Source: "@WIN_DLL_PATH@/libfltk.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libgcc_s_seh-1.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libgmp-10.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libgnutls-30.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libhogweed-6.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libidn2-0.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libjpeg-8.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libnettle-8.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libpixman-1-0.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libstdc++-6.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libtasn1-6.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/libwinpthread-1.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+Source: "@WIN_DLL_PATH@/zlib1.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace;
+#endif
 
 #define LINGUAS
 #define Lang


### PR DESCRIPTION
When building in Windows using MSYS2, some DLLs were missing during the packaging of the installer. This modification will locate the relevant DLLs and package them together with the installer.