### PR TITLE
vncviewer: add missing include for struct timeval

### DIFF
--- a/vncviewer/BaseTouchHandler.h
+++ b/vncviewer/BaseTouchHandler.h
@@ -22,6 +22,8 @@
 
 #include "GestureEvent.h"
 
+#include <sys/time.h>
+
 class BaseTouchHandler {
   public:
     virtual ~BaseTouchHandler();


### PR DESCRIPTION
The header file uses `struct timeval` but doesn't include the necessary header.
This breaks the build on NetBSD.