### PR TITLE
Add support for forward and back mouse buttons

### DIFF
--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -835,6 +835,7 @@ void CConnection::updateEncodings()
   encodings.push_back(pseudoEncodingContinuousUpdates);
   encodings.push_back(pseudoEncodingFence);
   encodings.push_back(pseudoEncodingQEMUKeyEvent);
+  encodings.push_back(pseudoEncodingExtendedMouseButtons);
 
   if (Decoder::supported(preferredEncoding)) {
     encodings.push_back(preferredEncoding);

--- a/common/rfb/CMsgHandler.cxx
+++ b/common/rfb/CMsgHandler.cxx
@@ -75,6 +75,11 @@ void CMsgHandler::endOfContinuousUpdates()
   server.supportsContinuousUpdates = true;
 }
 
+void CMsgHandler::supportsExtendedMouseButtons()
+{
+  server.supportsExtendedMouseButtons = true;
+}
+
 void CMsgHandler::supportsQEMUKeyEvent()
 {
   server.supportsQEMUKeyEvent = true;

--- a/common/rfb/CMsgHandler.h
+++ b/common/rfb/CMsgHandler.h
@@ -57,6 +57,7 @@ namespace rfb {
     virtual void fence(uint32_t flags, unsigned len, const uint8_t data[]);
     virtual void endOfContinuousUpdates();
     virtual void supportsQEMUKeyEvent();
+    virtual void supportsExtendedMouseButtons();
     virtual void serverInit(int width, int height,
                             const PixelFormat& pf,
                             const char* name) = 0;

--- a/common/rfb/CMsgReader.cxx
+++ b/common/rfb/CMsgReader.cxx
@@ -202,6 +202,10 @@ bool CMsgReader::readMsg()
       handler->supportsQEMUKeyEvent();
       ret = true;
       break;
+    case pseudoEncodingExtendedMouseButtons:
+      handler->supportsExtendedMouseButtons();
+      ret = true;
+      break;
     default:
       ret = readRect(dataRect, rectEncoding);
       break;

--- a/common/rfb/CMsgWriter.cxx
+++ b/common/rfb/CMsgWriter.cxx
@@ -22,6 +22,7 @@
 #endif
 
 #include <stdio.h>
+#include <assert.h>
 
 #include <rdr/OutStream.h>
 #include <rdr/MemOutStream.h>
@@ -173,18 +174,47 @@ void CMsgWriter::writeKeyEvent(uint32_t keysym, uint32_t keycode, bool down)
 }
 
 
-void CMsgWriter::writePointerEvent(const Point& pos, uint8_t buttonMask)
+void CMsgWriter::writePointerEvent(const Point& pos, uint16_t buttonMask)
 {
   Point p(pos);
+  bool extendedMouseButtons;
+
   if (p.x < 0) p.x = 0;
   if (p.y < 0) p.y = 0;
   if (p.x >= server->width()) p.x = server->width() - 1;
   if (p.y >= server->height()) p.y = server->height() - 1;
 
+  /* The highest bit in buttonMask is never sent to the server */
+  assert(!(buttonMask & 0x8000));
+
+  /* Only send extended pointerEvent message when needed */
+  extendedMouseButtons = buttonMask & 0x7f80;
+
   startMsg(msgTypePointerEvent);
-  os->writeU8(buttonMask);
-  os->writeU16(p.x);
-  os->writeU16(p.y);
+  if (server->supportsExtendedMouseButtons && extendedMouseButtons) {
+    int higherBits;
+    int lowerBits;
+
+    higherBits = (buttonMask  >> 7) & 0xff;
+    assert(!(higherBits & 0xfc)); /* Bits 2-7 are reserved */
+
+    lowerBits = buttonMask & 0x7f;
+    lowerBits |= 0x80; /* Set marker bit to 1 */
+
+    os->writeU8(lowerBits);
+    os->writeU16(p.x);
+    os->writeU16(p.y);
+    os->writeU8(higherBits);
+  } else {
+    /* Marker bit must be set to 0, otherwise the server might confuse
+     * the marker bit with the highest bit in a normal PointerEvent
+     * message.
+    */
+    buttonMask &= 0x7f;
+    os->writeU8(buttonMask);
+    os->writeU16(p.x);
+    os->writeU16(p.y);
+  }
   endMsg();
 }
 

--- a/common/rfb/CMsgWriter.h
+++ b/common/rfb/CMsgWriter.h
@@ -54,7 +54,7 @@ namespace rfb {
     void writeFence(uint32_t flags, unsigned len, const uint8_t data[]);
 
     void writeKeyEvent(uint32_t keysym, uint32_t keycode, bool down);
-    void writePointerEvent(const Point& pos, uint8_t buttonMask);
+    void writePointerEvent(const Point& pos, uint16_t buttonMask);
 
     void writeClientCutText(const char* str);
 

--- a/common/rfb/ClientParams.cxx
+++ b/common/rfb/ClientParams.cxx
@@ -228,3 +228,10 @@ bool ClientParams::supportsContinuousUpdates() const
     return true;
   return false;
 }
+
+bool ClientParams::supportsExtendedMouseButtons() const
+{
+  if (supportsEncoding(pseudoEncodingExtendedMouseButtons))
+    return true;
+  return false;
+}

--- a/common/rfb/ClientParams.h
+++ b/common/rfb/ClientParams.h
@@ -101,6 +101,7 @@ namespace rfb {
     bool supportsLEDState() const;
     bool supportsFence() const;
     bool supportsContinuousUpdates() const;
+    bool supportsExtendedMouseButtons() const;
 
     int compressLevel;
     int qualityLevel;

--- a/common/rfb/SConnection.cxx
+++ b/common/rfb/SConnection.cxx
@@ -433,6 +433,11 @@ void SConnection::supportsQEMUKeyEvent()
   writer()->writeQEMUKeyEvent();
 }
 
+void SConnection::supportsExtendedMouseButtons()
+{
+  writer()->writeExtendedMouseButtonsSupport();
+}
+
 void SConnection::versionReceived()
 {
 }

--- a/common/rfb/SConnection.h
+++ b/common/rfb/SConnection.h
@@ -98,6 +98,8 @@ namespace rfb {
 
     void supportsQEMUKeyEvent() override;
 
+    virtual void supportsExtendedMouseButtons() override;
+
 
     // Methods to be overridden in a derived class
 

--- a/common/rfb/SDesktop.h
+++ b/common/rfb/SDesktop.h
@@ -98,7 +98,7 @@ namespace rfb {
     // pointerEvent() is called whenever a client sends an event that
     // the pointer moved, or a button was pressed or released.
     virtual void pointerEvent(const Point& /*pos*/,
-                              uint8_t /*buttonMask*/) {};
+                              uint16_t /*buttonMask*/) {};
 
     // handleClipboardRequest() is called whenever a client requests
     // the server to send over its clipboard data. It will only be

--- a/common/rfb/SMsgHandler.cxx
+++ b/common/rfb/SMsgHandler.cxx
@@ -53,12 +53,13 @@ void SMsgHandler::setPixelFormat(const PixelFormat& pf)
 void SMsgHandler::setEncodings(int nEncodings, const int32_t* encodings)
 {
   bool firstFence, firstContinuousUpdates, firstLEDState,
-       firstQEMUKeyEvent;
+       firstQEMUKeyEvent, firstExtMouseButtonsEvent;
 
   firstFence = !client.supportsFence();
   firstContinuousUpdates = !client.supportsContinuousUpdates();
   firstLEDState = !client.supportsLEDState();
   firstQEMUKeyEvent = !client.supportsEncoding(pseudoEncodingQEMUKeyEvent);
+  firstExtMouseButtonsEvent = !client.supportsEncoding(pseudoEncodingExtendedMouseButtons);
 
   client.setEncodings(nEncodings, encodings);
 
@@ -72,6 +73,8 @@ void SMsgHandler::setEncodings(int nEncodings, const int32_t* encodings)
     supportsLEDState();
   if (client.supportsEncoding(pseudoEncodingQEMUKeyEvent) && firstQEMUKeyEvent)
     supportsQEMUKeyEvent();
+  if (client.supportsEncoding(pseudoEncodingExtendedMouseButtons) && firstExtMouseButtonsEvent)
+    supportsExtendedMouseButtons();
 }
 
 void SMsgHandler::keyEvent(uint32_t /*keysym*/, uint32_t /*keycode*/,
@@ -80,7 +83,7 @@ void SMsgHandler::keyEvent(uint32_t /*keysym*/, uint32_t /*keycode*/,
 }
 
 void SMsgHandler::pointerEvent(const Point& /*pos*/,
-                               uint8_t /*buttonMask*/)
+                               uint16_t /*buttonMask*/)
 {
 }
 
@@ -165,5 +168,9 @@ void SMsgHandler::supportsLEDState()
 }
 
 void SMsgHandler::supportsQEMUKeyEvent()
+{
+}
+
+void SMsgHandler::supportsExtendedMouseButtons()
 {
 }

--- a/common/rfb/SMsgHandler.h
+++ b/common/rfb/SMsgHandler.h
@@ -57,7 +57,7 @@ namespace rfb {
     virtual void keyEvent(uint32_t keysym, uint32_t keycode,
                           bool down);
     virtual void pointerEvent(const Point& pos,
-                              uint8_t buttonMask);
+                              uint16_t buttonMask);
 
     virtual void clientCutText(const char* str);
 
@@ -97,6 +97,11 @@ namespace rfb {
     // client wants the QEMU Extended Key Event extension. The default
     // handler will send a pseudo-rect back, signalling server support.
     virtual void supportsQEMUKeyEvent();
+
+    // supportsExtendedMouseButtons() is called the first time we detect that the
+    // client supports sending 16 bit mouse button state. This lets us pass more button
+    // states between server and client.
+    virtual void supportsExtendedMouseButtons();
 
     ClientParams client;
   };

--- a/common/rfb/SMsgReader.cxx
+++ b/common/rfb/SMsgReader.cxx
@@ -272,11 +272,32 @@ bool SMsgReader::readKeyEvent()
 
 bool SMsgReader::readPointerEvent()
 {
+  int mask;
+  int x;
+  int y;
+
   if (!is->hasData(1 + 2 + 2))
     return false;
-  int mask = is->readU8();
-  int x = is->readU16();
-  int y = is->readU16();
+
+  is->setRestorePoint();
+
+  mask = is->readU8();
+  x = is->readU16();
+  y = is->readU16();
+
+  if (handler->client.supportsExtendedMouseButtons() && mask & 0x80 ) {
+    int highBits;
+    int lowBits;
+
+    if (!is->hasDataOrRestore(1))
+      return false;
+
+    highBits = is->readU8();
+    lowBits = mask & 0x7f; /* Clear marker bit */
+    mask = (highBits << 7) | lowBits;
+  }
+
+  is->clearRestorePoint();
   handler->pointerEvent(Point(x, y), mask);
   return true;
 }

--- a/common/rfb/SMsgWriter.h
+++ b/common/rfb/SMsgWriter.h
@@ -93,6 +93,9 @@ namespace rfb {
     // And QEMU keyboard event handshake
     void writeQEMUKeyEvent();
 
+    // let the client know we support extended mouse button support
+    void writeExtendedMouseButtonsSupport();
+
     // needFakeUpdate() returns true when an immediate update is needed in
     // order to flush out pseudo-rectangles to the client.
     bool needFakeUpdate();
@@ -148,6 +151,7 @@ namespace rfb {
     void writeSetVMwareCursorPositionRect(int hotspotX, int hotspotY);
     void writeLEDStateRect(uint8_t state);
     void writeQEMUKeyEventRect();
+    void writeExtendedMouseButtonsRect();
 
     ClientParams* client;
     rdr::OutStream* os;
@@ -160,6 +164,7 @@ namespace rfb {
     bool needCursorPos;
     bool needLEDState;
     bool needQEMUKeyEvent;
+    bool needExtMouseButtonsEvent;
 
     typedef struct {
       uint16_t reason, result;

--- a/common/rfb/ServerParams.cxx
+++ b/common/rfb/ServerParams.cxx
@@ -32,7 +32,7 @@ ServerParams::ServerParams()
   : majorVersion(0), minorVersion(0),
     supportsQEMUKeyEvent(false),
     supportsSetDesktopSize(false), supportsFence(false),
-    supportsContinuousUpdates(false),
+    supportsContinuousUpdates(false), supportsExtendedMouseButtons(false),
     width_(0), height_(0),
     ledState_(ledUnknown)
 {

--- a/common/rfb/ServerParams.h
+++ b/common/rfb/ServerParams.h
@@ -79,6 +79,7 @@ namespace rfb {
     bool supportsSetDesktopSize;
     bool supportsFence;
     bool supportsContinuousUpdates;
+    bool supportsExtendedMouseButtons;
 
   private:
 

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -477,7 +477,7 @@ void VNCSConnectionST::setPixelFormat(const PixelFormat& pf)
   setCursor();
 }
 
-void VNCSConnectionST::pointerEvent(const Point& pos, uint8_t buttonMask)
+void VNCSConnectionST::pointerEvent(const Point& pos, uint16_t buttonMask)
 {
   if (rfb::Server::idleTimeout)
     idleTimer.start(secsToMillis(rfb::Server::idleTimeout));

--- a/common/rfb/VNCSConnectionST.h
+++ b/common/rfb/VNCSConnectionST.h
@@ -123,7 +123,7 @@ namespace rfb {
     void queryConnection(const char* userName) override;
     void clientInit(bool shared) override;
     void setPixelFormat(const PixelFormat& pf) override;
-    void pointerEvent(const Point& pos, uint8_t buttonMask) override;
+    void pointerEvent(const Point& pos, uint16_t buttonMask) override;
     void keyEvent(uint32_t keysym, uint32_t keycode,
                   bool down) override;
     void framebufferUpdateRequest(const Rect& r,

--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -482,7 +482,7 @@ void VNCServerST::keyEvent(uint32_t keysym, uint32_t keycode, bool down)
 }
 
 void VNCServerST::pointerEvent(VNCSConnectionST* client,
-                               const Point& pos, uint8_t buttonMask)
+                               const Point& pos, uint16_t buttonMask)
 {
   time_t now = time(nullptr);
   if (rfb::Server::maxIdleTime)

--- a/common/rfb/VNCServerST.h
+++ b/common/rfb/VNCServerST.h
@@ -117,7 +117,7 @@ namespace rfb {
 
     // Event handlers
     void keyEvent(uint32_t keysym, uint32_t keycode, bool down);
-    void pointerEvent(VNCSConnectionST* client, const Point& pos, uint8_t buttonMask);
+    void pointerEvent(VNCSConnectionST* client, const Point& pos, uint16_t buttonMask);
 
     void handleClipboardRequest(VNCSConnectionST* client);
     void handleClipboardAnnounce(VNCSConnectionST* client, bool available);

--- a/common/rfb/encodings.h
+++ b/common/rfb/encodings.h
@@ -36,6 +36,7 @@ namespace rfb {
 
   const int pseudoEncodingXCursor = -240;
   const int pseudoEncodingCursor = -239;
+  const int pseudoEncodingExtendedMouseButtons = -316;
   const int pseudoEncodingDesktopSize = -223;
   const int pseudoEncodingLEDState = -261;
   const int pseudoEncodingExtendedDesktopSize = -308;

--- a/tests/unit/emulatemb.cxx
+++ b/tests/unit/emulatemb.cxx
@@ -42,14 +42,14 @@ rfb::BoolParameter emulateMiddleButton("dummy_name", "dummy_desc", true);
 class TestClass : public EmulateMB
 {
 public:
-  void sendPointerEvent(const rfb::Point& pos, uint8_t buttonMask) override;
+  void sendPointerEvent(const rfb::Point& pos, uint16_t buttonMask) override;
 
-  struct PointerEventParams {rfb::Point pos; uint8_t mask; };
+  struct PointerEventParams {rfb::Point pos; uint16_t mask; };
 
   std::vector<PointerEventParams> results;
 };
 
-void TestClass::sendPointerEvent(const rfb::Point& pos, uint8_t buttonMask)
+void TestClass::sendPointerEvent(const rfb::Point& pos, uint16_t buttonMask)
 {
   PointerEventParams params;
   params.pos = pos;

--- a/unix/x0vncserver/XDesktop.cxx
+++ b/unix/x0vncserver/XDesktop.cxx
@@ -242,9 +242,9 @@ void XDesktop::init(VNCServer* vs)
 void XDesktop::start()
 {
   // Determine actual number of buttons of the X pointer device.
-  unsigned char btnMap[8];
-  int numButtons = XGetPointerMapping(dpy, btnMap, 8);
-  maxButtons = (numButtons > 8) ? 8 : numButtons;
+  unsigned char btnMap[9];
+  int numButtons = XGetPointerMapping(dpy, btnMap, 9);
+  maxButtons = (numButtons > 9) ? 9 : numButtons;
   vlog.info("Enabling %d button%s of X pointer device",
             maxButtons, (maxButtons != 1) ? "s" : "");
 
@@ -342,7 +342,7 @@ void XDesktop::queryConnection(network::Socket* sock,
   queryConnectDialog->map();
 }
 
-void XDesktop::pointerEvent(const Point& pos, uint8_t buttonMask) {
+void XDesktop::pointerEvent(const Point& pos, uint16_t buttonMask) {
 #ifdef HAVE_XTEST
   if (!haveXtest) return;
   XTestFakeMotionEvent(dpy, DefaultScreen(dpy),

--- a/unix/x0vncserver/XDesktop.h
+++ b/unix/x0vncserver/XDesktop.h
@@ -60,7 +60,7 @@ public:
   bool isRunning();
   void queryConnection(network::Socket* sock,
                        const char* userName) override;
-  void pointerEvent(const rfb::Point& pos, uint8_t buttonMask) override;
+  void pointerEvent(const rfb::Point& pos, uint16_t buttonMask) override;
   void keyEvent(uint32_t keysym, uint32_t xtcode, bool down) override;
   unsigned int setScreenLayout(int fb_width, int fb_height,
                                const rfb::ScreenSet& layout) override;
@@ -79,7 +79,7 @@ protected:
   rfb::VNCServer* server;
   QueryConnectDialog* queryConnectDialog;
   network::Socket* queryConnectSock;
-  uint8_t oldButtonMask;
+  uint16_t oldButtonMask;
   bool haveXtest;
   bool haveDamage;
   int maxButtons;

--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -463,7 +463,7 @@ void XserverDesktop::terminate()
   kill(getpid(), SIGTERM);
 }
 
-void XserverDesktop::pointerEvent(const Point& pos, uint8_t buttonMask)
+void XserverDesktop::pointerEvent(const Point& pos, uint16_t buttonMask)
 {
   vncPointerMove(pos.x + vncGetScreenX(screenIndex),
                  pos.y + vncGetScreenY(screenIndex));

--- a/unix/xserver/hw/vnc/XserverDesktop.h
+++ b/unix/xserver/hw/vnc/XserverDesktop.h
@@ -95,7 +95,7 @@ public:
   void terminate() override;
   void queryConnection(network::Socket* sock,
                        const char* userName) override;
-  void pointerEvent(const rfb::Point& pos, uint8_t buttonMask) override;
+  void pointerEvent(const rfb::Point& pos, uint16_t buttonMask) override;
   void keyEvent(uint32_t keysym, uint32_t keycode, bool down) override;
   unsigned int setScreenLayout(int fb_width, int fb_height,
                                const rfb::ScreenSet& layout) override;

--- a/unix/xserver/hw/vnc/vncInput.c
+++ b/unix/xserver/hw/vnc/vncInput.c
@@ -50,7 +50,7 @@ extern const unsigned int code_map_qnum_to_xorgevdev_len;
 extern const unsigned short code_map_qnum_to_xorgkbd[];
 extern const unsigned int code_map_qnum_to_xorgkbd_len;
 
-#define BUTTONS 7
+#define BUTTONS 9
 
 DeviceIntPtr vncKeyboardDev;
 DeviceIntPtr vncPointerDev;
@@ -206,6 +206,23 @@ static int vncPointerProc(DeviceIntPtr pDevice, int onoff)
 		btn_labels[4] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_WHEEL_DOWN);
 		btn_labels[5] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_HWHEEL_LEFT);
 		btn_labels[6] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_HWHEEL_RIGHT);
+
+		/*
+		 * The labels BTN_LABEL_PROP_BTN_SIDE and BTN_LABEL_PROP_BTN_EXTRA
+		 * represent the side buttons on mice that are typically used to
+		 * navigate back/forward respectively in web browsers.
+		 *
+		 * In X11, these labels are mapped to the BTN_SIDE and BTN_EXTRA
+		 * input codes, which are mapped in the Linux HID driver. These
+		 * are not to be confused with the BTN_FORWARD and BTN_BACK input
+		 * codes, which some applications also use for back/forward
+		 * navigation.
+		 *
+		 * It seems like most mice have their side buttons mapped to
+		 * BTN_SIDE and BTN_EXTRA.
+		 */
+		btn_labels[7] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_SIDE);
+		btn_labels[8] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_EXTRA);
 
 		axes_labels[0] = XIGetKnownProperty(AXIS_LABEL_PROP_REL_X);
 		axes_labels[1] = XIGetKnownProperty(AXIS_LABEL_PROP_REL_Y);

--- a/vncviewer/EmulateMB.cxx
+++ b/vncviewer/EmulateMB.cxx
@@ -199,7 +199,7 @@ EmulateMB::EmulateMB()
 {
 }
 
-void EmulateMB::filterPointerEvent(const rfb::Point& pos, uint8_t buttonMask)
+void EmulateMB::filterPointerEvent(const rfb::Point& pos, uint16_t buttonMask)
 {
   int btstate;
   int action1, action2;
@@ -280,7 +280,7 @@ void EmulateMB::filterPointerEvent(const rfb::Point& pos, uint8_t buttonMask)
 void EmulateMB::handleTimeout(rfb::Timer *t)
 {
   int action1, action2;
-  uint8_t buttonMask;
+  uint16_t buttonMask;
 
   if (&timer != t)
     return;
@@ -312,7 +312,7 @@ void EmulateMB::handleTimeout(rfb::Timer *t)
   state = stateTab[state][4][2];
 }
 
-void EmulateMB::sendAction(const rfb::Point& pos, uint8_t buttonMask, int action)
+void EmulateMB::sendAction(const rfb::Point& pos, uint16_t buttonMask, int action)
 {
   assert(action != 0);
 
@@ -325,7 +325,7 @@ void EmulateMB::sendAction(const rfb::Point& pos, uint8_t buttonMask, int action
   sendPointerEvent(pos, buttonMask);
 }
 
-int EmulateMB::createButtonMask(uint8_t buttonMask)
+int EmulateMB::createButtonMask(uint16_t buttonMask)
 {
   // Unset left and right buttons in the mask
   buttonMask &= ~0x5;

--- a/vncviewer/EmulateMB.h
+++ b/vncviewer/EmulateMB.h
@@ -26,22 +26,22 @@ class EmulateMB : public rfb::Timer::Callback {
 public:
   EmulateMB();
 
-  void filterPointerEvent(const rfb::Point& pos, uint8_t buttonMask);
+  void filterPointerEvent(const rfb::Point& pos, uint16_t buttonMask);
 
 protected:
-  virtual void sendPointerEvent(const rfb::Point& pos, uint8_t buttonMask)=0;
+  virtual void sendPointerEvent(const rfb::Point& pos, uint16_t buttonMask)=0;
 
   void handleTimeout(rfb::Timer *t) override;
 
 private:
-  void sendAction(const rfb::Point& pos, uint8_t buttonMask, int action);
+  void sendAction(const rfb::Point& pos, uint16_t buttonMask, int action);
 
-  int createButtonMask(uint8_t buttonMask);
+  int createButtonMask(uint16_t buttonMask);
 
 private:
   int state;
-  uint8_t emulatedButtonMask;
-  uint8_t lastButtonMask;
+  uint16_t emulatedButtonMask;
+  uint16_t lastButtonMask;
   rfb::Point lastPos, origPos;
   rfb::Timer timer;
 };

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -600,22 +600,22 @@ int Viewport::handle(int event)
   case FL_MOUSEWHEEL:
     buttonMask = 0;
     if (Fl::event_button1())
-      buttonMask |= 1;
+      buttonMask |= 1 << 0;
     if (Fl::event_button2())
-      buttonMask |= 2;
+      buttonMask |= 1 << 1;
     if (Fl::event_button3())
-      buttonMask |= 4;
+      buttonMask |= 1 << 2;
 
     if (event == FL_MOUSEWHEEL) {
       wheelMask = 0;
       if (Fl::event_dy() < 0)
-        wheelMask |= 8;
+        wheelMask |= 1 << 3;
       if (Fl::event_dy() > 0)
-        wheelMask |= 16;
+        wheelMask |= 1 << 4;
       if (Fl::event_dx() < 0)
-        wheelMask |= 32;
+        wheelMask |= 1 << 5;
       if (Fl::event_dx() > 0)
-        wheelMask |= 64;
+        wheelMask |= 1 << 6;
 
       // A quick press of the wheel "button", followed by a immediate
       // release below

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -606,6 +606,20 @@ int Viewport::handle(int event)
     if (Fl::event_button3())
       buttonMask |= 1 << 2;
 
+  // The back/forward buttons are not supported by FTLK 1.3 and require
+  // a patch which adds these buttons to the FLTK API. These buttons
+  // will be part of the upcoming 1.4 API:
+  //   * https://github.com/fltk/fltk/pull/1081
+  //
+  // A backport for branch-1.3 is available here:
+  //   * https://github.com/fltk/fltk/pull/1083
+#if defined(FL_BUTTON4) && defined(FL_BUTTON5)
+    if (Fl::event_button4())
+      buttonMask |= 1 << 7;
+    if (Fl::event_button5())
+      buttonMask |= 1 << 8;
+#endif
+
     if (event == FL_MOUSEWHEEL) {
       wheelMask = 0;
       if (Fl::event_dy() < 0)
@@ -660,7 +674,7 @@ int Viewport::handle(int event)
   return Fl_Widget::handle(event);
 }
 
-void Viewport::sendPointerEvent(const rfb::Point& pos, uint8_t buttonMask)
+void Viewport::sendPointerEvent(const rfb::Point& pos, uint16_t buttonMask)
 {
   if (viewOnly)
       return;
@@ -790,7 +804,7 @@ void Viewport::flushPendingClipboard()
 }
 
 
-void Viewport::handlePointerEvent(const rfb::Point& pos, uint8_t buttonMask)
+void Viewport::handlePointerEvent(const rfb::Point& pos, uint16_t buttonMask)
 {
   filterPointerEvent(pos, buttonMask);
 }
@@ -937,6 +951,8 @@ int Viewport::handleSystemEvent(void *event, void *data)
       (msg->message == WM_RBUTTONUP) ||
       (msg->message == WM_MBUTTONDOWN) ||
       (msg->message == WM_MBUTTONUP) ||
+      (msg->message == WM_XBUTTONDOWN) ||
+      (msg->message == WM_XBUTTONUP) ||
       (msg->message == WM_MOUSEWHEEL) ||
       (msg->message == WM_MOUSEHWHEEL)) {
     // We can't get a mouse event in the middle of an AltGr sequence, so

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -70,7 +70,7 @@ public:
   int handle(int event) override;
 
 protected:
-  void sendPointerEvent(const rfb::Point& pos, uint8_t buttonMask) override;
+  void sendPointerEvent(const rfb::Point& pos, uint16_t buttonMask) override;
 
 private:
   bool hasFocus();
@@ -81,7 +81,7 @@ private:
 
   void flushPendingClipboard();
 
-  void handlePointerEvent(const rfb::Point& pos, uint8_t buttonMask);
+  void handlePointerEvent(const rfb::Point& pos, uint16_t buttonMask);
   static void handlePointerTimeout(void *data);
 
   void resetKeyboard();
@@ -111,7 +111,7 @@ private:
   PlatformPixelBuffer* frameBuffer;
 
   rfb::Point lastPointerPos;
-  uint8_t lastButtonMask;
+  uint16_t lastButtonMask;
 
   typedef std::map<int, uint32_t> DownMap;
   DownMap downKeySym;

--- a/win/rfb_win32/SDisplay.cxx
+++ b/win/rfb_win32/SDisplay.cxx
@@ -312,7 +312,7 @@ void SDisplay::handleClipboardData(const char* data) {
 }
 
 
-void SDisplay::pointerEvent(const Point& pos, uint8_t buttonmask) {
+void SDisplay::pointerEvent(const Point& pos, uint16_t buttonmask) {
   if (pb->getRect().contains(pos)) {
     Point screenPos = pos.translate(screenRect.tl);
     // - Check that the SDesktop doesn't need restarting

--- a/win/rfb_win32/SDisplay.h
+++ b/win/rfb_win32/SDisplay.h
@@ -80,7 +80,7 @@ namespace rfb {
       void handleClipboardRequest() override;
       void handleClipboardAnnounce(bool available) override;
       void handleClipboardData(const char* data) override;
-      void pointerEvent(const Point& pos, uint8_t buttonmask) override;
+      void pointerEvent(const Point& pos, uint16_t buttonmask) override;
       void keyEvent(uint32_t keysym, uint32_t keycode, bool down) override;
 
       // -=- Clipboard events

--- a/win/rfb_win32/SInput.cxx
+++ b/win/rfb_win32/SInput.cxx
@@ -65,7 +65,7 @@ win32::SPointer::SPointer()
 }
 
 void
-win32::SPointer::pointerEvent(const Point& pos, uint8_t buttonmask)
+win32::SPointer::pointerEvent(const Point& pos, uint16_t buttonmask)
 {
   // - We are specifying absolute coordinates
   DWORD flags = MOUSEEVENTF_ABSOLUTE;

--- a/win/rfb_win32/SInput.h
+++ b/win/rfb_win32/SInput.h
@@ -44,10 +44,10 @@ namespace rfb {
       // - Create a pointer event at a the given coordinates, with the
       //   specified button state.  The event must be specified using
       //   Screen coordinates.
-      void pointerEvent(const Point& pos, uint8_t buttonmask);
+      void pointerEvent(const Point& pos, uint16_t buttonmask);
     protected:
       Point last_position;
-      uint8_t last_buttonmask;
+      uint16_t last_buttonmask;
     };
 
     // -=- Keyboard event handling


### PR DESCRIPTION
This is a continuation of the work initially done by [manny33](https://github.com/manny33) in #1711:
* https://github.com/TigerVNC/tigervnc/pull/1711

This PR intends to add support for forward and back mouse buttons by extending RFB with the pseudo-encoding `ExtendedMouseButtons`, which is IANA registered and has an open draft PR on rfbproto:
* https://github.com/rfbproto/rfbproto/pull/57

In its current state, this PR has a working implementation that works on Windows, Mac and Linux (with some issues that are being worked on).

I'm quite content with the RFB implementation on the VNC side, but the client-side implementation in [Viewport.cxx](https://github.com/TigerVNC/tigervnc/blob/master/vncviewer/Viewport.cxx) is currently being re-written quite extensively so that **all** mouse events are handled with native code instead of using a combination of FLTK and native code.

This is still a work in progress, and commits will be cleaned up / rebased.