### PR TITLE
Remove unnecessary mutexes

### DIFF
--- a/common/rfb/Configuration.cxx
+++ b/common/rfb/Configuration.cxx
@@ -32,13 +32,9 @@
 
 #include <stdexcept>
 
-#include <os/Mutex.h>
-
 #include <rfb/util.h>
 #include <rfb/Configuration.h>
 #include <rfb/LogWriter.h>
-
-#define LOCK_CONFIG os::AutoMutex a(mutex)
 
 #include <rdr/HexOutStream.h>
 #include <rdr/HexInStream.h>
@@ -209,12 +205,9 @@ VoidParameter::VoidParameter(const char* name_, const char* desc_,
 
   _next = conf->head;
   conf->head = this;
-
-  mutex = new os::Mutex();
 }
 
 VoidParameter::~VoidParameter() {
-  delete mutex;
 }
 
 const char*
@@ -385,7 +378,6 @@ StringParameter::~StringParameter() {
 }
 
 bool StringParameter::setParam(const char* v) {
-  LOCK_CONFIG;
   if (immutable) return true;
   if (!v)
     throw std::invalid_argument("setParam(<null>) not allowed");
@@ -399,7 +391,6 @@ std::string StringParameter::getDefaultStr() const {
 }
 
 std::string StringParameter::getValueStr() const {
-  LOCK_CONFIG;
   return value;
 }
 
@@ -438,7 +429,6 @@ bool BinaryParameter::setParam(const char* v) {
 }
 
 void BinaryParameter::setParam(const uint8_t* v, size_t len) {
-  LOCK_CONFIG;
   if (immutable) return; 
   vlog.debug("Set %s(Binary)", getName());
   delete [] value;
@@ -457,12 +447,10 @@ std::string BinaryParameter::getDefaultStr() const {
 }
 
 std::string BinaryParameter::getValueStr() const {
-  LOCK_CONFIG;
   return binToHex(value, length);
 }
 
 std::vector<uint8_t> BinaryParameter::getData() const {
-  LOCK_CONFIG;
   std::vector<uint8_t> out(length);
   memcpy(out.data(), value, length);
   return out;

--- a/common/rfb/Configuration.h
+++ b/common/rfb/Configuration.h
@@ -50,8 +50,6 @@
 #include <string>
 #include <vector>
 
-namespace os { class Mutex; }
-
 namespace rfb {
   class VoidParameter;
   struct ParameterIterator;
@@ -188,8 +186,6 @@ namespace rfb {
     bool immutable;
     const char* name;
     const char* description;
-
-    os::Mutex* mutex;
   };
 
   class AliasParameter : public VoidParameter {

--- a/common/rfb/Decoder.h
+++ b/common/rfb/Decoder.h
@@ -19,6 +19,7 @@
 #ifndef __RFB_DECODER_H__
 #define __RFB_DECODER_H__
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace rdr {

--- a/common/rfb/H264Decoder.cxx
+++ b/common/rfb/H264Decoder.cxx
@@ -29,13 +29,10 @@
 #include <rdr/MemInStream.h>
 #include <rdr/InStream.h>
 #include <rdr/OutStream.h>
-#include <rfb/LogWriter.h>
 #include <rfb/H264Decoder.h>
 #include <rfb/H264DecoderContext.h>
 
 using namespace rfb;
-
-static LogWriter vlog("H264Decoder");
 
 enum rectFlags {
   resetContext       = 0x1,

--- a/common/rfb/H264Decoder.cxx
+++ b/common/rfb/H264Decoder.cxx
@@ -53,7 +53,6 @@ H264Decoder::~H264Decoder()
 
 void H264Decoder::resetContexts()
 {
-  os::AutoMutex lock(&mutex);
   for (H264DecoderContext* context : contexts)
     delete context;
   contexts.clear();
@@ -61,7 +60,6 @@ void H264Decoder::resetContexts()
 
 H264DecoderContext* H264Decoder::findContext(const Rect& r)
 {
-  os::AutoMutex m(&mutex);
   for (H264DecoderContext* context : contexts)
     if (context->isEqualRect(r))
       return context;
@@ -118,7 +116,6 @@ void H264Decoder::decodeRect(const Rect& r, const uint8_t* buffer,
 
   if (!ctx)
   {
-    os::AutoMutex lock(&mutex);
     if (contexts.size() >= MAX_H264_INSTANCES)
     {
       H264DecoderContext* excess_ctx = contexts.front();

--- a/common/rfb/H264Decoder.cxx
+++ b/common/rfb/H264Decoder.cxx
@@ -134,9 +134,6 @@ void H264Decoder::decodeRect(const Rect& r, const uint8_t* buffer,
     contexts.push_back(ctx);
   }
 
-  if (!ctx->isReady())
-    throw std::runtime_error("H264Decoder: Context is not ready");
-
   if (!len)
     return;
 

--- a/common/rfb/H264Decoder.cxx
+++ b/common/rfb/H264Decoder.cxx
@@ -114,6 +114,12 @@ void H264Decoder::decodeRect(const Rect& r, const uint8_t* buffer,
     ctx = findContext(r);
   }
 
+  if (ctx && (reset & resetContext)) {
+    contexts.remove(ctx);
+    delete ctx;
+    ctx = nullptr;
+  }
+
   if (!ctx)
   {
     if (contexts.size() >= MAX_H264_INSTANCES)
@@ -130,9 +136,6 @@ void H264Decoder::decodeRect(const Rect& r, const uint8_t* buffer,
 
   if (!ctx->isReady())
     throw std::runtime_error("H264Decoder: Context is not ready");
-
-  if (reset & resetContext)
-    ctx->reset();
 
   if (!len)
     return;

--- a/common/rfb/H264Decoder.h
+++ b/common/rfb/H264Decoder.h
@@ -23,7 +23,6 @@
 
 #include <deque>
 
-#include <os/Mutex.h>
 #include <rfb/Decoder.h>
 
 namespace rfb {
@@ -44,7 +43,6 @@ namespace rfb {
     void resetContexts();
     H264DecoderContext* findContext(const Rect& r);
 
-    os::Mutex mutex;
     std::deque<H264DecoderContext*> contexts;
   };
 }

--- a/common/rfb/H264Decoder.h
+++ b/common/rfb/H264Decoder.h
@@ -21,7 +21,7 @@
 #ifndef __RFB_H264DECODER_H__
 #define __RFB_H264DECODER_H__
 
-#include <deque>
+#include <list>
 
 #include <rfb/Decoder.h>
 
@@ -43,7 +43,7 @@ namespace rfb {
     void resetContexts();
     H264DecoderContext* findContext(const Rect& r);
 
-    std::deque<H264DecoderContext*> contexts;
+    std::list<H264DecoderContext*> contexts;
   };
 }
 

--- a/common/rfb/H264DecoderContext.cxx
+++ b/common/rfb/H264DecoderContext.cxx
@@ -53,9 +53,3 @@ bool H264DecoderContext::isReady()
 {
   return initialized;
 }
-
-void H264DecoderContext::reset()
-{
-  freeCodec();
-  initCodec();
-}

--- a/common/rfb/H264DecoderContext.cxx
+++ b/common/rfb/H264DecoderContext.cxx
@@ -24,7 +24,6 @@
 
 #include <stdexcept>
 
-#include <os/Mutex.h>
 #include <rfb/LogWriter.h>
 
 #include <rfb/H264DecoderContext.h>
@@ -58,7 +57,6 @@ H264DecoderContext::~H264DecoderContext()
 
 bool H264DecoderContext::isReady()
 {
-  os::AutoMutex lock(&mutex);
   return initialized;
 }
 

--- a/common/rfb/H264DecoderContext.cxx
+++ b/common/rfb/H264DecoderContext.cxx
@@ -22,8 +22,6 @@
 #include <config.h>
 #endif
 
-#include <rfb/LogWriter.h>
-
 #include <rfb/H264DecoderContext.h>
 
 #ifdef H264_LIBAV
@@ -35,8 +33,6 @@
 #endif
 
 using namespace rfb;
-
-static LogWriter vlog("H264DecoderContext");
 
 H264DecoderContext *H264DecoderContext::createContext(const Rect &r)
 {

--- a/common/rfb/H264DecoderContext.cxx
+++ b/common/rfb/H264DecoderContext.cxx
@@ -40,16 +40,9 @@ static LogWriter vlog("H264DecoderContext");
 
 H264DecoderContext *H264DecoderContext::createContext(const Rect &r)
 {
-  H264DecoderContext *ret = new H264DecoderContextType(r);
-  ret->initCodec();
-  return ret;
+  return new H264DecoderContextType(r);
 }
 
 H264DecoderContext::~H264DecoderContext()
 {
-}
-
-bool H264DecoderContext::isReady()
-{
-  return initialized;
 }

--- a/common/rfb/H264DecoderContext.cxx
+++ b/common/rfb/H264DecoderContext.cxx
@@ -22,8 +22,6 @@
 #include <config.h>
 #endif
 
-#include <stdexcept>
-
 #include <rfb/LogWriter.h>
 
 #include <rfb/H264DecoderContext.h>
@@ -43,11 +41,7 @@ static LogWriter vlog("H264DecoderContext");
 H264DecoderContext *H264DecoderContext::createContext(const Rect &r)
 {
   H264DecoderContext *ret = new H264DecoderContextType(r);
-  if (!ret->initCodec())
-  {
-    throw std::runtime_error("H264DecoderContext: Unable to create context");
-  }
-
+  ret->initCodec();
   return ret;
 }
 

--- a/common/rfb/H264DecoderContext.h
+++ b/common/rfb/H264DecoderContext.h
@@ -47,8 +47,8 @@ namespace rfb {
 
       H264DecoderContext(const Rect &r) : rect(r) { initialized = false; }
 
-      virtual bool initCodec() { return false; }
-      virtual void freeCodec() {}
+      virtual void initCodec() = 0;
+      virtual void freeCodec() = 0;
   };
 }
 

--- a/common/rfb/H264DecoderContext.h
+++ b/common/rfb/H264DecoderContext.h
@@ -36,7 +36,6 @@ namespace rfb {
       virtual void decode(const uint8_t* /*h264_buffer*/,
                           uint32_t /*len*/,
                           ModifiablePixelBuffer* /*pb*/) {}
-      void reset();
 
       inline bool isEqualRect(const Rect &r) const { return r == rect; }
       bool isReady();

--- a/common/rfb/H264DecoderContext.h
+++ b/common/rfb/H264DecoderContext.h
@@ -23,7 +23,6 @@
 
 #include <stdint.h>
 
-#include <os/Mutex.h>
 #include <rfb/Rect.h>
 #include <rfb/Decoder.h>
 
@@ -43,7 +42,6 @@ namespace rfb {
       bool isReady();
 
     protected:
-      os::Mutex mutex;
       rfb::Rect rect;
       bool initialized;
 

--- a/common/rfb/H264DecoderContext.h
+++ b/common/rfb/H264DecoderContext.h
@@ -38,16 +38,11 @@ namespace rfb {
                           ModifiablePixelBuffer* /*pb*/) {}
 
       inline bool isEqualRect(const Rect &r) const { return r == rect; }
-      bool isReady();
 
     protected:
       rfb::Rect rect;
-      bool initialized;
 
-      H264DecoderContext(const Rect &r) : rect(r) { initialized = false; }
-
-      virtual void initCodec() = 0;
-      virtual void freeCodec() = 0;
+      H264DecoderContext(const Rect &r) : rect(r) {}
   };
 }
 

--- a/common/rfb/H264LibavDecoderContext.cxx
+++ b/common/rfb/H264LibavDecoderContext.cxx
@@ -44,7 +44,8 @@ using namespace rfb;
 
 static LogWriter vlog("H264LibavDecoderContext");
 
-void H264LibavDecoderContext::initCodec()
+H264LibavDecoderContext::H264LibavDecoderContext(const Rect& r)
+  : H264DecoderContext(r)
 {
   sws = nullptr;
   h264WorkBuffer = nullptr;
@@ -80,20 +81,16 @@ void H264LibavDecoderContext::initCodec()
     av_frame_free(&frame);
     throw std::runtime_error("Could not open video codec");
   }
-
-  initialized = true;
 }
 
-void H264LibavDecoderContext::freeCodec() {
-  if (!initialized)
-    return;
+H264LibavDecoderContext::~H264LibavDecoderContext()
+{
   av_parser_close(parser);
   avcodec_free_context(&avctx);
   av_frame_free(&rgbFrame);
   av_frame_free(&frame);
   sws_freeContext(sws);
   free(h264WorkBuffer);
-  initialized = false;
 }
 
 // We need to reallocate buffer because AVPacket uses non-const pointer.
@@ -120,8 +117,6 @@ uint8_t* H264LibavDecoderContext::makeH264WorkBuffer(const uint8_t* buffer, uint
 void H264LibavDecoderContext::decode(const uint8_t* h264_in_buffer,
                                      uint32_t len,
                                      ModifiablePixelBuffer* pb) {
-  if (!initialized)
-    return;
   uint8_t* h264_work_buffer = makeH264WorkBuffer(h264_in_buffer, len);
 
 #ifdef FFMPEG_INIT_PACKET_DEPRECATED

--- a/common/rfb/H264LibavDecoderContext.cxx
+++ b/common/rfb/H264LibavDecoderContext.cxx
@@ -42,8 +42,6 @@ using namespace rfb;
 static LogWriter vlog("H264LibavDecoderContext");
 
 bool H264LibavDecoderContext::initCodec() {
-  os::AutoMutex lock(&mutex);
-
   sws = nullptr;
   h264WorkBuffer = nullptr;
   h264WorkBufferLength = 0;
@@ -93,8 +91,6 @@ bool H264LibavDecoderContext::initCodec() {
 }
 
 void H264LibavDecoderContext::freeCodec() {
-  os::AutoMutex lock(&mutex);
-
   if (!initialized)
     return;
   av_parser_close(parser);
@@ -130,7 +126,6 @@ uint8_t* H264LibavDecoderContext::makeH264WorkBuffer(const uint8_t* buffer, uint
 void H264LibavDecoderContext::decode(const uint8_t* h264_in_buffer,
                                      uint32_t len,
                                      ModifiablePixelBuffer* pb) {
-  os::AutoMutex lock(&mutex);
   if (!initialized)
     return;
   uint8_t* h264_work_buffer = makeH264WorkBuffer(h264_in_buffer, len);

--- a/common/rfb/H264LibavDecoderContext.h
+++ b/common/rfb/H264LibavDecoderContext.h
@@ -38,7 +38,7 @@ namespace rfb {
                   ModifiablePixelBuffer* pb) override;
 
     protected:
-      bool initCodec() override;
+      void initCodec() override;
       void freeCodec() override;
 
     private:

--- a/common/rfb/H264LibavDecoderContext.h
+++ b/common/rfb/H264LibavDecoderContext.h
@@ -31,15 +31,11 @@ extern "C" {
 namespace rfb {
   class H264LibavDecoderContext : public H264DecoderContext {
     public:
-      H264LibavDecoderContext(const Rect &r) : H264DecoderContext(r) {}
-      ~H264LibavDecoderContext() { freeCodec(); }
+      H264LibavDecoderContext(const Rect &r);
+      ~H264LibavDecoderContext();
 
       void decode(const uint8_t* h264_buffer, uint32_t len,
                   ModifiablePixelBuffer* pb) override;
-
-    protected:
-      void initCodec() override;
-      void freeCodec() override;
 
     private:
       uint8_t* makeH264WorkBuffer(const uint8_t* buffer, uint32_t len);

--- a/common/rfb/H264WinDecoderContext.cxx
+++ b/common/rfb/H264WinDecoderContext.cxx
@@ -42,7 +42,8 @@ static LogWriter vlog("H264WinDecoderContext");
 static GUID CLSID_VideoProcessorMFT = { 0x88753b26, 0x5b24, 0x49bd, { 0xb2, 0xe7, 0xc, 0x44, 0x5c, 0x78, 0xc9, 0x82 } };
 #endif
 
-void H264WinDecoderContext::initCodec()
+H264WinDecoderContext::H264WinDecoderContext(const Rect &r)
+  : H264DecoderContext(r)
 {
   if (FAILED(MFStartup(MF_VERSION, MFSTARTUP_LITE)))
     throw std::runtime_error("Could not initialize MediaFoundation");
@@ -130,13 +131,9 @@ void H264WinDecoderContext::initCodec()
 
   input_sample->AddBuffer(input_buffer);
   decoded_sample->AddBuffer(decoded_buffer);
-
-  initialized = true;
 }
 
-void H264WinDecoderContext::freeCodec() {
-  if (!initialized)
-    return;
+H264WinDecoderContext::~H264WinDecoderContext() {
   SAFE_RELEASE(decoder)
   SAFE_RELEASE(converter)
   SAFE_RELEASE(input_sample)
@@ -146,15 +143,11 @@ void H264WinDecoderContext::freeCodec() {
   SAFE_RELEASE(decoded_buffer)
   SAFE_RELEASE(converted_buffer)
   MFShutdown();
-  initialized = false;
 }
 
 void H264WinDecoderContext::decode(const uint8_t* h264_buffer,
                                    uint32_t len,
                                    ModifiablePixelBuffer* pb) {
-  if (!initialized)
-    return;
-
   if (FAILED(input_buffer->SetCurrentLength(len)))
   {
     input_buffer->Release();

--- a/common/rfb/H264WinDecoderContext.cxx
+++ b/common/rfb/H264WinDecoderContext.cxx
@@ -27,7 +27,6 @@
 #include <wmcodecdsp.h>
 #define SAFE_RELEASE(obj) if (obj) { obj->Release(); obj = nullptr; }
 
-#include <os/Mutex.h>
 #include <rfb/LogWriter.h>
 #include <rfb/PixelBuffer.h>
 #include <rfb/H264WinDecoderContext.h>
@@ -42,8 +41,6 @@ static GUID CLSID_VideoProcessorMFT = { 0x88753b26, 0x5b24, 0x49bd, { 0xb2, 0xe7
 #endif
 
 bool H264WinDecoderContext::initCodec() {
-  os::AutoMutex lock(&mutex);
-
   if (FAILED(MFStartup(MF_VERSION, MFSTARTUP_LITE)))
   {
     vlog.error("Could not initialize MediaFoundation");
@@ -146,8 +143,6 @@ bool H264WinDecoderContext::initCodec() {
 }
 
 void H264WinDecoderContext::freeCodec() {
-  os::AutoMutex lock(&mutex);
-
   if (!initialized)
     return;
   SAFE_RELEASE(decoder)
@@ -165,7 +160,6 @@ void H264WinDecoderContext::freeCodec() {
 void H264WinDecoderContext::decode(const uint8_t* h264_buffer,
                                    uint32_t len,
                                    ModifiablePixelBuffer* pb) {
-  os::AutoMutex lock(&mutex);
   if (!initialized)
     return;
 

--- a/common/rfb/H264WinDecoderContext.h
+++ b/common/rfb/H264WinDecoderContext.h
@@ -30,15 +30,11 @@
 namespace rfb {
   class H264WinDecoderContext : public H264DecoderContext {
     public:
-      H264WinDecoderContext(const Rect &r) : H264DecoderContext(r) {};
-      ~H264WinDecoderContext() { freeCodec(); }
+      H264WinDecoderContext(const Rect &r);
+      ~H264WinDecoderContext();
 
       void decode(const uint8_t* h264_buffer, uint32_t len,
                   ModifiablePixelBuffer* pb) override;
-
-    protected:
-      void initCodec() override;
-      void freeCodec() override;
 
     private:
       LONG stride;

--- a/common/rfb/H264WinDecoderContext.h
+++ b/common/rfb/H264WinDecoderContext.h
@@ -37,7 +37,7 @@ namespace rfb {
                   ModifiablePixelBuffer* pb) override;
 
     protected:
-      bool initCodec() override;
+      void initCodec() override;
       void freeCodec() override;
 
     private:

--- a/common/rfb/Logger_file.cxx
+++ b/common/rfb/Logger_file.cxx
@@ -26,8 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <os/Mutex.h>
-
 #include <rfb/Logger_file.h>
 
 using namespace rfb;
@@ -37,19 +35,15 @@ Logger_File::Logger_File(const char* loggerName)
     m_lastLogTime(0)
 {
   m_filename[0] = '\0';
-  mutex = new os::Mutex();
 }
 
 Logger_File::~Logger_File()
 {
   closeFile();
-  delete mutex;
 }
 
 void Logger_File::write(int /*level*/, const char *logname, const char *message)
 {
-  os::AutoMutex a(mutex);
-
   if (!m_file) {
     if (m_filename[0] == '\0')
       return;

--- a/common/rfb/Logger_file.h
+++ b/common/rfb/Logger_file.h
@@ -26,8 +26,6 @@
 
 #include <rfb/Logger.h>
 
-namespace os { class Mutex; }
-
 namespace rfb {
 
   class Logger_File : public Logger {
@@ -47,7 +45,6 @@ namespace rfb {
     char m_filename[PATH_MAX];
     FILE* m_file;
     time_t m_lastLogTime;
-    os::Mutex* mutex;
   };
 
   bool initFileLogger(const char* filename);


### PR DESCRIPTION
Remove many of the existing mutexes as they are either not needed, or provide incomplete protection and hence give a false sense of security.

We are currently only running viewer decoders on threads, so there is very little code that needs thread safety. And we can probably make do by writing that code in a way that doesn't access global objects¹.

The exception is the WinVNC code, which is very thread heavy. But it is unmaintained and will not be a blocker for this.

¹ I'd really like to enforce this, but I don't know how without sprinkling a thread id check in lots of places.