### PR TITLE
CI: Update Java Matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        java: [ '8', '11', '16' ]
+        java: [ '8', '11', '17', '21' ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup java


### PR DESCRIPTION
Adds 17 LTS and 21 LTS, and removes 16 as it's no longer supported.