### PR TITLE
CSecurityTLS: change the variable that x509 authentication CA and CRL file from global to local

### DIFF
--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -121,6 +121,13 @@ namespace rfb {
 
     // Methods to be overridden in a derived class
 
+    /*!
+     * \brief Get x509 authentication CA and CRL file, the file format is pem.
+     * \param ca: certificate authority, the file format is pem.
+     * \param crl: certificate revocation list, the file format is pem.
+     */
+    virtual int getX509File(std::string* ca, std::string* crl) = 0;
+
     // authSuccess() is called when authentication has succeeded.
     virtual void authSuccess();
 

--- a/common/rfb/CSecurityTLS.h
+++ b/common/rfb/CSecurityTLS.h
@@ -42,9 +42,6 @@ namespace rfb {
     int getType() const override { return anon ? secTypeTLSNone : secTypeX509None; }
     bool isSecure() const override { return !anon; }
 
-    static StringParameter X509CA;
-    static StringParameter X509CRL;
-
   protected:
     void shutdown();
     void freeResources();

--- a/tests/perf/decperf.cxx
+++ b/tests/perf/decperf.cxx
@@ -75,6 +75,7 @@ public:
   void setColourMapEntries(int, int, uint16_t*) override;
   void bell() override;
   void serverCutText(const char*) override;
+  virtual int getX509File(std::string *ca, std::string *crl) override;
 
 public:
   double cpuTime;
@@ -172,6 +173,11 @@ void CConn::bell()
 
 void CConn::serverCutText(const char*)
 {
+}
+
+int CConn::getX509File(std::string *, std::string *)
+{
+    return 0;
 }
 
 struct stats

--- a/tests/perf/encperf.cxx
+++ b/tests/perf/encperf.cxx
@@ -108,6 +108,7 @@ public:
   void setColourMapEntries(int, int, uint16_t*) override;
   void bell() override;
   void serverCutText(const char*) override;
+  virtual int getX509File(std::string *ca, std::string *crl) override;
 
 public:
   double decodeTime;
@@ -277,6 +278,11 @@ void CConn::bell()
 
 void CConn::serverCutText(const char*)
 {
+}
+
+int CConn::getX509File(std::string *, std::string *)
+{
+    return 0;
 }
 
 Manager::Manager(class rfb::SConnection *conn_) :

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -606,3 +606,10 @@ void CConn::handleUpdateTimeout(void *data)
 
   Fl::repeat_timeout(1.0, handleUpdateTimeout, data);
 }
+
+int CConn::getX509File(std::string *ca, std::string *crl)
+{
+    *ca = ::X509CA;
+    *crl = ::X509CRL;
+    return 0;
+}

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -45,6 +45,8 @@ public:
   static void socketEvent(FL_SOCKET fd, void *data);
 
   // CConnection callback methods
+  virtual int getX509File(std::string *ca, std::string *crl) override;
+
   void initDone() override;
 
   void setDesktopSize(int w, int h) override;

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -303,8 +303,8 @@ void OptionsDialog::loadOptions(void)
   }
 
 #ifdef HAVE_GNUTLS
-  caInput->value(CSecurityTLS::X509CA);
-  crlInput->value(CSecurityTLS::X509CRL);
+  caInput->value(::X509CA);
+  crlInput->value(::X509CRL);
 
   handleX509(encX509Checkbox, this);
 #endif
@@ -434,8 +434,8 @@ void OptionsDialog::storeOptions(void)
       security.EnableSecType(secTypeX509Plain);
   }
 
-  CSecurityTLS::X509CA.setParam(caInput->value());
-  CSecurityTLS::X509CRL.setParam(crlInput->value());
+  ::X509CA.setParam(caInput->value());
+  ::X509CRL.setParam(crlInput->value());
 #endif
 
 #ifdef HAVE_NETTLE

--- a/vncviewer/UserDialog.h
+++ b/vncviewer/UserDialog.h
@@ -30,7 +30,6 @@ public:
   ~UserDialog();
 
   // UserPasswdGetter callbacks
-
   void getUserPasswd(bool secure, std::string* user,
                      std::string* password) override;
 
@@ -43,6 +42,7 @@ public:
  private:
   std::string savedUsername;
   std::string savedPassword;
+
 };
 
 #endif

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -52,6 +52,7 @@ using namespace std;
 
 static LogWriter vlog("Parameters");
 
+static const char* configdirfn(const char* fn);
 
 IntParameter pointerEventInterval("PointerEventInterval",
                                   "Time in milliseconds to rate-limit"
@@ -75,6 +76,13 @@ BoolParameter reconnectOnError("ReconnectOnError",
 StringParameter passwordFile("PasswordFile",
                              "Password file for VNC authentication", "");
 AliasParameter passwd("passwd", "Alias for PasswordFile", &passwordFile);
+
+StringParameter X509CA("X509CA", "X509 CA certificate",
+                       configdirfn("x509_ca.pem"),
+                       ConfViewer);
+StringParameter X509CRL("X509CRL", "X509 CRL file",
+                        configdirfn("x509_crl.pem"),
+                        ConfViewer);
 
 BoolParameter autoSelect("AutoSelect",
                          "Auto select pixel format and encoding. "
@@ -175,8 +183,8 @@ static const char* IDENTIFIER_STRING = "TigerVNC Configuration file Version 1.0"
 static VoidParameter* parameterArray[] = {
   /* Security */
 #ifdef HAVE_GNUTLS
-  &CSecurityTLS::X509CA,
-  &CSecurityTLS::X509CRL,
+  &X509CA,
+  &X509CRL,
 #endif // HAVE_GNUTLS
   &SecurityClient::secTypes,
   /* Misc. */
@@ -220,6 +228,19 @@ static const struct EscapeMap {
 } replaceMap[] = { { '\n', 'n' },
                    { '\r', 'r' },
                    { '\\', '\\' } };
+
+static const char* configdirfn(const char* fn)
+{
+  static char full_path[PATH_MAX];
+  const char* configdir;
+
+  configdir = os::getvncconfigdir();
+  if (configdir == nullptr)
+    return "";
+
+  snprintf(full_path, sizeof(full_path), "%s/%s", configdir, fn);
+  return full_path;
+}
 
 static bool encodeValue(const char* val, char* dest, size_t destSize) {
 

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -37,6 +37,11 @@ extern rfb::BoolParameter dotWhenNoCursor;
 
 extern rfb::StringParameter passwordFile;
 
+#ifdef HAVE_GNUTLS
+extern rfb::StringParameter X509CA;
+extern rfb::StringParameter X509CRL;
+#endif
+
 extern rfb::BoolParameter autoSelect;
 extern rfb::BoolParameter fullColour;
 extern rfb::AliasParameter fullColourAlias;


### PR DESCRIPTION
CSecurityTLS: change the variable that x509 authentication CA and CRL file from global to local.
Use different CA files for multiple connections.
