### PR TITLE
Better resize rate limiting

### DIFF
--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -30,6 +30,7 @@
 #include <rfb/Exception.h>
 #include <rfb/clipboardTypes.h>
 #include <rfb/fenceTypes.h>
+#include <rfb/screenTypes.h>
 #include <rfb/CMsgReader.h>
 #include <rfb/CMsgWriter.h>
 #include <rfb/CSecurity.h>
@@ -431,6 +432,11 @@ void CConnection::setExtendedDesktopSize(unsigned reason,
   decoder.flush();
 
   CMsgHandler::setExtendedDesktopSize(reason, result, w, h, layout);
+
+  if ((reason == reasonClient) && (result != resultSuccess)) {
+    vlog.error("SetDesktopSize failed: %d", result);
+    return;
+  }
 
   if (continuousUpdates)
     writer()->writeEnableContinuousUpdates(true, 0, 0,

--- a/common/rfb/ComparingUpdateTracker.cxx
+++ b/common/rfb/ComparingUpdateTracker.cxx
@@ -258,10 +258,12 @@ void ComparingUpdateTracker::logStats()
 
   ratio = (double)totalPixels / missedPixels;
 
-  vlog.info("%s in / %s out",
-            siPrefix(totalPixels, "pixels").c_str(),
-            siPrefix(missedPixels, "pixels").c_str());
-  vlog.info("(1:%g ratio)", ratio);
+  // FIXME: This gets spammed on each session resize, so we'll have to
+  //        keep it on a debug level for now
+  vlog.debug("%s in / %s out",
+             siPrefix(totalPixels, "pixels").c_str(),
+             siPrefix(missedPixels, "pixels").c_str());
+  vlog.debug("(1:%g ratio)", ratio);
 
   totalPixels = missedPixels = 0;
 }

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -37,6 +37,7 @@
 #include <rfb/Security.h>
 #include <rfb/fenceTypes.h>
 #include <rfb/Timer.h>
+#include <rfb/screenTypes.h>
 #include <network/TcpSocket.h>
 #ifndef WIN32
 #include <network/UnixSocket.h>
@@ -314,6 +315,16 @@ void CConn::initDone()
   int encNum = encodingNum(::preferredEncoding);
   if (encNum != -1)
     setPreferredEncoding(encNum);
+}
+
+void CConn::setExtendedDesktopSize(unsigned reason, unsigned result,
+                                   int w, int h,
+                                   const rfb::ScreenSet& layout)
+{
+  CConnection::setExtendedDesktopSize(reason, result, w, h, layout);
+
+  if (reason == reasonClient)
+    desktop->setDesktopSizeDone(result);
 }
 
 // setName() is called when the desktop name changes

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -35,7 +35,6 @@
 #include <rfb/Hostname.h>
 #include <rfb/LogWriter.h>
 #include <rfb/Security.h>
-#include <rfb/screenTypes.h>
 #include <rfb/fenceTypes.h>
 #include <rfb/Timer.h>
 #include <network/TcpSocket.h>
@@ -315,28 +314,6 @@ void CConn::initDone()
   int encNum = encodingNum(::preferredEncoding);
   if (encNum != -1)
     setPreferredEncoding(encNum);
-}
-
-// setDesktopSize() is called when the desktop size changes (including when
-// it is set initially).
-void CConn::setDesktopSize(int w, int h)
-{
-  CConnection::setDesktopSize(w,h);
-  resizeFramebuffer();
-}
-
-// setExtendedDesktopSize() is a more advanced version of setDesktopSize()
-void CConn::setExtendedDesktopSize(unsigned reason, unsigned result,
-                                   int w, int h, const rfb::ScreenSet& layout)
-{
-  CConnection::setExtendedDesktopSize(reason, result, w, h, layout);
-
-  if ((reason == reasonClient) && (result != resultSuccess)) {
-    vlog.error(_("SetDesktopSize failed: %d"), result);
-    return;
-  }
-
-  resizeFramebuffer();
 }
 
 // setName() is called when the desktop name changes

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -57,11 +57,6 @@ public:
 
   void initDone() override;
 
-  void setDesktopSize(int w, int h) override;
-  void setExtendedDesktopSize(unsigned reason, unsigned result,
-                              int w, int h,
-                              const rfb::ScreenSet& layout) override;
-
   void setName(const char* name) override;
 
   void setColourMapEntries(int firstColour, int nColours,

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -57,6 +57,10 @@ public:
 
   void initDone() override;
 
+  void setExtendedDesktopSize(unsigned reason, unsigned result,
+                              int w, int h,
+                              const rfb::ScreenSet& layout) override;
+
   void setName(const char* name) override;
 
   void setColourMapEntries(int firstColour, int nColours,

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -83,7 +83,7 @@ DesktopWindow::DesktopWindow(int w, int h, const char *name,
                              CConn* cc_)
   : Fl_Window(w, h), cc(cc_), offscreen(nullptr), overlay(nullptr),
     firstUpdate(true),
-    delayedFullscreen(false), delayedDesktopSize(false),
+    delayedFullscreen(false), sentDesktopSize(false),
     keyboardGrabbed(false), mouseGrabbed(false),
     statsLastUpdates(0), statsLastPixels(0), statsLastPosition(0),
     statsGraph(nullptr)
@@ -339,15 +339,8 @@ void DesktopWindow::setName(const char *name)
 void DesktopWindow::updateWindow()
 {
   if (firstUpdate) {
-    if (cc->server.supportsSetDesktopSize) {
-      // Hack: Wait until we're in the proper mode and position until
-      // resizing things, otherwise we might send the wrong thing.
-      if (delayedFullscreen)
-        delayedDesktopSize = true;
-      else
-        handleDesktopSize();
-    }
     firstUpdate = false;
+    remoteResize();
   }
 
   viewport->updateWindow();
@@ -697,21 +690,10 @@ void DesktopWindow::resize(int x, int y, int w, int h)
   Fl_Window::resize(x, y, w, h);
 
   if (resizing) {
-    // Try to get the remote size to match our window size, provided
-    // the following conditions are true:
-    //
-    // a) The user has this feature turned on
-    // b) The server supports it
-    // c) We're not still waiting for a chance to handle DesktopSize
-    // d) We're not still waiting for startup fullscreen to kick in
-    //
-    if (not firstUpdate and not delayedFullscreen and
-        ::remoteResize and cc->server.supportsSetDesktopSize) {
-      // We delay updating the remote desktop as we tend to get a flood
-      // of resize events as the user is dragging the window.
-      Fl::remove_timeout(handleResizeTimeout, this);
-      Fl::add_timeout(0.5, handleResizeTimeout, this);
-    }
+    // We delay updating the remote desktop as we tend to get a flood
+    // of resize events as the user is dragging the window.
+    Fl::remove_timeout(handleResizeTimeout, this);
+    Fl::add_timeout(0.5, handleResizeTimeout, this);
 
     repositionWidgets();
   }
@@ -1290,32 +1272,13 @@ void DesktopWindow::maximizeWindow()
 }
 
 
-void DesktopWindow::handleDesktopSize()
-{
-  if (strcmp(desktopSize, "") != 0) {
-    int width, height;
-
-    // An explicit size has been requested
-
-    if (sscanf(desktopSize, "%dx%d", &width, &height) != 2)
-      return;
-
-    remoteResize(width, height);
-  } else if (::remoteResize) {
-    // No explicit size, but remote resizing is on so make sure it
-    // matches whatever size the window ended up being
-    remoteResize(w(), h());
-  }
-}
-
-
 void DesktopWindow::handleResizeTimeout(void *data)
 {
   DesktopWindow *self = (DesktopWindow *)data;
 
   assert(self);
 
-  self->remoteResize(self->w(), self->h());
+  self->remoteResize();
 }
 
 
@@ -1330,10 +1293,32 @@ void DesktopWindow::reconfigureFullscreen(void* /*data*/)
 }
 
 
-void DesktopWindow::remoteResize(int width, int height)
+void DesktopWindow::remoteResize()
 {
+  int width, height;
   ScreenSet layout;
   ScreenSet::const_iterator iter;
+
+  if (!::remoteResize)
+    return;
+  if (!cc->server.supportsSetDesktopSize)
+    return;
+
+  // Don't pester the server with a resize until we have our final size
+  if (delayedFullscreen)
+    return;
+
+  width = w();
+  height = h();
+
+  if (!sentDesktopSize && (strcmp(desktopSize, "") != 0)) {
+    // An explicit size has been requested
+
+    if (sscanf(desktopSize, "%dx%d", &width, &height) != 2)
+      return;
+
+    sentDesktopSize = true;
+  }
 
   if (!fullscreen_active() || (width > w()) || (height > h())) {
     // In windowed mode (or the framebuffer is so large that we need
@@ -1573,11 +1558,7 @@ void DesktopWindow::handleFullscreenTimeout(void *data)
   assert(self);
 
   self->delayedFullscreen = false;
-
-  if (self->delayedDesktopSize) {
-    self->handleDesktopSize();
-    self->delayedDesktopSize = false;
-  }
+  self->remoteResize();
 }
 
 void DesktopWindow::scrollTo(int x, int y)

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -55,6 +55,9 @@ public:
   // Resize the current framebuffer, but retain the contents
   void resizeFramebuffer(int new_w, int new_h);
 
+  // A previous call to writeSetDesktopSize() has completed
+  void setDesktopSizeDone(unsigned result);
+
   // New image for the locally rendered cursor
   void setCursor(int width, int height, const rfb::Point& hotspot,
                  const uint8_t* data);
@@ -131,6 +134,9 @@ private:
   bool firstUpdate;
   bool delayedFullscreen;
   bool sentDesktopSize;
+
+  bool pendingRemoteResize;
+  struct timeval lastResize;
 
   bool keyboardGrabbed;
   bool mouseGrabbed;

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -101,10 +101,9 @@ private:
 
   void maximizeWindow();
 
-  void handleDesktopSize();
   static void handleResizeTimeout(void *data);
   static void reconfigureFullscreen(void *data);
-  void remoteResize(int width, int height);
+  void remoteResize();
 
   void repositionWidgets();
 
@@ -131,7 +130,7 @@ private:
 
   bool firstUpdate;
   bool delayedFullscreen;
-  bool delayedDesktopSize;
+  bool sentDesktopSize;
 
   bool keyboardGrabbed;
   bool mouseGrabbed;


### PR DESCRIPTION
Be more aggressive with resizing, limiting it to once ever 100 ms instead of after a 500 ms idle period. This avoids unnecessary delays when entering or leaving full screen, or when maximizing.

Fixes #1763.