### PR TITLE
Add Nix flake

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -404,3 +404,32 @@ Distribution-Specific Packaging
 
 Configuration for building packages for current versions of RHEL/CentOS
 and Ubuntu LTS can be found under contrib/packages.
+
+
+===============
+Build using Nix
+===============
+
+The perhaps easiest way to build TigerVNC is using Nix.
+
+To install Nix on Linux, macOS or WSL:
+
+  curl --proto '=https' --tlsv1.2 -sSf -L \
+    https://install.determinate.systems/nix | sh -s -- install --determinate
+
+To build native binaries for the current system (supports linux and darwin on
+x86_64 and aarch64):
+
+  nix build .
+
+To build for 64-bit Windows:
+
+  nix build .#windows
+
+To build for 32-bit Windows:
+
+  nix build .#windows32
+
+To build the Java version of the TigerVNC Viewer:
+
+  nix build .#java

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729186406,
+        "narHash": "sha256-Mo0O07tWvUiW5F4O1lEFnaFnb3xVrQ4OnB+bAf0GlUA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73bd40281687e5bd0dadb63b34865231fd20e7e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,113 @@
+{
+  description = "Tiger VNC";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: let
+
+      pname = "tigervnc";
+      version = let
+        cmakeListsContent = builtins.readFile ./CMakeLists.txt;
+        versionMatch =
+          builtins.match ".*set\\(VERSION ([0-9.]+)\\).*" cmakeListsContent;
+      in assert versionMatch != null;
+        builtins.elemAt versionMatch 0;
+      src = ./.;
+      pkgs = import nixpkgs { inherit system; };
+
+      native-build = pkgs.stdenv.mkDerivation {
+        inherit pname version src;
+        nativeBuildInputs = with pkgs; [
+          cmake
+          gettext
+        ];
+        buildInputs = with pkgs; [
+          fltk
+          gmp
+          libjpeg_turbo
+          nettle
+          pam
+          pixman
+          xorg.libXi
+          zlib
+        ];
+      };
+
+      windows-build = is64: let
+        ming = pkgs.pkgsCross.${if is64 then "mingwW64" else "mingw32"};
+        fltk = (ming.fltk.override {
+          zlib = zlib;
+          libjpeg = libjpeg_turbo;
+          withGL = false;
+          withCairo = false;
+          withDocs = false;
+          withShared = false;
+        }).overrideAttrs (old: {
+          meta = old.meta // {
+            # fltk can be built for Windows despite nixpkgs claiming otherwise
+            platforms = ming.lib.platforms.all;
+          };
+        });
+        gmp = ming.gmp.override { withStatic = true; };
+        confStatic = pkg: pkg.overrideAttrs (old: {
+          configureFlags = (old.configureFlags or [])
+                           ++ [ "--disable-shared" "--enable-static" ]; });
+        mcfg = confStatic ming.windows.mcfgthreads;
+        libjpeg_turbo = (ming.libjpeg_turbo.override {
+          enableStatic = true;
+          enableShared = false;
+          enableJpeg8 = true;
+        }).overrideAttrs (old: {
+          CFLAGS = [ "-L${mcfg}/lib" ]; });
+        nettle = confStatic (ming.nettle.override { gmp = gmp; });
+        pixman = ming.pixman.overrideAttrs (old: {
+          mesonFlags = (old.mesonFlags or [])
+                       ++ [ "-Ddefault_library=static" ]; });
+        zlib = ming.zlib.override { shared = false; };
+      in ming.stdenv.mkDerivation {
+        inherit pname version;
+        nativeBuildInputs = with pkgs; [
+          cmake
+          gettext
+        ];
+        buildInputs = [
+          fltk
+          gmp
+          libjpeg_turbo
+          mcfg
+          nettle
+          pixman
+          zlib
+        ];
+        src = ./.;
+        CXXFLAGS = [
+          "-DLC_MESSAGES=0"
+          "-static"
+        ];
+        # Enforce self-contained build. Shared libraries will only be allowed if
+        # included in the output
+        allowedReferences = [];
+      };
+
+      java-build = pkgs.stdenv.mkDerivation {
+        pname = "${pname}-java";
+        inherit version;
+        src = ./java;
+        nativeBuildInputs = with pkgs; [
+          cmake
+          zulu
+        ];
+        installPhase = ''
+          mkdir -p $out/bin
+          cp *.jar $out/bin
+        '';
+      };
+
+    in { packages = {
+           default = native-build;
+           windows = windows-build true;
+           windows32 = windows-build false;
+           java = java-build;
+         }; }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,9 @@
           };
         });
         gmp = ming.gmp.override { withStatic = true; };
+        libiconv = ming.libiconv.override
+          { enableStatic = true; enableShared = false; };
+        libintl = confStatic (ming.libintl.override { inherit libiconv; });
         confStatic = pkg: pkg.overrideAttrs (old: {
           configureFlags = (old.configureFlags or [])
                            ++ [ "--disable-shared" "--enable-static" ]; });
@@ -73,6 +76,8 @@
         buildInputs = [
           fltk
           gmp
+          libiconv
+          libintl
           libjpeg_turbo
           mcfg
           nettle
@@ -81,12 +86,11 @@
         ];
         src = ./.;
         CXXFLAGS = [
-          "-DLC_MESSAGES=0"
           "-static"
         ];
         # Enforce self-contained build. Shared libraries will only be allowed if
-        # included in the output
-        allowedReferences = [];
+        # included in the output. An exception is made for gettext (todo fix).
+        allowedReferences = [ libintl ];
       };
 
       java-build = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
After much failure trying to follow `BUILDING.txt` instructions, I only managed to build using Nix. Contributing a `flake.nix` in case others have similar trouble.

* Supports one-line build for
  * linux x86_64
  * linux aarch64 (not tested)
  * darwin x86_64 (not tested)
  * darwin aarch_64 (not tested)
  * java
  * windows 64-bit
  * windows 32-bit

Marking as **draft** due to a couple of questions:
* NLS support for Windows (separate commit) creates a `vncviewer.exe` with a hard-coded path pointing to `gettext` language support files. Not sure why.
* Not sure if we want to support release builds using Nix.
* Windows builds are almost entirely static, using no `*.dll` files except for `wm_hooks.dll`. Do we want the other builds to also be static?