### PR TITLE
Split SystemException to handle Windows

### DIFF
--- a/common/network/Socket.cxx
+++ b/common/network/Socket.cxx
@@ -53,7 +53,7 @@ void network::initSockets() {
   WSADATA initResult;
   
   if (WSAStartup(requiredVersion, &initResult) != 0)
-    throw SocketException("unable to initialise Winsock2", errorNumber);
+    throw rdr::SocketException("unable to initialise Winsock2", errorNumber);
 #else
   signal(SIGPIPE, SIG_IGN);
 #endif
@@ -161,7 +161,7 @@ Socket* SocketListener::accept() {
 
   // Accept an incoming connection
   if ((new_sock = ::accept(fd, nullptr, nullptr)) < 0)
-    throw SocketException("unable to accept new connection", errorNumber);
+    throw rdr::SocketException("unable to accept new connection", errorNumber);
 
   // Create the socket object & check connection is allowed
   Socket* s = createSocket(new_sock);
@@ -179,7 +179,7 @@ void SocketListener::listen(int sock)
   if (::listen(sock, 5) < 0) {
     int e = errorNumber;
     closesocket(sock);
-    throw SocketException("unable to set socket to listening mode", e);
+    throw rdr::SocketException("unable to set socket to listening mode", e);
   }
 
   fd = sock;

--- a/common/network/Socket.h
+++ b/common/network/Socket.h
@@ -26,7 +26,6 @@
 #include <limits.h>
 #include <rdr/FdInStream.h>
 #include <rdr/FdOutStream.h>
-#include <rdr/Exception.h>
 
 namespace network {
 
@@ -105,10 +104,6 @@ namespace network {
   protected:
     int fd;
     ConnectionFilter* filter;
-  };
-
-  struct SocketException : public rdr::SystemException {
-    SocketException(const char* text, int err_) : rdr::SystemException(text, err_) {}
   };
 
 }

--- a/common/os/Mutex.cxx
+++ b/common/os/Mutex.cxx
@@ -43,7 +43,7 @@ Mutex::Mutex()
   systemMutex = new pthread_mutex_t;
   ret = pthread_mutex_init((pthread_mutex_t*)systemMutex, nullptr);
   if (ret != 0)
-    throw rdr::SystemException("Failed to create mutex", ret);
+    throw rdr::PosixException("Failed to create mutex", ret);
 #endif
 }
 
@@ -67,7 +67,7 @@ void Mutex::lock()
 
   ret = pthread_mutex_lock((pthread_mutex_t*)systemMutex);
   if (ret != 0)
-    throw rdr::SystemException("Failed to lock mutex", ret);
+    throw rdr::PosixException("Failed to lock mutex", ret);
 #endif
 }
 
@@ -80,7 +80,7 @@ void Mutex::unlock()
 
   ret = pthread_mutex_unlock((pthread_mutex_t*)systemMutex);
   if (ret != 0)
-    throw rdr::SystemException("Failed to unlock mutex", ret);
+    throw rdr::PosixException("Failed to unlock mutex", ret);
 #endif
 }
 
@@ -97,7 +97,7 @@ Condition::Condition(Mutex* mutex_)
   systemCondition = new pthread_cond_t;
   ret = pthread_cond_init((pthread_cond_t*)systemCondition, nullptr);
   if (ret != 0)
-    throw rdr::SystemException("Failed to create condition variable", ret);
+    throw rdr::PosixException("Failed to create condition variable", ret);
 #endif
 }
 
@@ -120,14 +120,14 @@ void Condition::wait()
                                  (CRITICAL_SECTION*)mutex->systemMutex,
                                  INFINITE);
   if (!ret)
-    throw rdr::SystemException("Failed to wait on condition variable", GetLastError());
+    throw rdr::Win32Exception("Failed to wait on condition variable", GetLastError());
 #else
   int ret;
 
   ret = pthread_cond_wait((pthread_cond_t*)systemCondition,
                           (pthread_mutex_t*)mutex->systemMutex);
   if (ret != 0)
-    throw rdr::SystemException("Failed to wait on condition variable", ret);
+    throw rdr::PosixException("Failed to wait on condition variable", ret);
 #endif
 }
 
@@ -140,7 +140,7 @@ void Condition::signal()
 
   ret = pthread_cond_signal((pthread_cond_t*)systemCondition);
   if (ret != 0)
-    throw rdr::SystemException("Failed to signal condition variable", ret);
+    throw rdr::PosixException("Failed to signal condition variable", ret);
 #endif
 }
 
@@ -153,6 +153,6 @@ void Condition::broadcast()
 
   ret = pthread_cond_broadcast((pthread_cond_t*)systemCondition);
   if (ret != 0)
-    throw rdr::SystemException("Failed to broadcast condition variable", ret);
+    throw rdr::PosixException("Failed to broadcast condition variable", ret);
 #endif
 }

--- a/common/os/Thread.cxx
+++ b/common/os/Thread.cxx
@@ -66,7 +66,7 @@ void Thread::start()
 #ifdef WIN32
   *(HANDLE*)threadId = CreateThread(nullptr, 0, startRoutine, this, 0, nullptr);
   if (*(HANDLE*)threadId == nullptr)
-    throw rdr::SystemException("Failed to create thread", GetLastError());
+    throw rdr::Win32Exception("Failed to create thread", GetLastError());
 #else
   int ret;
   sigset_t all, old;
@@ -76,14 +76,14 @@ void Thread::start()
   sigfillset(&all);
   ret = pthread_sigmask(SIG_SETMASK, &all, &old);
   if (ret != 0)
-    throw rdr::SystemException("Failed to mask signals", ret);
+    throw rdr::PosixException("Failed to mask signals", ret);
 
   ret = pthread_create((pthread_t*)threadId, nullptr, startRoutine, this);
 
   pthread_sigmask(SIG_SETMASK, &old, nullptr);
 
   if (ret != 0)
-    throw rdr::SystemException("Failed to create thread", ret);
+    throw rdr::PosixException("Failed to create thread", ret);
 #endif
 
   running = true;
@@ -99,13 +99,13 @@ void Thread::wait()
 
   ret = WaitForSingleObject(*(HANDLE*)threadId, INFINITE);
   if (ret != WAIT_OBJECT_0)
-    throw rdr::SystemException("Failed to join thread", GetLastError());
+    throw rdr::Win32Exception("Failed to join thread", GetLastError());
 #else
   int ret;
 
   ret = pthread_join(*(pthread_t*)threadId, nullptr);
   if (ret != 0)
-    throw rdr::SystemException("Failed to join thread", ret);
+    throw rdr::PosixException("Failed to join thread", ret);
 #endif
 }
 

--- a/common/rdr/Exception.cxx
+++ b/common/rdr/Exception.cxx
@@ -76,11 +76,23 @@ GAIException::GAIException(const char* s, int err_)
   strncat(str_, ")", len-1-strlen(str_));
 }
 
-SystemException::SystemException(const char* s, int err_)
+PosixException::PosixException(const char* s, int err_)
   : Exception("%s", s), err(err_)
 {
   strncat(str_, ": ", len-1-strlen(str_));
-#ifdef _WIN32
+  strncat(str_, strerror(err), len-1-strlen(str_));
+  strncat(str_, " (", len-1-strlen(str_));
+  char buf[20];
+    sprintf(buf,"%d",err);
+  strncat(str_, buf, len-1-strlen(str_));
+  strncat(str_, ")", len-1-strlen(str_));
+}
+
+#ifdef WIN32
+Win32Exception::Win32Exception(const char* s, unsigned err_)
+  : Exception("%s", s), err(err_)
+{
+  strncat(str_, ": ", len-1-strlen(str_));
   wchar_t *currStr = new wchar_t[len-strlen(str_)];
   FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                  nullptr, err, 0, currStr, len-1-strlen(str_), nullptr);
@@ -92,18 +104,10 @@ SystemException::SystemException(const char* s, int err_)
   if ((l >= 2) && (str_[l-2] == '\r') && (str_[l-1] == '\n'))
       str_[l-2] = 0;
 
-#else
-  strncat(str_, strerror(err), len-1-strlen(str_));
-#endif
   strncat(str_, " (", len-1-strlen(str_));
   char buf[20];
-#ifdef WIN32
-  if (err < 0)
-    sprintf(buf, "%x", err);
-  else
-#endif
-    sprintf(buf,"%d",err);
+  sprintf(buf,"%d",err);
   strncat(str_, buf, len-1-strlen(str_));
   strncat(str_, ")", len-1-strlen(str_));
 }
-
+#endif

--- a/common/rdr/Exception.h
+++ b/common/rdr/Exception.h
@@ -32,14 +32,27 @@ namespace rdr {
     virtual const char* str() const { return str_; }
   };
 
-  struct SystemException : public Exception {
+  struct PosixException : public Exception {
     int err;
-    SystemException(const char* s, int err_);
+    PosixException(const char* s, int err_);
   };
 
-  struct SocketException : public SystemException {
-    SocketException(const char* text, int err_) : SystemException(text, err_) {}
+#ifdef WIN32
+  struct Win32Exception : public Exception {
+    unsigned err;
+    Win32Exception(const char* s, unsigned err_);
   };
+#endif
+
+#ifdef WIN32
+  struct SocketException : public Win32Exception {
+    SocketException(const char* text, unsigned err_) : Win32Exception(text, err_) {}
+  };
+#else
+  struct SocketException : public PosixException {
+    SocketException(const char* text, int err_) : PosixException(text, err_) {}
+  };
+#endif
 
   struct GAIException : public Exception {
     int err;

--- a/common/rdr/Exception.h
+++ b/common/rdr/Exception.h
@@ -37,6 +37,10 @@ namespace rdr {
     SystemException(const char* s, int err_);
   };
 
+  struct SocketException : public SystemException {
+    SocketException(const char* text, int err_) : SystemException(text, err_) {}
+  };
+
   struct GAIException : public Exception {
     int err;
     GAIException(const char* s, int err_);

--- a/common/rdr/FdInStream.cxx
+++ b/common/rdr/FdInStream.cxx
@@ -92,7 +92,7 @@ size_t FdInStream::readFd(uint8_t* buf, size_t len)
   } while (n < 0 && errorNumber == EINTR);
 
   if (n < 0)
-    throw SystemException("select", errorNumber);
+    throw SocketException("select", errorNumber);
 
   if (n == 0)
     return 0;
@@ -102,7 +102,7 @@ size_t FdInStream::readFd(uint8_t* buf, size_t len)
   } while (n < 0 && errorNumber == EINTR);
 
   if (n < 0)
-    throw SystemException("read", errorNumber);
+    throw SocketException("read", errorNumber);
   if (n == 0)
     throw EndOfStream();
 

--- a/common/rdr/FdOutStream.cxx
+++ b/common/rdr/FdOutStream.cxx
@@ -117,7 +117,7 @@ size_t FdOutStream::writeFd(const uint8_t* data, size_t length)
   } while (n < 0 && errorNumber == EINTR);
 
   if (n < 0)
-    throw SystemException("select", errorNumber);
+    throw SocketException("select", errorNumber);
 
   if (n == 0)
     return 0;
@@ -134,7 +134,7 @@ size_t FdOutStream::writeFd(const uint8_t* data, size_t length)
   } while (n < 0 && (errorNumber == EINTR));
 
   if (n < 0)
-    throw SystemException("write", errorNumber);
+    throw SocketException("write", errorNumber);
 
   gettimeofday(&lastWrite, nullptr);
 

--- a/common/rdr/FileInStream.cxx
+++ b/common/rdr/FileInStream.cxx
@@ -33,7 +33,7 @@ FileInStream::FileInStream(const char *fileName)
 {
   file = fopen(fileName, "rb");
   if (!file)
-    throw SystemException("fopen", errno);
+    throw PosixException("fopen", errno);
 }
 
 FileInStream::~FileInStream(void) {
@@ -48,7 +48,7 @@ bool FileInStream::fillBuffer()
   size_t n = fread((uint8_t*)end, 1, availSpace(), file);
   if (n == 0) {
     if (ferror(file))
-      throw SystemException("fread", errno);
+      throw PosixException("fread", errno);
     if (feof(file))
       throw EndOfStream();
     return false;

--- a/common/rdr/RandomStream.cxx
+++ b/common/rdr/RandomStream.cxx
@@ -89,7 +89,7 @@ bool RandomStream::fillBuffer() {
 #ifdef RFB_HAVE_WINCRYPT
   if (provider) {
     if (!CryptGenRandom(provider, availSpace(), (uint8_t*)end))
-      throw rdr::SystemException("unable to CryptGenRandom", GetLastError());
+      throw rdr::Win32Exception("unable to CryptGenRandom", GetLastError());
     end += availSpace();
   } else {
 #else
@@ -97,8 +97,8 @@ bool RandomStream::fillBuffer() {
   if (fp) {
     size_t n = fread((uint8_t*)end, 1, availSpace(), fp);
     if (n <= 0)
-      throw rdr::SystemException("reading /dev/urandom or /dev/random failed",
-                                 errno);
+      throw rdr::PosixException("reading /dev/urandom or /dev/random failed",
+                                errno);
     end += n;
   } else {
 #else

--- a/common/rdr/TLSInStream.cxx
+++ b/common/rdr/TLSInStream.cxx
@@ -56,10 +56,10 @@ ssize_t TLSInStream::pull(gnutls_transport_ptr_t str, void* data, size_t size)
     in->readBytes((uint8_t*)data, size);
   } catch (EndOfStream&) {
     return 0;
-  } catch (SystemException &e) {
+  } catch (SocketException& e) {
     vlog.error("Failure reading TLS data: %s", e.str());
     gnutls_transport_set_errno(self->session, e.err);
-    self->saved_exception = new SystemException(e);
+    self->saved_exception = new SocketException(e);
     return -1;
   } catch (Exception& e) {
     vlog.error("Failure reading TLS data: %s", e.str());

--- a/common/rdr/TLSOutStream.cxx
+++ b/common/rdr/TLSOutStream.cxx
@@ -46,10 +46,10 @@ ssize_t TLSOutStream::push(gnutls_transport_ptr_t str, const void* data,
   try {
     out->writeBytes((const uint8_t*)data, size);
     out->flush();
-  } catch (SystemException &e) {
+  } catch (SocketException& e) {
     vlog.error("Failure sending TLS data: %s", e.str());
     gnutls_transport_set_errno(self->session, e.err);
-    self->saved_exception = new SystemException(e);
+    self->saved_exception = new SocketException(e);
     return -1;
   } catch (Exception& e) {
     vlog.error("Failure sending TLS data: %s", e.str());

--- a/common/rfb/SSecurityRSAAES.cxx
+++ b/common/rfb/SSecurityRSAAES.cxx
@@ -156,7 +156,7 @@ void SSecurityRSAAES::loadPrivateKey()
 {
   FILE* file = fopen(keyFile, "rb");
   if (!file)
-    throw rdr::SystemException("failed to open key file", errno);
+    throw rdr::PosixException("failed to open key file", errno);
   fseek(file, 0, SEEK_END);
   size_t size = ftell(file);
   if (size == 0 || size > MaxKeyFileSize) {
@@ -167,7 +167,7 @@ void SSecurityRSAAES::loadPrivateKey()
   std::vector<uint8_t> data(size);
   if (fread(data.data(), 1, data.size(), file) != size) {
     fclose(file);
-    throw rdr::SystemException("failed to read key", errno);
+    throw rdr::PosixException("failed to read key", errno);
   }
   fclose(file);
 

--- a/unix/tx/TXDialog.h
+++ b/unix/tx/TXDialog.h
@@ -63,7 +63,7 @@ public:
         FD_ZERO(&rfds);
         FD_SET(ConnectionNumber(dpy), &rfds);
         int n = select(FD_SETSIZE, &rfds, nullptr, nullptr, nullptr);
-        if (n < 0) throw rdr::SystemException("select",errno);
+        if (n < 0) throw rdr::SocketException("select", errno);
       }
     }
     return true;

--- a/unix/vncconfig/vncconfig.cxx
+++ b/unix/vncconfig/vncconfig.cxx
@@ -330,7 +330,7 @@ int main(int argc, char** argv)
       FD_ZERO(&rfds);
       FD_SET(ConnectionNumber(dpy), &rfds);
       int n = select(FD_SETSIZE, &rfds, nullptr, nullptr, tvp);
-      if (n < 0) throw rdr::SystemException("select",errno);
+      if (n < 0) throw rdr::SocketException("select", errno);
     }
 
     XCloseDisplay(dpy);

--- a/unix/x0vncserver/x0vncserver.cxx
+++ b/unix/x0vncserver/x0vncserver.cxx
@@ -441,7 +441,7 @@ int main(int argc, char** argv)
           vlog.debug("Interrupted select() system call");
           continue;
         } else {
-          throw rdr::SystemException("select", errno);
+          throw rdr::SocketException("select", errno);
         }
       }
 

--- a/vncviewer/ServerDialog.cxx
+++ b/vncviewer/ServerDialog.cxx
@@ -359,7 +359,7 @@ void ServerDialog::loadServerHistory()
       return;
     }
     std::string msg = format(_("Could not open \"%s\""), filepath);
-    throw rdr::SystemException(msg.c_str(), errno);
+    throw rdr::PosixException(msg.c_str(), errno);
   }
 
   int lineNr = 0;
@@ -375,7 +375,7 @@ void ServerDialog::loadServerHistory()
       fclose(f);
       std::string msg = format(_("Failed to read line %d in "
                                  "file \"%s\""), lineNr, filepath);
-      throw rdr::SystemException(msg.c_str(), errno);
+      throw rdr::PosixException(msg.c_str(), errno);
     }
 
     int len = strlen(line);
@@ -431,7 +431,7 @@ void ServerDialog::saveServerHistory()
   FILE* f = fopen(filepath, "w+");
   if (!f) {
     std::string msg = format(_("Could not open \"%s\""), filepath);
-    throw rdr::SystemException(msg.c_str(), errno);
+    throw rdr::PosixException(msg.c_str(), errno);
   }
 
   // Save the last X elements to the config file.

--- a/vncviewer/Surface_Win32.cxx
+++ b/vncviewer/Surface_Win32.cxx
@@ -57,10 +57,10 @@ void Surface::draw(int src_x, int src_y, int dst_x, int dst_y,
 
   dc = CreateCompatibleDC(fl_gc);
   if (!dc)
-    throw rdr::SystemException("CreateCompatibleDC", GetLastError());
+    throw rdr::Win32Exception("CreateCompatibleDC", GetLastError());
 
   if (!SelectObject(dc, bitmap))
-    throw rdr::SystemException("SelectObject", GetLastError());
+    throw rdr::Win32Exception("SelectObject", GetLastError());
 
   if (!BitBlt(fl_gc, dst_x, dst_y, dst_w, dst_h,
               dc, src_x, src_y, SRCCOPY)) {
@@ -70,7 +70,7 @@ void Surface::draw(int src_x, int src_y, int dst_x, int dst_y,
     // with it. For now, we've only seen this error and for this function
     // so only ignore this combination.
     if (GetLastError() != ERROR_INVALID_HANDLE)
-      throw rdr::SystemException("BitBlt", GetLastError());
+      throw rdr::Win32Exception("BitBlt", GetLastError());
   }
 
   DeleteDC(dc);
@@ -83,10 +83,10 @@ void Surface::draw(Surface* dst, int src_x, int src_y,
 
   dstdc = CreateCompatibleDC(nullptr);
   if (!dstdc)
-    throw rdr::SystemException("CreateCompatibleDC", GetLastError());
+    throw rdr::Win32Exception("CreateCompatibleDC", GetLastError());
 
   if (!SelectObject(dstdc, dst->bitmap))
-    throw rdr::SystemException("SelectObject", GetLastError());
+    throw rdr::Win32Exception("SelectObject", GetLastError());
 
   origdc = fl_gc;
   fl_gc = dstdc;
@@ -113,15 +113,15 @@ void Surface::blend(Surface* dst, int src_x, int src_y,
 
   dstdc = CreateCompatibleDC(nullptr);
   if (!dstdc)
-    throw rdr::SystemException("CreateCompatibleDC", GetLastError());
+    throw rdr::Win32Exception("CreateCompatibleDC", GetLastError());
   srcdc = CreateCompatibleDC(nullptr);
   if (!srcdc)
-    throw rdr::SystemException("CreateCompatibleDC", GetLastError());
+    throw rdr::Win32Exception("CreateCompatibleDC", GetLastError());
 
   if (!SelectObject(dstdc, dst->bitmap))
-    throw rdr::SystemException("SelectObject", GetLastError());
+    throw rdr::Win32Exception("SelectObject", GetLastError());
   if (!SelectObject(srcdc, bitmap))
-    throw rdr::SystemException("SelectObject", GetLastError());
+    throw rdr::Win32Exception("SelectObject", GetLastError());
 
   blend.BlendOp = AC_SRC_OVER;
   blend.BlendFlags = 0;
@@ -136,7 +136,7 @@ void Surface::blend(Surface* dst, int src_x, int src_y,
     // with it. For now, we've only seen this error and for this function
     // so only ignore this combination.
     if (GetLastError() != ERROR_INVALID_HANDLE)
-      throw rdr::SystemException("BitBlt", GetLastError());
+      throw rdr::Win32Exception("BitBlt", GetLastError());
   }
 
   DeleteDC(srcdc);
@@ -161,7 +161,7 @@ void Surface::alloc()
   bitmap = CreateDIBSection(nullptr, (BITMAPINFO*)&bih,
                             DIB_RGB_COLORS, (void**)&data, nullptr, 0);
   if (!bitmap)
-    throw rdr::SystemException("CreateDIBSection", GetLastError());
+    throw rdr::Win32Exception("CreateDIBSection", GetLastError());
 }
 
 void Surface::dealloc()

--- a/vncviewer/UserDialog.cxx
+++ b/vncviewer/UserDialog.cxx
@@ -115,7 +115,7 @@ void UserDialog::getUserPasswd(bool secure_, std::string* user,
 
     fp = fopen(passwordFileName, "rb");
     if (!fp)
-      throw rdr::SystemException(_("Opening password file failed"), errno);
+      throw rdr::PosixException(_("Opening password file failed"), errno);
 
     obfPwd.resize(fread(obfPwd.data(), 1, obfPwd.size(), fp));
     fclose(fp);

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -318,7 +318,7 @@ static void setKeyString(const char *_name, const char *_value, HKEY* hKey) {
 
   LONG res = RegSetValueExW(*hKey, name, 0, REG_SZ, (BYTE*)&value, (wcslen(value)+1)*2);
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException("RegSetValueExW", res);
+    throw rdr::Win32Exception("RegSetValueExW", res);
 }
 
 
@@ -334,7 +334,7 @@ static void setKeyInt(const char *_name, const int _value, HKEY* hKey) {
 
   LONG res = RegSetValueExW(*hKey, name, 0, REG_DWORD, (BYTE*)&value, sizeof(DWORD));
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException("RegSetValueExW", res);
+    throw rdr::Win32Exception("RegSetValueExW", res);
 }
 
 
@@ -355,7 +355,7 @@ static bool getKeyString(const char* _name, char* dest, size_t destSize, HKEY* h
   if (res != ERROR_SUCCESS){
     delete [] value;
     if (res != ERROR_FILE_NOT_FOUND)
-      throw rdr::SystemException("RegQueryValueExW", res);
+      throw rdr::Win32Exception("RegQueryValueExW", res);
     // The value does not exist, defaults will be used.
     return false;
   }
@@ -392,7 +392,7 @@ static bool getKeyInt(const char* _name, int* dest, HKEY* hKey) {
   LONG res = RegQueryValueExW(*hKey, name, nullptr, nullptr, (LPBYTE)&value, &dwordsize);
   if (res != ERROR_SUCCESS){
     if (res != ERROR_FILE_NOT_FOUND)
-      throw rdr::SystemException("RegQueryValueExW", res);
+      throw rdr::Win32Exception("RegQueryValueExW", res);
     // The value does not exist, defaults will be used.
     return false;
   }
@@ -412,7 +412,7 @@ static void removeValue(const char* _name, HKEY* hKey) {
   LONG res = RegDeleteValueW(*hKey, name);
   if (res != ERROR_SUCCESS) {
     if (res != ERROR_FILE_NOT_FOUND)
-      throw rdr::SystemException("RegDeleteValueW", res);
+      throw rdr::Win32Exception("RegDeleteValueW", res);
     // The value does not exist, no need to remove it.
     return;
   }
@@ -426,7 +426,7 @@ void saveHistoryToRegKey(const list<string>& serverHistory) {
                              &hKey, nullptr);
 
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException(_("Failed to create registry key"), res);
+    throw rdr::Win32Exception(_("Failed to create registry key"), res);
 
   unsigned index = 0;
   assert(SERVER_HISTORY_SIZE < 100);
@@ -447,7 +447,7 @@ void saveHistoryToRegKey(const list<string>& serverHistory) {
 
   res = RegCloseKey(hKey);
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException(_("Failed to close registry key"), res);
+    throw rdr::Win32Exception(_("Failed to close registry key"), res);
 }
 
 static void saveToReg(const char* servername) {
@@ -459,7 +459,7 @@ static void saveToReg(const char* servername) {
                              REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, nullptr,
                              &hKey, nullptr);
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException(_("Failed to create registry key"), res);
+    throw rdr::Win32Exception(_("Failed to create registry key"), res);
 
   try {
     setKeyString("ServerName", servername, &hKey);
@@ -502,7 +502,7 @@ static void saveToReg(const char* servername) {
 
   res = RegCloseKey(hKey);
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException(_("Failed to close registry key"), res);
+    throw rdr::Win32Exception(_("Failed to close registry key"), res);
 }
 
 list<string> loadHistoryFromRegKey() {
@@ -518,7 +518,7 @@ list<string> loadHistoryFromRegKey() {
       return serverHistory;
     }
 
-    throw rdr::SystemException(_("Failed to open registry key"), res);
+    throw rdr::Win32Exception(_("Failed to open registry key"), res);
   }
 
   unsigned index;
@@ -545,7 +545,7 @@ list<string> loadHistoryFromRegKey() {
 
   res = RegCloseKey(hKey);
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException(_("Failed to close registry key"), res);
+    throw rdr::Win32Exception(_("Failed to close registry key"), res);
 
   return serverHistory;
 }
@@ -592,7 +592,7 @@ static char* loadFromReg() {
       return nullptr;
     }
 
-    throw rdr::SystemException(_("Failed to open registry key"), res);
+    throw rdr::Win32Exception(_("Failed to open registry key"), res);
   }
 
   const size_t buffersize = 256;
@@ -614,7 +614,7 @@ static char* loadFromReg() {
 
   res = RegCloseKey(hKey);
   if (res != ERROR_SUCCESS)
-    throw rdr::SystemException(_("Failed to close registry key"), res);
+    throw rdr::Win32Exception(_("Failed to close registry key"), res);
 
   return servername;
 }
@@ -648,7 +648,7 @@ void saveViewerParameters(const char *filename, const char *servername) {
   FILE* f = fopen(filepath, "w+");
   if (!f) {
     std::string msg = format(_("Could not open \"%s\""), filepath);
-    throw rdr::SystemException(msg.c_str(), errno);
+    throw rdr::PosixException(msg.c_str(), errno);
   }
 
   fprintf(f, "%s\n", IDENTIFIER_STRING);
@@ -755,7 +755,7 @@ char* loadViewerParameters(const char *filename) {
     if (!filename)
       return nullptr; // Use defaults.
     std::string msg = format(_("Could not open \"%s\""), filepath);
-    throw rdr::SystemException(msg.c_str(), errno);
+    throw rdr::PosixException(msg.c_str(), errno);
   }
   
   int lineNr = 0;
@@ -770,7 +770,7 @@ char* loadViewerParameters(const char *filename) {
       fclose(f);
       std::string msg = format(_("Failed to read line %d in "
                                  "file \"%s\""), lineNr, filepath);
-      throw rdr::SystemException(msg.c_str(), errno);
+      throw rdr::PosixException(msg.c_str(), errno);
     }
 
     if (strlen(line) == (sizeof(line) - 1)) {

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -808,7 +808,7 @@ int main(int argc, char** argv)
             vlog.debug("Interrupted select() system call");
             continue;
           } else {
-            throw rdr::SystemException("select", errno);
+            throw rdr::SocketException("select", errno);
           }
         }
 

--- a/win/rfb_win32/CleanDesktop.cxx
+++ b/win/rfb_win32/CleanDesktop.cxx
@@ -45,7 +45,7 @@ struct ActiveDesktop {
     HRESULT result = CoCreateInstance(CLSID_ActiveDesktop, nullptr, CLSCTX_INPROC_SERVER,
                                       IID_IActiveDesktop, (PVOID*)&handle);
     if (result != S_OK)
-      throw rdr::SystemException("failed to contact Active Desktop", result);
+      throw rdr::Win32Exception("failed to contact Active Desktop", HRESULT_CODE(result));
   }
   ~ActiveDesktop() {
     if (handle)

--- a/win/rfb_win32/Clipboard.cxx
+++ b/win/rfb_win32/Clipboard.cxx
@@ -127,7 +127,7 @@ Clipboard::setClipText(const char* text) {
 
     // - Firstly, we must open the clipboard
     if (!OpenClipboard(getHandle()))
-      throw rdr::SystemException("unable to open Win32 clipboard", GetLastError());
+      throw rdr::Win32Exception("unable to open Win32 clipboard", GetLastError());
 
     // - Convert the supplied clipboard text into UTF-16 format with CRLF
     std::string filtered(convertCRLF(text));
@@ -142,11 +142,11 @@ Clipboard::setClipText(const char* text) {
 
     // - Next, we must clear out any existing data
     if (!EmptyClipboard())
-      throw rdr::SystemException("unable to empty Win32 clipboard", GetLastError());
+      throw rdr::Win32Exception("unable to empty Win32 clipboard", GetLastError());
 
     // - Set the new clipboard data
     if (!SetClipboardData(CF_UNICODETEXT, clip_handle))
-      throw rdr::SystemException("unable to set Win32 clipboard", GetLastError());
+      throw rdr::Win32Exception("unable to set Win32 clipboard", GetLastError());
     clip_handle = nullptr;
 
     vlog.debug("set clipboard");

--- a/win/rfb_win32/CompatibleBitmap.h
+++ b/win/rfb_win32/CompatibleBitmap.h
@@ -30,7 +30,7 @@ namespace rfb {
       CompatibleBitmap(HDC hdc, int width, int height) {
         hbmp = CreateCompatibleBitmap(hdc, width, height);
         if (!hbmp)
-          throw rdr::SystemException("CreateCompatibleBitmap() failed", GetLastError());
+          throw rdr::Win32Exception("CreateCompatibleBitmap() failed", GetLastError());
       }
       virtual ~CompatibleBitmap() {
         if (hbmp) DeleteObject(hbmp);

--- a/win/rfb_win32/CurrentUser.cxx
+++ b/win/rfb_win32/CurrentUser.cxx
@@ -80,7 +80,7 @@ CurrentUserToken::CurrentUserToken() {
     if (!OpenProcessToken(GetCurrentProcess(), GENERIC_ALL, &h)) {
       DWORD err = GetLastError();
       if (err != ERROR_CALL_NOT_IMPLEMENTED)
-        throw rdr::SystemException("OpenProcessToken failed", err);
+        throw rdr::Win32Exception("OpenProcessToken failed", err);
       h = INVALID_HANDLE_VALUE;
     }
   }
@@ -96,7 +96,7 @@ ImpersonateCurrentUser::ImpersonateCurrentUser() {
   if (!ImpersonateLoggedOnUser(token)) {
     DWORD err = GetLastError();
     if (err != ERROR_CALL_NOT_IMPLEMENTED)
-      throw rdr::SystemException("Failed to impersonate user", GetLastError());
+      throw rdr::Win32Exception("Failed to impersonate user", GetLastError());
   }
 }
 
@@ -114,7 +114,7 @@ UserName::UserName() {
   char buf[UNLEN+1];
   DWORD len = UNLEN+1;
   if (!GetUserName(buf, &len))
-    throw rdr::SystemException("GetUserName failed", GetLastError());
+    throw rdr::Win32Exception("GetUserName failed", GetLastError());
   assign(buf);
 }
 

--- a/win/rfb_win32/DIBSectionBuffer.cxx
+++ b/win/rfb_win32/DIBSectionBuffer.cxx
@@ -85,7 +85,7 @@ void DIBSectionBuffer::initBuffer(const PixelFormat& pf, int w, int h) {
 
     if (!new_bitmap) {
       int err = GetLastError();
-      throw rdr::SystemException("unable to create DIB section", err);
+      throw rdr::Win32Exception("unable to create DIB section", err);
     }
 
     vlog.debug("recreateBuffer()");
@@ -128,7 +128,7 @@ void DIBSectionBuffer::initBuffer(const PixelFormat& pf, int w, int h) {
     // Determine the *actual* DIBSection format
     DIBSECTION ds;
     if (!GetObject(bitmap, sizeof(ds), &ds))
-      throw rdr::SystemException("GetObject", GetLastError());
+      throw rdr::Win32Exception("GetObject", GetLastError());
 
     // Correct the "stride" of the DIB
     // *** This code DWORD aligns each row - is that right???

--- a/win/rfb_win32/DeviceContext.cxx
+++ b/win/rfb_win32/DeviceContext.cxx
@@ -51,10 +51,10 @@ PixelFormat DeviceContext::getPF(HDC dc) {
   bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
   bi.bmiHeader.biBitCount = 0;
   if (!::GetDIBits(dc, bitmap, 0, 1, nullptr, (BITMAPINFO*)&bi, DIB_RGB_COLORS)) {
-    throw rdr::SystemException("unable to determine device pixel format", GetLastError());
+    throw rdr::Win32Exception("unable to determine device pixel format", GetLastError());
   }
   if (!::GetDIBits(dc, bitmap, 0, 1, nullptr, (BITMAPINFO*)&bi, DIB_RGB_COLORS)) {
-    throw rdr::SystemException("unable to determine pixel shifts/palette", GetLastError());
+    throw rdr::Win32Exception("unable to determine pixel shifts/palette", GetLastError());
   }
 
   // Set the initial format information
@@ -151,7 +151,7 @@ Rect DeviceContext::getClipBox(HDC dc) {
   // Get the display dimensions
   RECT cr;
   if (!GetClipBox(dc, &cr))
-    throw rdr::SystemException("GetClipBox", GetLastError());
+    throw rdr::Win32Exception("GetClipBox", GetLastError());
   return Rect(cr.left, cr.top, cr.right, cr.bottom);
 }
 
@@ -159,7 +159,7 @@ Rect DeviceContext::getClipBox(HDC dc) {
 DeviceDC::DeviceDC(const char* deviceName) {
   dc = ::CreateDC("DISPLAY", deviceName, nullptr, nullptr);
   if (!dc)
-    throw rdr::SystemException("failed to create DeviceDC", GetLastError());
+    throw rdr::Win32Exception("failed to create DeviceDC", GetLastError());
 }
 
 DeviceDC::~DeviceDC() {
@@ -171,7 +171,7 @@ DeviceDC::~DeviceDC() {
 WindowDC::WindowDC(HWND wnd) : hwnd(wnd) {
   dc = GetDC(wnd);
   if (!dc)
-    throw rdr::SystemException("GetDC failed", GetLastError());
+    throw rdr::Win32Exception("GetDC failed", GetLastError());
 }
 
 WindowDC::~WindowDC() {
@@ -183,7 +183,7 @@ WindowDC::~WindowDC() {
 CompatibleDC::CompatibleDC(HDC existing) {
   dc = CreateCompatibleDC(existing);
   if (!dc)
-    throw rdr::SystemException("CreateCompatibleDC failed", GetLastError());
+    throw rdr::Win32Exception("CreateCompatibleDC failed", GetLastError());
 }
 
 CompatibleDC::~CompatibleDC() {
@@ -195,7 +195,7 @@ CompatibleDC::~CompatibleDC() {
 BitmapDC::BitmapDC(HDC hdc, HBITMAP hbitmap) : CompatibleDC(hdc){
   oldBitmap = (HBITMAP)SelectObject(dc, hbitmap);
   if (!oldBitmap)
-    throw rdr::SystemException("SelectObject to CompatibleDC failed",
+    throw rdr::Win32Exception("SelectObject to CompatibleDC failed",
     GetLastError());
 }
 

--- a/win/rfb_win32/DeviceFrameBuffer.cxx
+++ b/win/rfb_win32/DeviceFrameBuffer.cxx
@@ -102,7 +102,7 @@ DeviceFrameBuffer::grabRect(const Rect &rect) {
     if (ignoreGrabErrors)
       vlog.error("BitBlt failed:%ld", GetLastError());
     else
-      throw rdr::SystemException("BitBlt failed", GetLastError());
+      throw rdr::Win32Exception("BitBlt failed", GetLastError());
   }
 }
 
@@ -138,7 +138,7 @@ void DeviceFrameBuffer::setCursor(HCURSOR hCursor, VNCServer* server)
 
     BITMAP maskInfo;
     if (!GetObject(iconInfo.hbmMask, sizeof(BITMAP), &maskInfo))
-      throw rdr::SystemException("GetObject() failed", GetLastError());
+      throw rdr::Win32Exception("GetObject() failed", GetLastError());
     if (maskInfo.bmPlanes != 1)
       throw rdr::Exception("unsupported multi-plane cursor");
     if (maskInfo.bmBitsPixel != 1)
@@ -174,7 +174,7 @@ void DeviceFrameBuffer::setCursor(HCURSOR hCursor, VNCServer* server)
 
       if (!GetDIBits(dc, iconInfo.hbmColor, 0, height,
                      buffer.data(), (LPBITMAPINFO)&bi, DIB_RGB_COLORS))
-        throw rdr::SystemException("GetDIBits", GetLastError());
+        throw rdr::Win32Exception("GetDIBits", GetLastError());
 
       // We may not get the RGBA order we want, so shuffle things around
       int ridx, gidx, bidx, aidx;
@@ -217,7 +217,7 @@ void DeviceFrameBuffer::setCursor(HCURSOR hCursor, VNCServer* server)
 
       if (!GetBitmapBits(iconInfo.hbmMask,
                          maskInfo.bmWidthBytes * maskInfo.bmHeight, mask.data()))
-        throw rdr::SystemException("GetBitmapBits", GetLastError());
+        throw rdr::Win32Exception("GetBitmapBits", GetLastError());
 
       bool doOutline = false;
       uint8_t* rwbuffer = buffer.data();

--- a/win/rfb_win32/Dialog.cxx
+++ b/win/rfb_win32/Dialog.cxx
@@ -65,7 +65,7 @@ bool Dialog::showDialog(const char* resource, HWND owner)
   INT_PTR result = DialogBoxParam(inst, resource, owner,
                                   staticDialogProc, (LPARAM)this);
   if (result<0)
-    throw rdr::SystemException("DialogBoxParam failed", GetLastError());
+    throw rdr::Win32Exception("DialogBoxParam failed", GetLastError());
   alreadyShowing = false;
   return (result == 1);
 }
@@ -275,7 +275,7 @@ bool PropSheet::showPropSheet(HWND owner_, bool showApply, bool showCtxtHelp, bo
 
     handle = (HWND)PropertySheet(&header);
     if ((handle == nullptr) || (handle == (HWND)-1))
-      throw rdr::SystemException("PropertySheet failed", GetLastError());
+      throw rdr::Win32Exception("PropertySheet failed", GetLastError());
     centerWindow(handle, owner_);
     plog.info("created %p", handle);
 

--- a/win/rfb_win32/IconInfo.h
+++ b/win/rfb_win32/IconInfo.h
@@ -28,7 +28,7 @@ namespace rfb {
     struct IconInfo : public ICONINFO {
       IconInfo(HICON icon) {
         if (!GetIconInfo(icon, this))
-          throw rdr::SystemException("GetIconInfo() failed", GetLastError());
+          throw rdr::Win32Exception("GetIconInfo() failed", GetLastError());
       }
       ~IconInfo() {
         if (hbmColor)

--- a/win/rfb_win32/IntervalTimer.h
+++ b/win/rfb_win32/IntervalTimer.h
@@ -41,7 +41,7 @@ namespace rfb {
         if (!active || interval_ != interval) {
           interval = interval_;
           if (!SetTimer(hwnd, id, interval, nullptr))
-            throw rdr::SystemException("SetTimer", GetLastError());
+            throw rdr::Win32Exception("SetTimer", GetLastError());
           active = true;
         }
       }

--- a/win/rfb_win32/LaunchProcess.cxx
+++ b/win/rfb_win32/LaunchProcess.cxx
@@ -53,7 +53,7 @@ void LaunchProcess::start(HANDLE userToken, bool createConsole) {
   char buf[256];
   HDESK desktop = GetThreadDesktop(GetCurrentThreadId());
   if (!GetUserObjectInformation(desktop, UOI_NAME, buf, 256, &size))
-    throw rdr::SystemException("unable to launch process", GetLastError());
+    throw rdr::Win32Exception("unable to launch process", GetLastError());
 
   snprintf(desktopName, 256, "WinSta0\\%s", buf);
 
@@ -95,7 +95,7 @@ void LaunchProcess::start(HANDLE userToken, bool createConsole) {
                             flags, nullptr, nullptr,
                             &sinfo, &procInfo);
   if (!success)
-    throw rdr::SystemException("unable to launch process", GetLastError());
+    throw rdr::Win32Exception("unable to launch process", GetLastError());
 
   // Wait for it to finish initialising
   WaitForInputIdle(procInfo.hProcess, 15000);
@@ -119,7 +119,7 @@ bool LaunchProcess::await(DWORD timeoutMs) {
     detach();
     return true;
   } else if (result == WAIT_FAILED) {
-    throw rdr::SystemException("await() failed", GetLastError());
+    throw rdr::Win32Exception("await() failed", GetLastError());
   }
   return false;
 }

--- a/win/rfb_win32/LocalMem.h
+++ b/win/rfb_win32/LocalMem.h
@@ -28,7 +28,7 @@ namespace rfb {
     // Allocate and/or manage LocalAlloc memory.
     struct LocalMem {
       LocalMem(int size) : ptr(LocalAlloc(LMEM_FIXED, size)) {
-        if (!ptr) throw rdr::SystemException("LocalAlloc", GetLastError());
+        if (!ptr) throw rdr::Win32Exception("LocalAlloc", GetLastError());
       }
       LocalMem(void* p) : ptr(p) {}
       ~LocalMem() {LocalFree(ptr);}

--- a/win/rfb_win32/MonitorInfo.cxx
+++ b/win/rfb_win32/MonitorInfo.cxx
@@ -44,7 +44,7 @@ static void fillMonitorInfo(HMONITOR monitor, MONITORINFOEXA* mi) {
   memset(mi, 0, sizeof(MONITORINFOEXA));
   mi->cbSize = sizeof(MONITORINFOEXA);
   if (!GetMonitorInfo(monitor, mi))
-    throw rdr::SystemException("failed to GetMonitorInfo", GetLastError());
+    throw rdr::Win32Exception("failed to GetMonitorInfo", GetLastError());
   vlog.debug("monitor is %ld,%ld-%ld,%ld", mi->rcMonitor.left, mi->rcMonitor.top, mi->rcMonitor.right, mi->rcMonitor.bottom);
   vlog.debug("work area is %ld,%ld-%ld,%ld", mi->rcWork.left, mi->rcWork.top, mi->rcWork.right, mi->rcWork.bottom);
   vlog.debug("device is \"%s\"", mi->szDevice);
@@ -57,7 +57,7 @@ MonitorInfo::MonitorInfo(HWND window) {
 
   HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
   if (!monitor)
-    throw rdr::SystemException("failed to get monitor", GetLastError());
+    throw rdr::Win32Exception("failed to get monitor", GetLastError());
   fillMonitorInfo(monitor, this);
 }
 
@@ -67,7 +67,7 @@ MonitorInfo::MonitorInfo(const RECT& r) {
 
   HMONITOR monitor = MonitorFromRect(&r, MONITOR_DEFAULTTONEAREST);
   if (!monitor)
-    throw rdr::SystemException("failed to get monitor", GetLastError());
+    throw rdr::Win32Exception("failed to get monitor", GetLastError());
   fillMonitorInfo(monitor, this);
 }
 

--- a/win/rfb_win32/MsgWindow.cxx
+++ b/win/rfb_win32/MsgWindow.cxx
@@ -82,7 +82,7 @@ MsgWindowClass::MsgWindowClass() : classAtom(0) {
   wndClass.lpszClassName = "rfb::win32::MsgWindowClass";
   classAtom = RegisterClass(&wndClass);
   if (!classAtom) {
-    throw rdr::SystemException("unable to register MsgWindow window class", GetLastError());
+    throw rdr::Win32Exception("unable to register MsgWindow window class", GetLastError());
   }
 }
 
@@ -104,7 +104,7 @@ MsgWindow::MsgWindow(const char* name_) : name(name_), handle(nullptr) {
                         name.c_str(), WS_OVERLAPPED, 0, 0, 10, 10,
                         nullptr, nullptr, baseClass.instance, this);
   if (!handle) {
-    throw rdr::SystemException("unable to create WMNotifier window instance", GetLastError());
+    throw rdr::Win32Exception("unable to create WMNotifier window instance", GetLastError());
   }
   vlog.debug("created window \"%s\" (%p)", name.c_str(), handle);
 }

--- a/win/rfb_win32/RegConfig.cxx
+++ b/win/rfb_win32/RegConfig.cxx
@@ -69,8 +69,8 @@ void RegConfig::loadRegistryConfig(RegKey& key) {
       if (!Configuration::setParam(name, value.c_str()))
         vlog.info("unable to process %s", name);
     }
-  } catch (rdr::SystemException& e) {
-    if (e.err != 6)
+  } catch (rdr::Win32Exception& e) {
+    if (e.err != ERROR_INVALID_HANDLE)
       vlog.error("%s", e.str());
   }
 }
@@ -115,5 +115,5 @@ void RegConfigThread::worker() {
   thread_id = GetCurrentThreadId();
   while ((result = eventMgr.getMessage(&msg, nullptr, 0, 0)) > 0) {}
   if (result < 0)
-    throw rdr::SystemException("RegConfigThread failed", GetLastError());
+    throw rdr::Win32Exception("RegConfigThread failed", GetLastError());
 }

--- a/win/rfb_win32/Registry.cxx
+++ b/win/rfb_win32/Registry.cxx
@@ -54,7 +54,7 @@ RegKey::RegKey() : key(nullptr), freeKey(false), valueName(nullptr), valueNameBu
 RegKey::RegKey(const HKEY k) : key(nullptr), freeKey(false), valueName(nullptr), valueNameBufLen(0) {
   LONG result = RegOpenKeyEx(k, nullptr, 0, KEY_ALL_ACCESS, &key);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegOpenKeyEx(HKEY)", result);
+    throw rdr::Win32Exception("RegOpenKeyEx(HKEY)", result);
   vlog.debug("duplicated %p to %p", k, key);
   freeKey = true;
 }
@@ -62,7 +62,7 @@ RegKey::RegKey(const HKEY k) : key(nullptr), freeKey(false), valueName(nullptr),
 RegKey::RegKey(const RegKey& k) : key(nullptr), freeKey(false), valueName(nullptr), valueNameBufLen(0) {
   LONG result = RegOpenKeyEx(k.key, nullptr, 0, KEY_ALL_ACCESS, &key);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegOpenKeyEx(RegKey&)", result);
+    throw rdr::Win32Exception("RegOpenKeyEx(RegKey&)", result);
   vlog.debug("duplicated %p to %p", k.key, key);
   freeKey = true;
 }
@@ -86,7 +86,7 @@ bool RegKey::createKey(const RegKey& root, const char* name) {
   LONG result = RegCreateKey(root.key, name, &key);
   if (result != ERROR_SUCCESS) {
     vlog.error("RegCreateKey(%p, %s): %lx", root.key, name, result);
-    throw rdr::SystemException("RegCreateKeyEx", result);
+    throw rdr::Win32Exception("RegCreateKeyEx", result);
   }
   vlog.debug("createKey(%p,%s) = %p", root.key, name, key);
   freeKey = true;
@@ -97,7 +97,7 @@ void RegKey::openKey(const RegKey& root, const char* name, bool readOnly) {
   close();
   LONG result = RegOpenKeyEx(root.key, name, 0, readOnly ? KEY_READ : KEY_ALL_ACCESS, &key);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegOpenKeyEx (open)", result);
+    throw rdr::Win32Exception("RegOpenKeyEx (open)", result);
   vlog.debug("openKey(%p,%s,%s) = %p", root.key, name,
 	         readOnly ? "ro" : "rw", key);
   freeKey = true;
@@ -109,7 +109,7 @@ void RegKey::setDACL(const PACL acl, bool inherit) {
     DACL_SECURITY_INFORMATION |
     (inherit ? UNPROTECTED_DACL_SECURITY_INFORMATION : PROTECTED_DACL_SECURITY_INFORMATION),
     nullptr, nullptr, acl, nullptr)) != ERROR_SUCCESS)
-    throw rdr::SystemException("RegKey::setDACL failed", result);
+    throw rdr::Win32Exception("RegKey::setDACL failed", result);
 }
 
 void RegKey::close() {
@@ -123,19 +123,19 @@ void RegKey::close() {
 void RegKey::deleteKey(const char* name) const {
   LONG result = RegDeleteKey(key, name);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegDeleteKey", result);
+    throw rdr::Win32Exception("RegDeleteKey", result);
 }
 
 void RegKey::deleteValue(const char* name) const {
   LONG result = RegDeleteValue(key, name);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegDeleteValue", result);
+    throw rdr::Win32Exception("RegDeleteValue", result);
 }
 
 void RegKey::awaitChange(bool watchSubTree, DWORD filter, HANDLE event) const {
   LONG result = RegNotifyChangeKeyValue(key, watchSubTree, filter, event, event != nullptr);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegNotifyChangeKeyValue", result);
+    throw rdr::Win32Exception("RegNotifyChangeKeyValue", result);
 }
 
 
@@ -144,22 +144,22 @@ RegKey::operator HKEY() const {return key;}
 
 void RegKey::setExpandString(const char* valname, const char* value) const {
   LONG result = RegSetValueEx(key, valname, 0, REG_EXPAND_SZ, (const BYTE*)value, (strlen(value)+1)*sizeof(char));
-  if (result != ERROR_SUCCESS) throw rdr::SystemException("setExpandString", result);
+  if (result != ERROR_SUCCESS) throw rdr::Win32Exception("setExpandString", result);
 }
 
 void RegKey::setString(const char* valname, const char* value) const {
   LONG result = RegSetValueEx(key, valname, 0, REG_SZ, (const BYTE*)value, (strlen(value)+1)*sizeof(char));
-  if (result != ERROR_SUCCESS) throw rdr::SystemException("setString", result);
+  if (result != ERROR_SUCCESS) throw rdr::Win32Exception("setString", result);
 }
 
 void RegKey::setBinary(const char* valname, const void* value, size_t length) const {
   LONG result = RegSetValueEx(key, valname, 0, REG_BINARY, (const BYTE*)value, length);
-  if (result != ERROR_SUCCESS) throw rdr::SystemException("setBinary", result);
+  if (result != ERROR_SUCCESS) throw rdr::Win32Exception("setBinary", result);
 }
 
 void RegKey::setInt(const char* valname, int value) const {
   LONG result = RegSetValueEx(key, valname, 0, REG_DWORD, (const BYTE*)&value, sizeof(value));
-  if (result != ERROR_SUCCESS) throw rdr::SystemException("setInt", result);
+  if (result != ERROR_SUCCESS) throw rdr::Win32Exception("setInt", result);
 }
 
 void RegKey::setBool(const char* valname, bool value) const {
@@ -214,11 +214,11 @@ std::string RegKey::getRepresentation(const char* valname) const {
   DWORD type, length;
   LONG result = RegQueryValueEx(key, valname, nullptr, &type, nullptr, &length);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("get registry value length", result);
+    throw rdr::Win32Exception("get registry value length", result);
   std::vector<uint8_t> data(length);
   result = RegQueryValueEx(key, valname, nullptr, &type, (BYTE*)data.data(), &length);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("get registry value", result);
+    throw rdr::Win32Exception("get registry value", result);
 
   switch (type) {
   case REG_BINARY:
@@ -243,7 +243,7 @@ std::string RegKey::getRepresentation(const char* valname) const {
       std::string str((char*)data.data(), length);
       DWORD required = ExpandEnvironmentStrings(str.c_str(), nullptr, 0);
       if (required==0)
-        throw rdr::SystemException("ExpandEnvironmentStrings", GetLastError());
+        throw rdr::Win32Exception("ExpandEnvironmentStrings", GetLastError());
       std::vector<char> expanded(required);
       length = ExpandEnvironmentStrings(str.c_str(), expanded.data(), required);
       if (required<length)
@@ -271,7 +271,7 @@ const char* RegKey::getValueName(int i) {
   DWORD maxValueNameLen;
   LONG result = RegQueryInfoKey(key, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &maxValueNameLen, nullptr, nullptr, nullptr);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegQueryInfoKey", result);
+    throw rdr::Win32Exception("RegQueryInfoKey", result);
   if (valueNameBufLen < maxValueNameLen + 1) {
     valueNameBufLen = maxValueNameLen + 1;
     delete [] valueName;
@@ -281,7 +281,7 @@ const char* RegKey::getValueName(int i) {
   result = RegEnumValue(key, i, valueName, &length, nullptr, nullptr, nullptr, nullptr);
   if (result == ERROR_NO_MORE_ITEMS) return nullptr;
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegEnumValue", result);
+    throw rdr::Win32Exception("RegEnumValue", result);
   return valueName;
 }
 
@@ -289,7 +289,7 @@ const char* RegKey::getKeyName(int i) {
   DWORD maxValueNameLen;
   LONG result = RegQueryInfoKey(key, nullptr, nullptr, nullptr, nullptr, &maxValueNameLen, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegQueryInfoKey", result);
+    throw rdr::Win32Exception("RegQueryInfoKey", result);
   if (valueNameBufLen < maxValueNameLen + 1) {
     valueNameBufLen = maxValueNameLen + 1;
     delete [] valueName;
@@ -299,6 +299,6 @@ const char* RegKey::getKeyName(int i) {
   result = RegEnumKeyEx(key, i, valueName, &length, nullptr, nullptr, nullptr, nullptr);
   if (result == ERROR_NO_MORE_ITEMS) return nullptr;
   if (result != ERROR_SUCCESS)
-    throw rdr::SystemException("RegEnumKey", result);
+    throw rdr::Win32Exception("RegEnumKey", result);
   return valueName;
 }

--- a/win/rfb_win32/SInput.cxx
+++ b/win/rfb_win32/SInput.cxx
@@ -126,7 +126,7 @@ win32::SPointer::pointerEvent(const Point& pos, uint8_t buttonmask)
     evt.mi.mouseData = data;
     evt.mi.time = 0;
     if (SendInput(1, &evt, sizeof(evt)) != 1)
-      throw rdr::SystemException("SendInput", GetLastError());
+      throw rdr::Win32Exception("SendInput", GetLastError());
   }
 }
 

--- a/win/rfb_win32/Security.cxx
+++ b/win/rfb_win32/Security.cxx
@@ -99,7 +99,7 @@ PSID Sid::copySID(const PSID sid) {
     throw rdr::Exception("invalid SID in copyPSID");
   PSID buf = (PSID)new uint8_t[GetLengthSid(sid)];
   if (!CopySid(GetLengthSid(sid), buf, sid))
-    throw rdr::SystemException("CopySid failed", GetLastError());
+    throw rdr::Win32Exception("CopySid failed", GetLastError());
   return buf;
 }
 
@@ -108,7 +108,7 @@ void Sid::setSID(const PSID sid) {
     throw rdr::Exception("invalid SID in copyPSID");
   resize(GetLengthSid(sid));
   if (!CopySid(GetLengthSid(sid), data(), sid))
-    throw rdr::SystemException("CopySid failed", GetLastError());
+    throw rdr::Win32Exception("CopySid failed", GetLastError());
 }
 
 void Sid::getUserNameAndDomain(char** name, char** domain) {
@@ -117,12 +117,12 @@ void Sid::getUserNameAndDomain(char** name, char** domain) {
   SID_NAME_USE use;
   LookupAccountSid(nullptr, (PSID)*this, nullptr, &nameLen, nullptr, &domainLen, &use);
   if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-    throw rdr::SystemException("Unable to determine SID name lengths", GetLastError());
+    throw rdr::Win32Exception("Unable to determine SID name lengths", GetLastError());
   vlog.info("nameLen=%lu, domainLen=%lu, use=%d", nameLen, domainLen, use);
   *name = new char[nameLen];
   *domain = new char[domainLen];
   if (!LookupAccountSid(nullptr, (PSID)*this, *name, &nameLen, *domain, &domainLen, &use))
-    throw rdr::SystemException("Unable to lookup account SID", GetLastError());
+    throw rdr::Win32Exception("Unable to lookup account SID", GetLastError());
 }
 
 
@@ -133,7 +133,7 @@ Sid::Administrators::Administrators() {
                                 SECURITY_BUILTIN_DOMAIN_RID,
                                 DOMAIN_ALIAS_RID_ADMINS,
                                 0, 0, 0, 0, 0, 0, &sid)) 
-    throw rdr::SystemException("Sid::Administrators", GetLastError());
+    throw rdr::Win32Exception("Sid::Administrators", GetLastError());
   setSID(sid);
   FreeSid(sid);
 }
@@ -144,7 +144,7 @@ Sid::SYSTEM::SYSTEM() {
   if (!AllocateAndInitializeSid(&ntAuth, 1,
                                 SECURITY_LOCAL_SYSTEM_RID,
                                 0, 0, 0, 0, 0, 0, 0, &sid))
-          throw rdr::SystemException("Sid::SYSTEM", GetLastError());
+          throw rdr::Win32Exception("Sid::SYSTEM", GetLastError());
   setSID(sid);
   FreeSid(sid);
 }
@@ -154,7 +154,7 @@ Sid::FromToken::FromToken(HANDLE h) {
   GetTokenInformation(h, TokenUser, nullptr, 0, &required);
   std::vector<uint8_t> tmp(required);
   if (!GetTokenInformation(h, TokenUser, tmp.data(), tmp.size(), &required))
-    throw rdr::SystemException("GetTokenInformation", GetLastError());
+    throw rdr::Win32Exception("GetTokenInformation", GetLastError());
   TOKEN_USER* tokenUser = (TOKEN_USER*)tmp.data();
   setSID(tokenUser->User.Sid);
 }
@@ -164,7 +164,7 @@ PACL rfb::win32::CreateACL(const AccessEntries& ae, PACL existing_acl) {
   PACL new_dacl;
   DWORD result;
   if ((result = SetEntriesInAcl(ae.entry_count, ae.entries, existing_acl, &new_dacl)) != ERROR_SUCCESS)
-    throw rdr::SystemException("SetEntriesInAcl", result);
+    throw rdr::Win32Exception("SetEntriesInAcl", result);
   return new_dacl;
 }
 
@@ -172,18 +172,18 @@ PACL rfb::win32::CreateACL(const AccessEntries& ae, PACL existing_acl) {
 PSECURITY_DESCRIPTOR rfb::win32::CreateSdWithDacl(const PACL dacl) {
   SECURITY_DESCRIPTOR absSD;
   if (!InitializeSecurityDescriptor(&absSD, SECURITY_DESCRIPTOR_REVISION))
-    throw rdr::SystemException("InitializeSecurityDescriptor", GetLastError());
+    throw rdr::Win32Exception("InitializeSecurityDescriptor", GetLastError());
   Sid::SYSTEM owner;
   if (!SetSecurityDescriptorOwner(&absSD, owner, FALSE))
-    throw rdr::SystemException("SetSecurityDescriptorOwner", GetLastError());
+    throw rdr::Win32Exception("SetSecurityDescriptorOwner", GetLastError());
   Sid::Administrators group;
   if (!SetSecurityDescriptorGroup(&absSD, group, FALSE))
-    throw rdr::SystemException("SetSecurityDescriptorGroupp", GetLastError());
+    throw rdr::Win32Exception("SetSecurityDescriptorGroupp", GetLastError());
   if (!SetSecurityDescriptorDacl(&absSD, TRUE, dacl, FALSE))
-    throw rdr::SystemException("SetSecurityDescriptorDacl", GetLastError());
+    throw rdr::Win32Exception("SetSecurityDescriptorDacl", GetLastError());
   DWORD sdSize = GetSecurityDescriptorLength(&absSD);
   SecurityDescriptorPtr sd(sdSize);
   if (!MakeSelfRelativeSD(&absSD, (PSECURITY_DESCRIPTOR)sd.ptr, &sdSize))
-    throw rdr::SystemException("MakeSelfRelativeSD", GetLastError());
+    throw rdr::Win32Exception("MakeSelfRelativeSD", GetLastError());
   return sd.takeSD();
 }

--- a/win/rfb_win32/Service.cxx
+++ b/win/rfb_win32/Service.cxx
@@ -115,7 +115,7 @@ Service::start() {
     vlog.error("unable to set shutdown parameters: %lu", GetLastError());
   service = this;
   if (!StartServiceCtrlDispatcher(entry))
-    throw SystemException("unable to start service", GetLastError());
+    throw Win32Exception("unable to start service", GetLastError());
 }
 
 void
@@ -335,7 +335,7 @@ bool rfb::win32::registerService(const char* name,
   // - Open the SCM
   ServiceHandle scm = OpenSCManager(nullptr, nullptr, SC_MANAGER_CREATE_SERVICE);
   if (!scm)
-    throw rdr::SystemException("unable to open Service Control Manager", GetLastError());
+    throw rdr::Win32Exception("unable to open Service Control Manager", GetLastError());
 
   // - Add the service
   ServiceHandle handle = CreateService(scm,
@@ -344,7 +344,7 @@ bool rfb::win32::registerService(const char* name,
     SERVICE_AUTO_START, SERVICE_ERROR_IGNORE,
     cmdline.c_str(), nullptr, nullptr, nullptr, nullptr, nullptr);
   if (!handle)
-    throw rdr::SystemException("unable to create service", GetLastError());
+    throw rdr::Win32Exception("unable to create service", GetLastError());
 
   // - Set a description
   SERVICE_DESCRIPTION sdesc = {(LPTSTR)desc};
@@ -380,14 +380,14 @@ bool rfb::win32::unregisterService(const char* name) {
   // - Open the SCM
   ServiceHandle scm = OpenSCManager(nullptr, nullptr, SC_MANAGER_CREATE_SERVICE);
   if (!scm)
-    throw rdr::SystemException("unable to open Service Control Manager", GetLastError());
+    throw rdr::Win32Exception("unable to open Service Control Manager", GetLastError());
 
   // - Create the service
   ServiceHandle handle = OpenService(scm, name, SC_MANAGER_ALL_ACCESS);
   if (!handle)
-    throw rdr::SystemException("unable to locate the service", GetLastError());
+    throw rdr::Win32Exception("unable to locate the service", GetLastError());
   if (!DeleteService(handle))
-    throw rdr::SystemException("unable to remove the service", GetLastError());
+    throw rdr::Win32Exception("unable to remove the service", GetLastError());
 
   // - Register the event log source
   RegKey hk;
@@ -407,16 +407,16 @@ bool rfb::win32::startService(const char* name) {
   // - Open the SCM
   ServiceHandle scm = OpenSCManager(nullptr, nullptr, SC_MANAGER_CONNECT);
   if (!scm)
-    throw rdr::SystemException("unable to open Service Control Manager", GetLastError());
+    throw rdr::Win32Exception("unable to open Service Control Manager", GetLastError());
 
   // - Locate the service
   ServiceHandle handle = OpenService(scm, name, SERVICE_START);
   if (!handle)
-    throw rdr::SystemException("unable to open the service", GetLastError());
+    throw rdr::Win32Exception("unable to open the service", GetLastError());
 
   // - Start the service
   if (!StartService(handle, 0, nullptr))
-    throw rdr::SystemException("unable to start the service", GetLastError());
+    throw rdr::Win32Exception("unable to start the service", GetLastError());
 
   Sleep(500);
 
@@ -427,17 +427,17 @@ bool rfb::win32::stopService(const char* name) {
   // - Open the SCM
   ServiceHandle scm = OpenSCManager(nullptr, nullptr, SC_MANAGER_CONNECT);
   if (!scm)
-    throw rdr::SystemException("unable to open Service Control Manager", GetLastError());
+    throw rdr::Win32Exception("unable to open Service Control Manager", GetLastError());
 
   // - Locate the service
   ServiceHandle handle = OpenService(scm, name, SERVICE_STOP);
   if (!handle)
-    throw rdr::SystemException("unable to open the service", GetLastError());
+    throw rdr::Win32Exception("unable to open the service", GetLastError());
 
   // - Start the service
   SERVICE_STATUS status;
   if (!ControlService(handle, SERVICE_CONTROL_STOP, &status))
-    throw rdr::SystemException("unable to stop the service", GetLastError());
+    throw rdr::Win32Exception("unable to stop the service", GetLastError());
 
   Sleep(500);
 
@@ -448,17 +448,17 @@ DWORD rfb::win32::getServiceState(const char* name) {
   // - Open the SCM
   ServiceHandle scm = OpenSCManager(nullptr, nullptr, SC_MANAGER_CONNECT);
   if (!scm)
-    throw rdr::SystemException("unable to open Service Control Manager", GetLastError());
+    throw rdr::Win32Exception("unable to open Service Control Manager", GetLastError());
 
   // - Locate the service
   ServiceHandle handle = OpenService(scm, name, SERVICE_INTERROGATE);
   if (!handle)
-    throw rdr::SystemException("unable to open the service", GetLastError());
+    throw rdr::Win32Exception("unable to open the service", GetLastError());
 
   // - Get the service status
   SERVICE_STATUS status;
   if (!ControlService(handle, SERVICE_CONTROL_INTERROGATE, (SERVICE_STATUS*)&status))
-    throw rdr::SystemException("unable to query the service", GetLastError());
+    throw rdr::Win32Exception("unable to query the service", GetLastError());
 
   return status.dwCurrentState;
 }

--- a/win/rfb_win32/SocketManager.cxx
+++ b/win/rfb_win32/SocketManager.cxx
@@ -67,7 +67,7 @@ void SocketManager::addListener(network::SocketListener* sock_,
     flags |= FD_ADDRESS_LIST_CHANGE;
   try {
     if (event && (WSAEventSelect(sock_->getFd(), event, flags) == SOCKET_ERROR))
-      throw rdr::SystemException("Unable to select on listener", WSAGetLastError());
+      throw rdr::SocketException("Unable to select on listener", WSAGetLastError());
 
     // requestAddressChangeEvents MUST happen after WSAEventSelect, so that the socket is non-blocking
     if (acn)
@@ -184,7 +184,7 @@ int SocketManager::checkTimeouts() {
       if (j->second.sock->outStream().hasBufferedData())
         eventMask |= FD_WRITE;
       if (WSAEventSelect(j->second.sock->getFd(), j->first, eventMask) == SOCKET_ERROR)
-        throw rdr::SystemException("unable to adjust WSAEventSelect:%u", WSAGetLastError());
+        throw rdr::SocketException("unable to adjust WSAEventSelect:%u", WSAGetLastError());
     }
   }
 
@@ -234,11 +234,11 @@ void SocketManager::processEvent(HANDLE event) {
 
       // Fetch why this event notification triggered
       if (WSAEnumNetworkEvents(ci.sock->getFd(), event, &network_events) == SOCKET_ERROR)
-        throw rdr::SystemException("unable to get WSAEnumNetworkEvents:%u", WSAGetLastError());
+        throw rdr::SocketException("unable to get WSAEnumNetworkEvents:%u", WSAGetLastError());
 
       // Cancel event notification for this socket
       if (WSAEventSelect(ci.sock->getFd(), event, 0) == SOCKET_ERROR)
-        throw rdr::SystemException("unable to disable WSAEventSelect:%u", WSAGetLastError());
+        throw rdr::SocketException("unable to disable WSAEventSelect:%u", WSAGetLastError());
 
       // Reset the event object
       WSAResetEvent(event);
@@ -266,7 +266,7 @@ void SocketManager::processEvent(HANDLE event) {
       if (ci.sock->outStream().hasBufferedData())
         eventMask |= FD_WRITE;
       if (WSAEventSelect(ci.sock->getFd(), event, eventMask) == SOCKET_ERROR)
-        throw rdr::SystemException("unable to re-enable WSAEventSelect:%u", WSAGetLastError());
+        throw rdr::SocketException("unable to re-enable WSAEventSelect:%u", WSAGetLastError());
     } catch (rdr::Exception& e) {
       vlog.error("%s", e.str());
       remSocket(ci.sock);

--- a/win/rfb_win32/TsSessions.cxx
+++ b/win/rfb_win32/TsSessions.cxx
@@ -35,7 +35,7 @@ namespace win32 {
     if (processId == (DWORD)-1)
       processId = GetCurrentProcessId();
     if (!ProcessIdToSessionId(GetCurrentProcessId(), &id))
-      throw rdr::SystemException("ProcessIdToSessionId", GetLastError());
+      throw rdr::Win32Exception("ProcessIdToSessionId", GetLastError());
   }
 
   ProcessSessionId mySessionId;
@@ -57,7 +57,7 @@ namespace win32 {
     ConsoleSessionId console;
     vlog.info("Console session is %lu", console.id);
     if (!WTSConnectSession(sessionId, console.id, (PTSTR)"", 0))
-      throw rdr::SystemException("Unable to connect session to Console", GetLastError());
+      throw rdr::Win32Exception("Unable to connect session to Console", GetLastError());
 
     // Lock the newly connected session, for security
     LockWorkStation();

--- a/win/rfb_win32/WMCursor.cxx
+++ b/win/rfb_win32/WMCursor.cxx
@@ -45,7 +45,7 @@ WMCursor::getCursorInfo() {
   CURSORINFO info;
   info.cbSize = sizeof(CURSORINFO);
   if (!GetCursorInfo(&info))
-    throw rdr::SystemException("GetCursorInfo failed", GetLastError());
+    throw rdr::Win32Exception("GetCursorInfo failed", GetLastError());
   result.cursor = info.hCursor;
   result.position = Point(info.ptScreenPos.x, info.ptScreenPos.y);
   result.visible = info.flags & CURSOR_SHOWING;

--- a/win/rfb_win32/WMPoller.cxx
+++ b/win/rfb_win32/WMPoller.cxx
@@ -57,7 +57,7 @@ bool
 rfb::win32::WMPoller::checkPollWindow(HWND w) {
   char buffer[128];
   if (!GetClassName(w, buffer, 128))
-    throw rdr::SystemException("unable to get window class:%u", GetLastError());
+    throw rdr::Win32Exception("unable to get window class:%u", GetLastError());
   if ((strcmp(buffer, "tty") != 0) &&
     (strcmp(buffer, "ConsoleWindowClass") != 0)) {
     return false;

--- a/win/rfb_win32/Win32Util.cxx
+++ b/win/rfb_win32/Win32Util.cxx
@@ -46,19 +46,19 @@ FileVersionInfo::FileVersionInfo(const char* filename) {
   {
     Handle file(CreateFile(filename, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
 	  if (file.h == INVALID_HANDLE_VALUE)
-      throw rdr::SystemException("Failed to open file", GetLastError());
+      throw rdr::Win32Exception("Failed to open file", GetLastError());
   }
 
   // Get version info size
   DWORD handle;
   int size = GetFileVersionInfoSize((char*)filename, &handle);
   if (!size)
-    throw rdr::SystemException("GetVersionInfoSize failed", GetLastError());
+    throw rdr::Win32Exception("GetVersionInfoSize failed", GetLastError());
 
   // Get version info
   buf = new char[size];
   if (!GetFileVersionInfo((char*)filename, handle, size, buf))
-    throw rdr::SystemException("GetVersionInfo failed", GetLastError());
+    throw rdr::Win32Exception("GetVersionInfo failed", GetLastError());
 }
 
 FileVersionInfo::~FileVersionInfo() {

--- a/win/vncconfig/Legacy.cxx
+++ b/win/vncconfig/Legacy.cxx
@@ -42,7 +42,7 @@ void LegacyPage::LoadPrefs()
         std::string username;
         try {
           username = UserName();
-        } catch (rdr::SystemException& e) {
+        } catch (rdr::Win32Exception& e) {
           if (e.err != ERROR_NOT_LOGGED_ON)
             throw;
         }

--- a/win/vncconfig/vncconfig.cxx
+++ b/win/vncconfig/vncconfig.cxx
@@ -125,7 +125,7 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE /*prev*/, char* /*cmdLine*/, int /*
 
         // Set the DACL, and don't allow the key to inherit its parent's DACL
         rootKey.setDACL(acl, false);
-      } catch (rdr::SystemException& e) {
+      } catch (rdr::Win32Exception& e) {
         // Something weird happens on NT 4.0 SP5 but I can't reproduce it on other
         // NT 4.0 service pack revisions.
         if (e.err == ERROR_INVALID_PARAMETER) {
@@ -169,7 +169,7 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE /*prev*/, char* /*cmdLine*/, int /*
 #else
       sheet.showPropSheet(nullptr, true, false);
 #endif
-    } catch (rdr::SystemException& e) {
+    } catch (rdr::Win32Exception& e) {
       switch (e.err) {
       case ERROR_ACCESS_DENIED:
         MsgBox(nullptr, "You do not have sufficient access rights to run the VNC Configuration applet",

--- a/win/winvnc/QueryConnectDialog.cxx
+++ b/win/winvnc/QueryConnectDialog.cxx
@@ -74,7 +74,7 @@ void QueryConnectDialog::worker() {
 
 void QueryConnectDialog::initDialog() {
   if (!SetTimer(handle, 1, 1000, nullptr))
-    throw rdr::SystemException("SetTimer", GetLastError());
+    throw rdr::Win32Exception("SetTimer", GetLastError());
   setItemString(IDC_QUERY_HOST, peerIp.c_str());
   if (userName.empty())
     userName = "(anonymous)";

--- a/win/winvnc/VNCServerWin32.cxx
+++ b/win/winvnc/VNCServerWin32.cxx
@@ -188,7 +188,7 @@ int VNCServerWin32::run() {
     while (runServer) {
       result = sockMgr.getMessage(&msg, nullptr, 0, 0);
       if (result < 0)
-        throw rdr::SystemException("getMessage", GetLastError());
+        throw rdr::Win32Exception("getMessage", GetLastError());
       if (!isServiceProcess() && (result == 0))
         break;
       TranslateMessage(&msg);
@@ -196,7 +196,7 @@ int VNCServerWin32::run() {
     }
 
     vlog.debug("Server exited cleanly");
-  } catch (rdr::SystemException &s) {
+  } catch (rdr::Win32Exception &s) {
     vlog.error("%s", s.str());
     result = s.err;
   } catch (rdr::Exception &e) {

--- a/win/winvnc/winvnc.cxx
+++ b/win/winvnc/winvnc.cxx
@@ -177,13 +177,13 @@ static void processParams(int argc, char** argv) {
         // Try to clean up earlier services we've had
         try {
           rfb::win32::unregisterService("WinVNC4");
-        } catch (rdr::SystemException&) {
+        } catch (rdr::Win32Exception&) {
           // Do nothing as we might fail simply because there was no
           // service to remove
         }
         try {
           rfb::win32::unregisterService("TigerVNC Server");
-        } catch (rdr::SystemException&) {
+        } catch (rdr::Win32Exception&) {
         }
 
         if (rfb::win32::registerService(VNCServerService::Name,


### PR DESCRIPTION
Windows has (at least) two error namespaces, both errno and GetLastResult(). These overlap, so it is important we keep track of which one we are dealing with.
    
To make things extra problematic, the BSD socket API normally uses errno, but on Windows it has been mapped in to the GetLastResult() namespace.
    
Try to keep better control of this by using separate classes for the namespaces.
