### PR TITLE
Only announce clipboard for plain text data

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -754,6 +754,11 @@ void Viewport::handleClipboardChange(int source, void *data)
     return;
 #endif
 
+  if (!Fl::clipboard_contains(Fl::clipboard_plain_text)) {
+    vlog.debug("Got non-plain text in local clipboard, ignoring.");
+    return;
+  }
+
   self->clipboardSource = source;
 
   if (!self->hasFocus()) {


### PR DESCRIPTION
FLTK has support for both image and plain text clipboard data, we don't. This means we only send plain text clipboard from the viewer to the server. Some applications can get confused when we announce that clipboard is available and later don't send anything. An example of such an application is QGIS, in the remote session it froze when an image was copied on the client side.

Steps to reproduce:

1. Connect using the vncviewer on Windows
2. In the remote session, open the app QGIS and open the sample project "Bee Farming" (can be downloaded from [here](https://docs.qfield.org/get-started/sample-projects/)).
3. On the Windows side (client-side), copy an image
4. Notice that the QGIS app freezes

Xvnc logs the following:

```
 Tue Oct  1 11:30:06 2024
  Selection:   Remote clipboard announced, grabbing local ownership
  Selection:   Grabbed PRIMARY selection
  Selection:   Grabbed CLIPBOARD selection
  Selection:   Selection request for PRIMARY (type TARGETS)
  Selection:   Selection request for PRIMARY (type UTF8_STRING)
  Selection:   Requesting clipboard data from client
 
 Tue Oct  1 11:30:11 2024
  Selection:   Selection request for PRIMARY (type UTF8_STRING)
  Selection:   Requesting clipboard data from client
 
 Tue Oct  1 11:30:16 2024
  Selection:   Selection request for PRIMARY (type UTF8_STRING)
  Selection:   Requesting clipboard data from client
 
 Tue Oct  1 11:30:21 2024
  Selection:   Selection request for CLIPBOARD (type TARGETS)
```

While vncviewer logs:

```
 Tue Oct 01 11:30:04 2024
  Viewport:    Local clipboard changed whilst not focused, will notify server
              later
 
 Tue Oct 01 11:30:06 2024
  Viewport:    Focus regained after local clipboard change, notifying server
```

The problem for the QGIS application seems to occur when it has been notified by the VNC server that clipboard is available, and then doesn't get anything after asking for it.

This fix means we only call announceClipboard() when the clipboard contains plain text. That means TigerVNC is now more robust and doesn't trigger freezes in buggy applications.