### PR TITLE
rename maximize param

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -174,7 +174,7 @@ DesktopWindow::DesktopWindow(int w, int h, const char *name,
 #ifdef __APPLE__
   // On OS X we can do the maximize thing properly before the
   // window is showned. Other platforms handled further down...
-  if (maximize) {
+  if (::maximize) {
     int dummy;
     Fl::screen_work_area(dummy, dummy, w, h, geom_x, geom_y);
   }
@@ -208,7 +208,7 @@ DesktopWindow::DesktopWindow(int w, int h, const char *name,
   // maximized property on Windows and X11 before showing the window.
   // See STR #2083 and STR #2178
 #ifndef __APPLE__
-  if (maximize) {
+  if (::maximize) {
     maximizeWindow();
   }
 #endif


### PR DESCRIPTION
[ 72%] Building CXX object vncviewer/CMakeFiles/vncviewer.dir/DesktopWindow.cxx.o /Users/fedo/repos/tigervnc/vncviewer/DesktopWindow.cxx:177:7: error: reference to non-static member function must be called; did you mean to call it with no arguments?
  177 |   if (maximize) {
      |       ^~~~~~~~
      |               ()
/Users/fedo/repos/tigervnc/vncviewer/DesktopWindow.cxx:177:7: error: value of type 'void' is not contextually convertible to 'bool'
  177 |   if (maximize) {
      |       ^~~~~~~~
2 errors generated.
make[2]: *** [vncviewer/CMakeFiles/vncviewer.dir/DesktopWindow.cxx.o] Error 1
make[1]: *** [vncviewer/CMakeFiles/vncviewer.dir/all] Error 2
make: *** [all] Error 2