### PR TITLE
Use event taps for keyboard grab on macOS

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -848,8 +848,12 @@ int DesktopWindow::handle(int event)
 
 #ifdef __APPLE__
     // Complain to the user if we won't have permission to grab keyboard
-    if (fullscreenSystemKeys && fullscreen_active())
-      cocoa_is_trusted(true);
+    if (fullscreenSystemKeys && fullscreen_active()) {
+      // FIXME: There is some race during initial full screen where we
+      //        fail to give focus to the popup, but we can work around
+      //        it using a timer
+      Fl::add_timeout(0, [](void*) { cocoa_is_trusted(true); }, nullptr);
+    }
 #endif
 
     if (fullscreen_active())

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -846,6 +846,12 @@ int DesktopWindow::handle(int event)
     // Update scroll bars
     repositionWidgets();
 
+#ifdef __APPLE__
+    // Complain to the user if we won't have permission to grab keyboard
+    if (fullscreenSystemKeys && fullscreen_active())
+      cocoa_is_trusted(true);
+#endif
+
     if (fullscreen_active())
       maybeGrabKeyboard();
     else

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -1066,20 +1066,8 @@ void DesktopWindow::fullscreen_on()
     }
 
   }
-#ifdef __APPLE__
-  // This is a workaround for a bug in FLTK, see: https://github.com/fltk/fltk/pull/277
-  int savedLevel = -1;
-  if (shown())
-    savedLevel = cocoa_get_level(this);
-#endif
+
   fullscreen_screens(top, bottom, left, right);
-#ifdef __APPLE__
-  // This is a workaround for a bug in FLTK, see: https://github.com/fltk/fltk/pull/277
-  if (savedLevel != -1) {
-    if (cocoa_get_level(this) != savedLevel)
-      cocoa_set_level(this, savedLevel);
-  }
-#endif
 
   if (!fullscreen_active())
     fullscreen();

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -44,6 +44,10 @@
 #include "fltk/Fl_Monitor_Arrangement.h"
 #include "fltk/Fl_Navigation.h"
 
+#ifdef __APPLE__
+#include "cocoa.h"
+#endif
+
 #include <FL/Fl.H>
 #include <FL/Fl_Tabs.H>
 #include <FL/Fl_Button.H>
@@ -883,6 +887,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
                                                       CHECK_MIN_WIDTH,
                                                       CHECK_HEIGHT,
                                                       _("Pass system keys directly to server (full screen)")));
+    systemKeysCheckbox->callback(handleSystemKeys, this);
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
     menuKeyChoice = new Fl_Choice(LBLLEFT(tx, ty, 150, CHOICE_HEIGHT, _("Menu key")));
@@ -1127,6 +1132,20 @@ void OptionsDialog::handleRSAAES(Fl_Widget* /*widget*/, void *data)
     dialog->authVncCheckbox->value(true);
     dialog->authPlainCheckbox->value(true);
   }
+}
+
+
+void OptionsDialog::handleSystemKeys(Fl_Widget* /*widget*/, void* data)
+{
+#ifdef __APPLE__
+  OptionsDialog* dialog = (OptionsDialog*)data;
+
+  // Pop up the access dialog if needed
+  if (dialog->systemKeysCheckbox->value())
+    cocoa_is_trusted(true);
+#else
+  (void)data;
+#endif
 }
 
 

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -65,6 +65,8 @@ protected:
   static void handleX509(Fl_Widget *widget, void *data);
   static void handleRSAAES(Fl_Widget *widget, void *data);
 
+  static void handleSystemKeys(Fl_Widget *widget, void *data);
+
   static void handleClipboard(Fl_Widget *widget, void *data);
 
   static void handleFullScreenMode(Fl_Widget *widget, void *data);

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -23,6 +23,8 @@ class Fl_Window;
 
 void cocoa_prevent_native_fullscreen(Fl_Window *win);
 
+bool cocoa_is_trusted(bool prompt=false);
+
 bool cocoa_tap_keyboard();
 void cocoa_untap_keyboard();
 

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -26,8 +26,8 @@ void cocoa_prevent_native_fullscreen(Fl_Window *win);
 int cocoa_get_level(Fl_Window *win);
 void cocoa_set_level(Fl_Window *win, int level);
 
-int cocoa_capture_displays(Fl_Window *win);
-void cocoa_release_displays(Fl_Window *win);
+bool cocoa_tap_keyboard();
+void cocoa_untap_keyboard();
 
 typedef struct CGColorSpace *CGColorSpaceRef;
 

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -23,9 +23,6 @@ class Fl_Window;
 
 void cocoa_prevent_native_fullscreen(Fl_Window *win);
 
-int cocoa_get_level(Fl_Window *win);
-void cocoa_set_level(Fl_Window *win, int level);
-
 bool cocoa_tap_keyboard();
 void cocoa_untap_keyboard();
 

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -42,22 +42,6 @@ void cocoa_prevent_native_fullscreen(Fl_Window *win)
 #endif
 }
 
-int cocoa_get_level(Fl_Window *win)
-{
-  NSWindow *nsw;
-  nsw = (NSWindow*)fl_xid(win);
-  assert(nsw);
-  return [nsw level];
-}
-
-void cocoa_set_level(Fl_Window *win, int level)
-{
-  NSWindow *nsw;
-  nsw = (NSWindow*)fl_xid(win);
-  assert(nsw);
-  [nsw setLevel:level];
-}
-
 static bool cocoa_is_trusted()
 {
   CFStringRef keys[1];

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -20,15 +20,17 @@
 #include <config.h>
 #endif
 
-#include <FL/Fl.H>
+#include <assert.h>
+#include <dlfcn.h>
+
 #include <FL/Fl_Window.H>
 #include <FL/x.H>
 
 #import <Cocoa/Cocoa.h>
+#import <ApplicationServices/ApplicationServices.h>
 
-#include <core/Rect.h>
-
-static bool captured = false;
+static CFMachPortRef event_tap;
+static CFRunLoopSourceRef tap_source;
 
 void cocoa_prevent_native_fullscreen(Fl_Window *win)
 {
@@ -56,86 +58,125 @@ void cocoa_set_level(Fl_Window *win, int level)
   [nsw setLevel:level];
 }
 
-int cocoa_capture_displays(Fl_Window *win)
+static bool cocoa_is_trusted()
 {
-  NSWindow *nsw;
+  CFStringRef keys[1];
+  CFBooleanRef values[1];
+  CFDictionaryRef options;
 
-  nsw = (NSWindow*)fl_xid(win);
-  assert(nsw);
+  Boolean trusted;
 
-  CGDisplayCount count;
-  CGDirectDisplayID displays[16];
+#if !defined(MAC_OS_X_VERSION_10_9) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9
+  // FIXME: Raise system requirements so this isn't needed
+  void *lib;
+  typedef Boolean (*AXIsProcessTrustedWithOptionsRef)(CFDictionaryRef);
+  AXIsProcessTrustedWithOptionsRef AXIsProcessTrustedWithOptions;
+  CFStringRef kAXTrustedCheckOptionPrompt;
 
-  int sx, sy, sw, sh;
-  core::Rect windows_rect, screen_rect;
+  lib = dlopen(nullptr, 0);
+  if (lib == nullptr)
+    return false;
 
-  windows_rect.setXYWH(win->x(), win->y(), win->w(), win->h());
+  AXIsProcessTrustedWithOptions =
+    (AXIsProcessTrustedWithOptionsRef)dlsym(lib, "AXIsProcessTrustedWithOptions");
 
-  if (CGGetActiveDisplayList(16, displays, &count) != kCGErrorSuccess)
-    return 1;
+  dlclose(lib);
 
-  if (count != (unsigned)Fl::screen_count())
-    return 1;
+  if (AXIsProcessTrustedWithOptions == nullptr)
+    return false;
 
-  for (int i = 0; i < Fl::screen_count(); i++) {
-    Fl::screen_xywh(sx, sy, sw, sh, i);
+  kAXTrustedCheckOptionPrompt = CFSTR("AXTrustedCheckOptionPrompt");
+#endif
 
-    screen_rect.setXYWH(sx, sy, sw, sh);
-    if (screen_rect.enclosed_by(windows_rect)) {
-      if (CGDisplayCapture(displays[i]) != kCGErrorSuccess)
-        return 1;
+  keys[0] = kAXTrustedCheckOptionPrompt;
+  values[0] = kCFBooleanTrue;
+  options = CFDictionaryCreate(kCFAllocatorDefault,
+                               (const void**)keys,
+                               (const void**)values, 1,
+                               &kCFCopyStringDictionaryKeyCallBacks,
+                               &kCFTypeDictionaryValueCallBacks);
+  if (options == nullptr)
+    return false;
 
-    } else {
-      // A display might have been captured with the previous
-      // monitor selection. In that case we don't want to keep
-      // it when its no longer inside the window_rect.
-      CGDisplayRelease(displays[i]);
-    }
-  }
+  trusted = AXIsProcessTrustedWithOptions(options);
+  CFRelease(options);
 
-  captured = true;
-
-  if ([nsw level] == CGShieldingWindowLevel())
-    return 0;
-
-  [nsw setLevel:CGShieldingWindowLevel()];
-
-  // We're not getting put in front of the shielding window in many
-  // cases on macOS 13, despite setLevel: being documented as also
-  // pushing the window to the front. So let's explicitly move it.
-  [nsw orderFront:nsw];
-
-  return 0;
+  return trusted;
 }
 
-void cocoa_release_displays(Fl_Window *win)
+static CGEventRef cocoa_event_tap(CGEventTapProxy /*proxy*/,
+                                  CGEventType type, CGEventRef event,
+                                  void* /*refcon*/)
 {
-  NSWindow *nsw;
-  int newlevel;
+  ProcessSerialNumber psn;
+  OSErr err;
 
-  if (captured)
-    CGReleaseAllDisplays();
+  // We should just be getting these events, but just in case
+  if ((type != kCGEventKeyDown) &&
+      (type != kCGEventKeyUp) &&
+      (type != kCGEventFlagsChanged))
+    return event;
 
-  captured = false;
+  // Redirect the event to us, no matter the original target
+  // (note that this will loop if kCGAnnotatedSessionEventTap is used)
+  err = GetCurrentProcess(&psn);
+  if (err != noErr)
+    return event;
 
-  nsw = (NSWindow*)fl_xid(win);
-  assert(nsw);
+  // FIXME: CGEventPostToPid() in macOS 10.11+
+  CGEventPostToPSN(&psn, event);
 
-  // Someone else has already changed the level of this window
-  if ([nsw level] != CGShieldingWindowLevel())
+  // Stop delivery to original target
+  return nullptr;
+}
+
+bool cocoa_tap_keyboard()
+{
+  CGEventMask mask;
+
+  if (event_tap != nullptr)
+    return true;
+
+  if (!cocoa_is_trusted())
+    return false;
+
+  mask = CGEventMaskBit(kCGEventKeyDown) |
+         CGEventMaskBit(kCGEventKeyUp) |
+         CGEventMaskBit(kCGEventFlagsChanged);
+
+  // Cannot be kCGAnnotatedSessionEventTap as window manager intercepts
+  // before that (e.g. Ctrl+Up)
+  event_tap = CGEventTapCreate(kCGSessionEventTap,
+                               kCGHeadInsertEventTap,
+                               kCGEventTapOptionDefault,
+                               mask, cocoa_event_tap, nullptr);
+  if (event_tap == nullptr)
+    return false;
+
+  tap_source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault,
+                                             event_tap, 0);
+  CFRunLoopAddSource(CFRunLoopGetCurrent(), tap_source,
+                     kCFRunLoopCommonModes);
+
+  return true;
+}
+
+void cocoa_untap_keyboard()
+{
+  if (event_tap == nullptr)
     return;
 
-  // FIXME: Store the previous level somewhere so we don't have to hard
-  //        code a level here.
-  if (win->fullscreen_active() && win->contains(Fl::focus()))
-    newlevel = NSStatusWindowLevel;
-  else
-    newlevel = NSNormalWindowLevel;
+  // Need to explicitly disable the tap first, or we get a short delay
+  // where all events are dropped
+  CGEventTapEnable(event_tap, false);
 
-  // Only change if different as the level change also moves the window
-  // to the top of that level.
-  if ([nsw level] != newlevel)
-    [nsw setLevel:newlevel];
+  CFRunLoopRemoveSource(CFRunLoopGetCurrent(), tap_source,
+                        kCFRunLoopCommonModes);
+  CFRelease(tap_source);
+  tap_source = nullptr;
+
+  CFRelease(event_tap);
+  event_tap = nullptr;
 }
 
 CGColorSpaceRef cocoa_win_color_space(Fl_Window *win)

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -29,6 +29,8 @@
 #import <Cocoa/Cocoa.h>
 #import <ApplicationServices/ApplicationServices.h>
 
+#include "cocoa.h"
+
 static CFMachPortRef event_tap;
 static CFRunLoopSourceRef tap_source;
 
@@ -42,7 +44,7 @@ void cocoa_prevent_native_fullscreen(Fl_Window *win)
 #endif
 }
 
-static bool cocoa_is_trusted()
+bool cocoa_is_trusted(bool prompt)
 {
   CFStringRef keys[1];
   CFBooleanRef values[1];
@@ -73,7 +75,7 @@ static bool cocoa_is_trusted()
 #endif
 
   keys[0] = kAXTrustedCheckOptionPrompt;
-  values[0] = kCFBooleanTrue;
+  values[0] = prompt ? kCFBooleanTrue : kCFBooleanFalse;
   options = CFDictionaryCreate(kCFAllocatorDefault,
                                (const void**)keys,
                                (const void**)values, 1,


### PR DESCRIPTION
These are the slightly more proper way to grab the keyboard and macOS and is what similar applications do. It avoids a lot of issues we have, e.g., problems with multiple monitors.
    
Unfortunately we need to have the user explicitly approve this (which really is a good thing, security wise), and Apple have chosen to mark this feature as only for accessibility.

Pre-requisite for windowed keyboard grabbing in #1375.