### PR TITLE
Add SELinux policy rules allowing to create directories under /root

### DIFF
--- a/unix/vncserver/selinux/vncsession.te
+++ b/unix/vncserver/selinux/vncsession.te
@@ -48,6 +48,14 @@ optional_policy(`
 	create_dirs_pattern(vnc_session_t, gconf_home_t, gconf_home_t)
 ')
 
+# Allowed to create /root/.local
+optional_policy(`
+	gen_require(`
+		type admin_home_t;
+	')
+	create_dirs_pattern(vnc_session_t, admin_home_t, admin_home_t)
+')
+
 # Manage TigerVNC files (mainly ~/.local/state/*.log)
 create_dirs_pattern(vnc_session_t, vnc_home_t, vnc_home_t)
 manage_files_pattern(vnc_session_t, vnc_home_t, vnc_home_t)
@@ -88,6 +96,7 @@ optional_policy(`
 	gen_require(`
 		attribute userdomain;
 		type gconf_home_t;
+		type admin_home_t;
 	')
 	userdom_admin_home_dir_filetrans(userdomain, vnc_home_t, dir, ".vnc")
 	userdom_user_home_dir_filetrans(userdomain, vnc_home_t, dir, ".vnc")
@@ -95,5 +104,6 @@ optional_policy(`
 	gnome_config_filetrans(userdomain, vnc_home_t, dir, "tigervnc")
 	gnome_data_filetrans(userdomain, vnc_home_t, dir, "tigervnc")
 	filetrans_pattern(userdomain, gconf_home_t, vnc_home_t, dir, "tigervnc")
+	filetrans_pattern(vnc_session_t, admin_home_t, vnc_home_t, dir, "tigervnc")
 	filetrans_pattern(vnc_session_t, gconf_home_t, vnc_home_t, dir, "tigervnc")
 ')


### PR DESCRIPTION
We have policy that allows to create ~/.local or ~/.config, but we don't have rule that allows the same under /root directory, where we fail in case any of these directories doesn't exist.
