### PR TITLE
Pointer position is not valid without pointer screen, so validate pointer screen before obtaining pointer position on screen.

### DIFF
--- a/unix/xserver/hw/vnc/vncInput.c
+++ b/unix/xserver/hw/vnc/vncInput.c
@@ -168,14 +168,21 @@ void vncPointerMove(int x, int y)
 void vncGetPointerPos(int *x, int *y)
 {
 	if (vncPointerDev != NULL) {
-		ScreenPtr ptrScreen;
+		/* Pointer position is not valid without pointer
+		 * screen, so validate pointer screen before obtaining
+		 * pointer position on screen. This is also important
+		 * to prevent miPointerGetPosition() from being called
+		 * when the pointer is disabled, as this could result
+		 * in a segmentation fault.
+		 */
+		ScreenPtr ptrScreen = miPointerGetScreen(vncPointerDev);
+		if (ptrScreen != NULL) {
+			miPointerGetPosition(vncPointerDev, &cursorPosX, &cursorPosY);
 
-		miPointerGetPosition(vncPointerDev, &cursorPosX, &cursorPosY);
-
-		/* Pointer coordinates are screen relative */
-		ptrScreen = miPointerGetScreen(vncPointerDev);
-		cursorPosX += ptrScreen->x;
-		cursorPosY += ptrScreen->y;
+			/* Pointer coordinates are screen relative */
+			cursorPosX += ptrScreen->x;
+			cursorPosY += ptrScreen->y;
+		}
 	}
 
 	*x = cursorPosX;


### PR DESCRIPTION
This is also important to prevent miPointerGetPosition() from being called when the pointer is disabled, as this could result in a segmentation fault.

In Xfce, it is really easy to disable the mouse and a few users have done it. Without this fix, VNC would fail immediately with a segmentation fault, and this would persist after VNC restart. The traceback:

```
(EE) 
(EE) Backtrace:
(EE) 0: /usr/bin/Xvnc (OsLookupColor+0x13d) [0x55e5397b59cd]
(EE) 1: /lib64/libpthread.so.0 (funlockfile+0x50) [0x7f30306a2d70]
(EE) 2: /usr/bin/Xvnc (miPointerGetPosition+0x47) [0x55e5397a19e7]
(EE) 3: /usr/bin/Xvnc (vncGetPointerPos+0x36) [0x55e5397d2486]
(EE) 4: /usr/bin/Xvnc (_ZN14XserverDesktop12blockHandlerEPi+0x101) [0x55e5397d0561]
(EE) 5: /usr/bin/Xvnc (vncCallBlockHandlers+0x31) [0x55e5397c3a61]
(EE) 6: /usr/bin/Xvnc (BlockHandler+0x40) [0x55e539765ac0]
(EE) 7: /usr/bin/Xvnc (WaitForSomething+0xd9) [0x55e5397afd09]
(EE) 8: /usr/bin/Xvnc (Dispatch+0xab) [0x55e539760e4b]
(EE) 9: /usr/bin/Xvnc (dix_main+0x376) [0x55e539765136]
(EE) 10: /lib64/libc.so.6 (__libc_start_main+0xe5) [0x7f302e4fb8a5]
(EE) 11: /usr/bin/Xvnc (_start+0x2e) [0x55e539678f2e]
(EE) 
(EE) Segmentation fault at address 0x2c
(EE) 
Fatal server error:
(EE) Caught signal 11 (Segmentation fault). Server aborting
(EE) 
```

The issue is that miPointerGetPosition will try to dereference NULL if the pointer is disabled.

I have adjusted the code to be more correct, and no longer fail. I didn't see a way to specifically check if the mouse was disabled, but I didn't need to as miPointerGetScreen validates that both the pointer is not null before dereferencing the pointer to the pointer screen, returning NULL if either of these are NULL. It is also more correct to only fetch the position on the screen if there is a valid screen set. This change is just more correct, and doesn't fail with segmentation fault.

However, the user symptoms go from VNC failing with segmentation fault, to the user being unable to use the mouse. This is exactly what they asked for, and it should be more self-evident as they will see that their mouse is now listed as not enabled in the UI, but it's difficult to re-enable mouse without an enabled mouse. I do not know why the users think this is a good idea - but at least with this fix it will behave exactly as they configured it to.

The prior code happened to fail in miPointerGetPosition first, but it is also worth noting that were that prior code to "work", by picking arbitrary position information like (0, 0) in the case that the pointer is disabled, the TigerVNC code following that dereferences the screen to get the screen (x, y) would have also failed with segmentation fault, due to attempt to dereference NULL. This change addresses this later issue as well.
