### PR TITLE
Fix typos

### DIFF
--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -71,7 +71,7 @@ faster to generate, thus improving the interactive feel.
 The viewer normally starts in full-color mode, but switches to
 low-color mode if the bandwidth is insufficient. However, this only
 occurs when communicating with servers supporting protocol 3.8 or
-newer, since many old servers does not support color mode changes
+newer, since many old servers do not support color mode changes
 safely.
 
 Automatic selection can be turned off by setting the
@@ -325,7 +325,7 @@ was launched. The environment variable \fIVNC_VIA_CMD\fR can override
 the default tunnel command of
 \fB/usr/bin/ssh\ -f\ -L\ "$L":"$H":"$R"\ "$G"\ sleep\ 20\fR.  The tunnel
 command is executed with the environment variables \fIL\fR, \fIH\fR,
-\fIR\fR, and \fIG\fR taken the values of the local port number, the remote
+\fIR\fR, and \fIG\fR taking the values of the local port number, the remote
 host, the port number on the remote host, and the gateway machine
 respectively.
 .


### PR DESCRIPTION
Thinking out loud, I would also rewrite this:

"taking the values of the local port number, the remote host, the port number on the remote host, and the gateway machine respectively."

Into:

"taking values of local port number, remote host, port number on the remote host, and gateway machine respectively."