### PR TITLE
Add FIXME comment regarding macOS minimise fix

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -1316,6 +1316,8 @@ void Viewport::popupContextMenu()
     break;
   case ID_MINIMIZE:
 #ifdef __APPLE__
+    // FIXME: Workaround for not being able to minimize in fullscreen
+    // https://github.com/TigerVNC/tigervnc/pull/1813
     if (window()->fullscreen_active())
       window()->fullscreen_off();
 #endif


### PR DESCRIPTION
An issue with minimise not working when in fullscreen on macOS was workaround in Pull Request #1813. The underlaying issue is currently unknown.

macOS native fullscreen mode was looked into, but no clear answer was given. See #1813 for details.