### PR TITLE
Convert unit tests to Google test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
           sudo apt-get install -y libgnutls28-dev nettle-dev libgmp-dev
           sudo apt-get install -y libxtst-dev libxdamage-dev libxfixes-dev libxrandr-dev libpam-dev
           sudo apt-get install -y libavcodec-dev libavutil-dev libswscale-dev
+          sudo apt-get install -y libgtest-dev
       - name: Configure
         run: cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build
       - name: Build
@@ -28,6 +29,15 @@ jobs:
         with:
           name: Linux (Ubuntu)
           path: build/tigervnc-*.tar.gz
+      - name: Test
+        working-directory: build
+        run: ctest --test-dir tests/unit/ --output-junit test-results.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-linux
+          path: build/tests/unit/test-results.xml
 
   build-windows:
     runs-on: windows-latest
@@ -45,7 +55,8 @@ jobs:
           pacman --sync --noconfirm --needed \
             mingw-w64-x86_64-libjpeg-turbo \
             mingw-w64-x86_64-gnutls mingw-w64-x86_64-pixman \
-            mingw-w64-x86_64-nettle mingw-w64-x86_64-gmp
+            mingw-w64-x86_64-nettle mingw-w64-x86_64-gmp \
+            mingw-w64-x86_64-gtest
           # MSYS2 only packages FLTK 1.4 now:
           # https://github.com/msys2/MINGW-packages/issues/22769
           pacman --upgrade --noconfirm --needed \
@@ -64,6 +75,15 @@ jobs:
         with:
           name: Windows
           path: build/release/tigervnc*.exe
+      - name: Test
+        working-directory: build
+        run: ctest --test-dir tests/unit/ --output-junit test-results.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-windows
+          path: build/tests/unit/test-results.xml
 
   build-macos:
     runs-on: macos-latest
@@ -74,6 +94,7 @@ jobs:
         run: |
           brew install fltk@1.3 pixman ffmpeg
           brew install gnutls nettle gmp
+          brew install googletest
           brew link fltk@1.3
       - name: Configure
         run: cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build
@@ -87,6 +108,15 @@ jobs:
         with:
           name: macOS
           path: build/TigerVNC-*.dmg
+      - name: Test
+        working-directory: build
+        run: ctest --test-dir tests/unit/ --output-junit test-results.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-macos
+          path: build/tests/unit/test-results.xml
 
   build-java:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,18 @@
+name: Test report
+
+on:
+  workflow_run:
+    workflows: ['build']
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: /test-results-(.*)/
+          name: Unit tests ($1)
+          path: '*.xml'
+          reporter: java-junit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,8 @@ if(UNIX AND NOT APPLE)
   endif()
 endif()
 
+find_package(GTest)
+
 # Generate config.h and make sure the source finds it
 configure_file(config.h.in config.h)
 add_definitions(-DHAVE_CONFIG_H)

--- a/common/rfb/PixelFormat.h
+++ b/common/rfb/PixelFormat.h
@@ -136,7 +136,7 @@ namespace rfb {
 
     /* Only for testing this class */
     friend void makePixel(const rfb::PixelFormat &, uint8_t *);
-    friend bool verifyPixel(const rfb::PixelFormat &,
+    friend void verifyPixel(const rfb::PixelFormat &,
                             const rfb::PixelFormat &,
                             const uint8_t *);
   };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,4 +6,6 @@ endif()
 add_subdirectory(perf)
 
 # Unit tests
-add_subdirectory(unit)
+if(GTest_FOUND)
+  add_subdirectory(unit)
+endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -15,7 +15,8 @@ add_executable(conv conv.cxx)
 target_link_libraries(conv rfb)
 
 add_executable(convertlf convertlf.cxx)
-target_link_libraries(convertlf core)
+target_link_libraries(convertlf core GTest::gtest_main)
+gtest_discover_tests(convertlf)
 
 add_executable(gesturehandler gesturehandler.cxx ../../vncviewer/GestureHandler.cxx)
 target_link_libraries(gesturehandler core)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -33,7 +33,8 @@ target_link_libraries(pixelformat rfb GTest::gtest_main)
 gtest_discover_tests(pixelformat)
 
 add_executable(unicode unicode.cxx)
-target_link_libraries(unicode core)
+target_link_libraries(unicode core GTest::gtest_main)
+gtest_discover_tests(unicode)
 
 add_executable(emulatemb emulatemb.cxx ../../vncviewer/EmulateMB.cxx)
 target_include_directories(emulatemb SYSTEM PUBLIC ${GETTEXT_INCLUDE_DIR})

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,7 +13,8 @@ target_link_libraries(configargs rfb GTest::gtest_main)
 gtest_discover_tests(configargs)
 
 add_executable(conv conv.cxx)
-target_link_libraries(conv rfb)
+target_link_libraries(conv rfb GTest::gtest_main)
+gtest_discover_tests(conv)
 
 add_executable(convertlf convertlf.cxx)
 target_link_libraries(convertlf core GTest::gtest_main)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,3 +1,10 @@
+include(GoogleTest)
+
+# Google Test requires a new C++ standard
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
+
+enable_testing()
+
 include_directories(${CMAKE_SOURCE_DIR}/common)
 include_directories(${CMAKE_SOURCE_DIR}/vncviewer)
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,7 +9,8 @@ include_directories(${CMAKE_SOURCE_DIR}/common)
 include_directories(${CMAKE_SOURCE_DIR}/vncviewer)
 
 add_executable(configargs configargs.cxx)
-target_link_libraries(configargs rfb)
+target_link_libraries(configargs rfb GTest::gtest_main)
+gtest_discover_tests(configargs)
 
 add_executable(conv conv.cxx)
 target_link_libraries(conv rfb)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -32,4 +32,5 @@ target_link_libraries(unicode core)
 
 add_executable(emulatemb emulatemb.cxx ../../vncviewer/EmulateMB.cxx)
 target_include_directories(emulatemb SYSTEM PUBLIC ${GETTEXT_INCLUDE_DIR})
-target_link_libraries(emulatemb core ${GETTEXT_LIBRARIES})
+target_link_libraries(emulatemb core ${GETTEXT_LIBRARIES} GTest::gtest_main)
+gtest_discover_tests(emulatemb)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -29,7 +29,8 @@ target_link_libraries(hostport network GTest::gtest_main)
 gtest_discover_tests(hostport)
 
 add_executable(pixelformat pixelformat.cxx)
-target_link_libraries(pixelformat rfb)
+target_link_libraries(pixelformat rfb GTest::gtest_main)
+gtest_discover_tests(pixelformat)
 
 add_executable(unicode unicode.cxx)
 target_link_libraries(unicode core)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,7 +21,8 @@ target_link_libraries(convertlf core GTest::gtest_main)
 gtest_discover_tests(convertlf)
 
 add_executable(gesturehandler gesturehandler.cxx ../../vncviewer/GestureHandler.cxx)
-target_link_libraries(gesturehandler core)
+target_link_libraries(gesturehandler core GTest::gtest_main)
+gtest_discover_tests(gesturehandler)
 
 add_executable(hostport hostport.cxx)
 target_link_libraries(hostport network GTest::gtest_main)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -22,7 +22,8 @@ add_executable(gesturehandler gesturehandler.cxx ../../vncviewer/GestureHandler.
 target_link_libraries(gesturehandler core)
 
 add_executable(hostport hostport.cxx)
-target_link_libraries(hostport network)
+target_link_libraries(hostport network GTest::gtest_main)
+gtest_discover_tests(hostport)
 
 add_executable(pixelformat pixelformat.cxx)
 target_link_libraries(pixelformat rfb)

--- a/tests/unit/configargs.cxx
+++ b/tests/unit/configargs.cxx
@@ -20,8 +20,7 @@
 #include <config.h>
 #endif
 
-#include <stdio.h>
-#include <string.h>
+#include <gtest/gtest.h>
 
 #include <core/Configuration.h>
 
@@ -29,22 +28,10 @@ static core::BoolParameter boolparam("boolparam", "", false);
 static core::IntParameter intparam("intparam", "", 0);
 static core::StringParameter strparam("strparam", "", "");
 
-#define ASSERT_EQ_I(expr, val) if ((expr) != (val)) { \
-  printf("FAILED on line %d (%s equals %d, expected %d)\n", __LINE__, #expr, (int)(expr), (int)(val)); \
-  return; \
-}
-
-#define ASSERT_EQ_S(expr, val) if (strcmp((expr), (val)) != 0) { \
-  printf("FAILED on line %d (%s equals %s, expected %s)\n", __LINE__, #expr, (const char*)(expr), (const char*)(val)); \
-  return; \
-}
-
-static void test_args()
+TEST(ConfigArgs, args)
 {
   int ret;
   std::vector<const char*> argv;
-
-  printf("%s: ", __func__);
 
   boolparam.setParam(true);
   intparam.setParam(1);
@@ -54,38 +41,34 @@ static void test_args()
   argv = {"prog" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 0);
-  ASSERT_EQ_I(ret, 0);
-  ASSERT_EQ_I(boolparam, true);
-  ASSERT_EQ_I(intparam, 1);
-  ASSERT_EQ_S(strparam, "test");
+  EXPECT_EQ(ret, 0);
+  EXPECT_EQ(boolparam, true);
+  EXPECT_EQ(intparam, 1);
+  EXPECT_STREQ(strparam, "test");
 
   // A bunch of standard arguments
   argv = {"prog", "arg1", "arg2", "arg3" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 2);
-  ASSERT_EQ_I(ret, 0);
-  ASSERT_EQ_I(boolparam, true);
-  ASSERT_EQ_I(intparam, 1);
-  ASSERT_EQ_S(strparam, "test");
+  EXPECT_EQ(ret, 0);
+  EXPECT_EQ(boolparam, true);
+  EXPECT_EQ(intparam, 1);
+  EXPECT_STREQ(strparam, "test");
 
   // A parameter without any dash
   argv = {"prog", "strparam", "intparam" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
-  ASSERT_EQ_I(boolparam, true);
-  ASSERT_EQ_I(intparam, 1);
-  ASSERT_EQ_S(strparam, "test");
-
-  printf("OK\n");
+  EXPECT_EQ(ret, 0);
+  EXPECT_EQ(boolparam, true);
+  EXPECT_EQ(intparam, 1);
+  EXPECT_STREQ(strparam, "test");
 }
 
-static void test_none()
+TEST(ConfigArgs, noDash)
 {
   int ret;
   std::vector<const char*> argv;
-
-  printf("%s: ", __func__);
 
   boolparam.setParam(true);
   intparam.setParam(1);
@@ -95,38 +78,34 @@ static void test_none()
   argv = {"prog", "intparam=12", "34"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(intparam, 12);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(intparam, 12);
 
   // string argument
   argv = {"prog", "strparam=foo", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_S(strparam, "foo");
+  EXPECT_EQ(ret, 1);
+  EXPECT_STREQ(strparam, "foo");
 
   // empty string argument
   argv = {"prog", "strparam=", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_S(strparam, "");
+  EXPECT_EQ(ret, 1);
+  EXPECT_STREQ(strparam, "");
 
   // Bad parameter
   argv = {"prog", "fooparam=123"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
-
-  printf("OK\n");
+  EXPECT_EQ(ret, 0);
 }
 
-static void test_single()
+TEST(ConfigArgs, singleDash)
 {
   int ret;
   std::vector<const char*> argv;
-
-  printf("%s: ", __func__);
 
   boolparam.setParam(true);
   intparam.setParam(1);
@@ -136,66 +115,62 @@ static void test_single()
   argv = {"prog", "-intparam", "12", "34"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 2);
-  ASSERT_EQ_I(intparam, 12);
+  EXPECT_EQ(ret, 2);
+  EXPECT_EQ(intparam, 12);
 
   // int argument with equals
   argv = {"prog", "-intparam=12", "34"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(intparam, 12);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(intparam, 12);
 
   // string argument
   argv = {"prog", "-strparam", "foo", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 2);
-  ASSERT_EQ_S(strparam, "foo");
+  EXPECT_EQ(ret, 2);
+  EXPECT_STREQ(strparam, "foo");
 
   // string argument with equals
   argv = {"prog", "-strparam=foo", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_S(strparam, "foo");
+  EXPECT_EQ(ret, 1);
+  EXPECT_STREQ(strparam, "foo");
 
   // empty string argument with equals
   argv = {"prog", "-strparam=", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_S(strparam, "");
+  EXPECT_EQ(ret, 1);
+  EXPECT_STREQ(strparam, "");
 
   // Missing argument
   intparam.setParam(1);
   argv = {"prog", "-intparam"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
-  ASSERT_EQ_I(intparam, 1);
+  EXPECT_EQ(ret, 0);
+  EXPECT_EQ(intparam, 1);
 
   // Bad parameter
   argv = {"prog", "-fooparam", "123"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
+  EXPECT_EQ(ret, 0);
 
   // Bad parameter with equals
   argv = {"prog", "-fooparam=123"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
-
-  printf("OK\n");
+  EXPECT_EQ(ret, 0);
 }
 
-static void test_double()
+TEST(ConfigArgs, doubleDash)
 {
   int ret;
   std::vector<const char*> argv;
-
-  printf("%s: ", __func__);
 
   boolparam.setParam(true);
   intparam.setParam(1);
@@ -205,159 +180,146 @@ static void test_double()
   argv = {"prog", "--intparam", "12", "34"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 2);
-  ASSERT_EQ_I(intparam, 12);
+  EXPECT_EQ(ret, 2);
+  EXPECT_EQ(intparam, 12);
 
   // int argument with equals
   argv = {"prog", "--intparam=12", "34"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(intparam, 12);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(intparam, 12);
 
   // string argument
   argv = {"prog", "--strparam", "foo", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 2);
-  ASSERT_EQ_S(strparam, "foo");
+  EXPECT_EQ(ret, 2);
+  EXPECT_STREQ(strparam, "foo");
 
   // string argument with equals
   argv = {"prog", "--strparam=foo", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_S(strparam, "foo");
+  EXPECT_EQ(ret, 1);
+  EXPECT_STREQ(strparam, "foo");
 
   // empty string argument with equals
   argv = {"prog", "--strparam=", "bar" };
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_S(strparam, "");
+  EXPECT_EQ(ret, 1);
+  EXPECT_STREQ(strparam, "");
 
   // Missing argument
   intparam.setParam(1);
   argv = {"prog", "--intparam"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
-  ASSERT_EQ_I(intparam, 1);
+  EXPECT_EQ(ret, 0);
+  EXPECT_EQ(intparam, 1);
 
   // Bad parameter
   argv = {"prog", "--fooparam", "123"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
+  EXPECT_EQ(ret, 0);
 
   // Bad parameter with equals
   argv = {"prog", "--fooparam=123"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 0);
-
-  printf("OK\n");
+  EXPECT_EQ(ret, 0);
 }
 
-static void test_bool()
+TEST(ConfigArgs, bool)
 {
   int ret;
   std::vector<const char*> argv;
-
-  printf("%s: ", __func__);
 
   // solo bool (single)
   boolparam.setParam(false);
   argv = {"prog", "-boolparam"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, true);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, true);
 
   // solo bool (double)
   boolparam.setParam(false);
   argv = {"prog", "--boolparam"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, true);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, true);
 
   // bool argument (single)
   boolparam.setParam(true);
   argv = {"prog", "-boolparam", "off", "on"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 2);
-  ASSERT_EQ_I(boolparam, false);
+  EXPECT_EQ(ret, 2);
+  EXPECT_EQ(boolparam, false);
 
   // bool argument (double)
   boolparam.setParam(true);
   argv = {"prog", "--boolparam", "off", "on"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 2);
-  ASSERT_EQ_I(boolparam, false);
+  EXPECT_EQ(ret, 2);
+  EXPECT_EQ(boolparam, false);
 
   // bool argument equals (single)
   boolparam.setParam(true);
   argv = {"prog", "-boolparam=off", "on"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, false);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, false);
 
   // bool argument equals (double)
   boolparam.setParam(true);
   argv = {"prog", "--boolparam=off", "on"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, false);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, false);
 
   // empty bool argument equals (single)
   boolparam.setParam(true);
   argv = {"prog", "-boolparam=", "on"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, true);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, true);
 
   // empty bool argument equals (double)
   boolparam.setParam(true);
   argv = {"prog", "--boolparam=", "on"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, true);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, true);
 
   // bool bad argument (single)
   boolparam.setParam(false);
   argv = {"prog", "-boolparam", "foo", "off"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, true);
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, true);
 
   // bool bad argument (double)
   boolparam.setParam(false);
   argv = {"prog", "--boolparam", "foo", "off"};
   ret = core::Configuration::handleParamArg(argv.size(),
                                             (char**)argv.data(), 1);
-  ASSERT_EQ_I(ret, 1);
-  ASSERT_EQ_I(boolparam, true);
-
-  printf("OK\n");
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(boolparam, true);
 }
 
-int main(int /*argc*/, char** /*argv*/)
+int main(int argc, char** argv)
 {
-  printf("Configuration argument handling test\n");
-
-  test_args();
-  test_none();
-  test_single();
-  test_double();
-  test_bool();
-
-  return 0;
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tests/unit/emulatemb.cxx
+++ b/tests/unit/emulatemb.cxx
@@ -1,4 +1,5 @@
 /* Copyright 2020 Alex Tanskanen <aleta@cendio.se> for Cendio AB
+ * Copyright 2025 Pierre Ossman <ossman@cendio.se> for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,9 +21,11 @@
 #include <config.h>
 #endif
 
-#include <stdio.h>
-#include <vector>
 #include <unistd.h>
+
+#include <vector>
+
+#include <gtest/gtest.h>
 
 #include <core/Rect.h>
 #include <core/Configuration.h>
@@ -58,34 +61,23 @@ void TestClass::sendPointerEvent(const core::Point& pos, uint16_t buttonMask)
   results.push_back(params);
 }
 
-#define ASSERT_EQ(expr, val) if ((expr) != (val)) { \
-  printf("FAILED on line %d (%s equals %d, expected %d)\n", __LINE__, #expr, (int)(expr), (int)(val)); \
-  return; \
-}
-
-void testDisabledOption()
+TEST(EmulateMB, disabledOption)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(false);
   test.filterPointerEvent({0, 10}, left);
 
   ASSERT_EQ(test.results.size(), 1);
 
-  ASSERT_EQ(test.results[0].pos.x, 0);
-  ASSERT_EQ(test.results[0].pos.y, 10);
-  ASSERT_EQ(test.results[0].mask, left);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[0].pos.x, 0);
+  EXPECT_EQ(test.results[0].pos.y, 10);
+  EXPECT_EQ(test.results[0].mask, left);
 }
 
-void testLeftClick()
+TEST(EmulateMB, leftClick)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({0, 0}, left);
@@ -93,26 +85,22 @@ void testLeftClick()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 0);
-  ASSERT_EQ(test.results[0].pos.y, 0);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 0);
+  EXPECT_EQ(test.results[0].pos.y, 0);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 0);
-  ASSERT_EQ(test.results[1].pos.y, 0);
-  ASSERT_EQ(test.results[1].mask, left);
+  EXPECT_EQ(test.results[1].pos.x, 0);
+  EXPECT_EQ(test.results[1].pos.y, 0);
+  EXPECT_EQ(test.results[1].mask, left);
 
-  ASSERT_EQ(test.results[2].pos.x, 0);
-  ASSERT_EQ(test.results[2].pos.y, 0);
-  ASSERT_EQ(test.results[2].mask, empty);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 0);
+  EXPECT_EQ(test.results[2].pos.y, 0);
+  EXPECT_EQ(test.results[2].mask, empty);
 }
 
-void testNormalLeftPress()
+TEST(EmulateMB, normalLeftPress)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({10, 20}, left);
@@ -121,40 +109,32 @@ void testNormalLeftPress()
 
   ASSERT_EQ(test.results.size(), 2);
 
-  ASSERT_EQ(test.results[0].pos.x, 10);
-  ASSERT_EQ(test.results[0].pos.y, 20);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 10);
+  EXPECT_EQ(test.results[0].pos.y, 20);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 10);
-  ASSERT_EQ(test.results[1].pos.y, 20);
-  ASSERT_EQ(test.results[1].mask, left);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[1].pos.x, 10);
+  EXPECT_EQ(test.results[1].pos.y, 20);
+  EXPECT_EQ(test.results[1].mask, left);
 }
 
-void testNormalMiddlePress()
+TEST(EmulateMB, normalMiddlePress)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({0, 0}, middle);
 
   ASSERT_EQ(test.results.size(), 1);
 
-  ASSERT_EQ(test.results[0].pos.x, 0);
-  ASSERT_EQ(test.results[0].pos.y, 0);
-  ASSERT_EQ(test.results[0].mask, middle);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[0].pos.x, 0);
+  EXPECT_EQ(test.results[0].pos.y, 0);
+  EXPECT_EQ(test.results[0].mask, middle);
 }
 
-void testNormalRightPress()
+TEST(EmulateMB, normalRightPress)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({0, 0}, right);
@@ -163,22 +143,18 @@ void testNormalRightPress()
 
   ASSERT_EQ(test.results.size(), 2);
 
-  ASSERT_EQ(test.results[0].pos.x, 0);
-  ASSERT_EQ(test.results[0].pos.y, 0);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 0);
+  EXPECT_EQ(test.results[0].pos.y, 0);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 0);
-  ASSERT_EQ(test.results[1].pos.y, 0);
-  ASSERT_EQ(test.results[1].mask, right);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[1].pos.x, 0);
+  EXPECT_EQ(test.results[1].pos.y, 0);
+  EXPECT_EQ(test.results[1].mask, right);
 }
 
-void testEmulateMiddleMouseButton()
+TEST(EmulateMB, emulateMiddleMouseButton)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({20, 30}, right);
@@ -186,22 +162,18 @@ void testEmulateMiddleMouseButton()
 
   ASSERT_EQ(test.results.size(), 2);
 
-  ASSERT_EQ(test.results[0].pos.x, 20);
-  ASSERT_EQ(test.results[0].pos.y, 30);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 20);
+  EXPECT_EQ(test.results[0].pos.y, 30);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 20);
-  ASSERT_EQ(test.results[1].pos.y, 30);
-  ASSERT_EQ(test.results[1].mask, middle);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[1].pos.x, 20);
+  EXPECT_EQ(test.results[1].pos.y, 30);
+  EXPECT_EQ(test.results[1].mask, middle);
 }
 
-void testLeftReleaseAfterEmulate()
+TEST(EmulateMB, leftReleaseAfterEmulate)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({20, 30}, left);
@@ -210,26 +182,22 @@ void testLeftReleaseAfterEmulate()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 20);
-  ASSERT_EQ(test.results[0].pos.y, 30);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 20);
+  EXPECT_EQ(test.results[0].pos.y, 30);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 20);
-  ASSERT_EQ(test.results[1].pos.y, 30);
-  ASSERT_EQ(test.results[1].mask, middle);
+  EXPECT_EQ(test.results[1].pos.x, 20);
+  EXPECT_EQ(test.results[1].pos.y, 30);
+  EXPECT_EQ(test.results[1].mask, middle);
 
-  ASSERT_EQ(test.results[2].pos.x, 20);
-  ASSERT_EQ(test.results[2].pos.y, 30);
-  ASSERT_EQ(test.results[2].mask, middle);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 20);
+  EXPECT_EQ(test.results[2].pos.y, 30);
+  EXPECT_EQ(test.results[2].mask, middle);
 }
 
-void testRightReleaseAfterEmulate()
+TEST(EmulateMB, rightReleaseAfterEmulate)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({20, 30}, right);
@@ -238,26 +206,22 @@ void testRightReleaseAfterEmulate()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 20);
-  ASSERT_EQ(test.results[0].pos.y, 30);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 20);
+  EXPECT_EQ(test.results[0].pos.y, 30);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 20);
-  ASSERT_EQ(test.results[1].pos.y, 30);
-  ASSERT_EQ(test.results[1].mask, middle);
+  EXPECT_EQ(test.results[1].pos.x, 20);
+  EXPECT_EQ(test.results[1].pos.y, 30);
+  EXPECT_EQ(test.results[1].mask, middle);
 
-  ASSERT_EQ(test.results[2].pos.x, 20);
-  ASSERT_EQ(test.results[2].pos.y, 30);
-  ASSERT_EQ(test.results[2].mask, middle);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 20);
+  EXPECT_EQ(test.results[2].pos.y, 30);
+  EXPECT_EQ(test.results[2].mask, middle);
 }
 
-void testLeftRepressAfterEmulate()
+TEST(EmulateMB, leftRepressAfterEmulate)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({20, 30}, left);
@@ -267,30 +231,26 @@ void testLeftRepressAfterEmulate()
 
   ASSERT_EQ(test.results.size(), 4);
 
-  ASSERT_EQ(test.results[0].pos.x, 20);
-  ASSERT_EQ(test.results[0].pos.y, 30);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 20);
+  EXPECT_EQ(test.results[0].pos.y, 30);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 20);
-  ASSERT_EQ(test.results[1].pos.y, 30);
-  ASSERT_EQ(test.results[1].mask, middle);
+  EXPECT_EQ(test.results[1].pos.x, 20);
+  EXPECT_EQ(test.results[1].pos.y, 30);
+  EXPECT_EQ(test.results[1].mask, middle);
 
-  ASSERT_EQ(test.results[2].pos.x, 20);
-  ASSERT_EQ(test.results[2].pos.y, 30);
-  ASSERT_EQ(test.results[2].mask, middle);
+  EXPECT_EQ(test.results[2].pos.x, 20);
+  EXPECT_EQ(test.results[2].pos.y, 30);
+  EXPECT_EQ(test.results[2].mask, middle);
 
-  ASSERT_EQ(test.results[3].pos.x, 20);
-  ASSERT_EQ(test.results[3].pos.y, 30);
-  ASSERT_EQ(test.results[3].mask, middleAndLeft);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[3].pos.x, 20);
+  EXPECT_EQ(test.results[3].pos.y, 30);
+  EXPECT_EQ(test.results[3].mask, middleAndLeft);
 }
 
-void testRightRepressAfterEmulate()
+TEST(EmulateMB, rightRepressAfterEmulate)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({20, 30}, right);
@@ -300,30 +260,26 @@ void testRightRepressAfterEmulate()
 
   ASSERT_EQ(test.results.size(), 4);
 
-  ASSERT_EQ(test.results[0].pos.x, 20);
-  ASSERT_EQ(test.results[0].pos.y, 30);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 20);
+  EXPECT_EQ(test.results[0].pos.y, 30);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 20);
-  ASSERT_EQ(test.results[1].pos.y, 30);
-  ASSERT_EQ(test.results[1].mask, middle);
+  EXPECT_EQ(test.results[1].pos.x, 20);
+  EXPECT_EQ(test.results[1].pos.y, 30);
+  EXPECT_EQ(test.results[1].mask, middle);
 
-  ASSERT_EQ(test.results[2].pos.x, 20);
-  ASSERT_EQ(test.results[2].pos.y, 30);
-  ASSERT_EQ(test.results[2].mask, middle);
+  EXPECT_EQ(test.results[2].pos.x, 20);
+  EXPECT_EQ(test.results[2].pos.y, 30);
+  EXPECT_EQ(test.results[2].mask, middle);
 
-  ASSERT_EQ(test.results[3].pos.x, 20);
-  ASSERT_EQ(test.results[3].pos.y, 30);
-  ASSERT_EQ(test.results[3].mask, middleAndRight);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[3].pos.x, 20);
+  EXPECT_EQ(test.results[3].pos.y, 30);
+  EXPECT_EQ(test.results[3].mask, middleAndRight);
 }
 
-void testBothPressAfterLeftTimeout()
+TEST(EmulateMB, bothPressAfterLeftTimeout)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({10, 20}, left);
@@ -333,26 +289,22 @@ void testBothPressAfterLeftTimeout()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 10);
-  ASSERT_EQ(test.results[0].pos.y, 20);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 10);
+  EXPECT_EQ(test.results[0].pos.y, 20);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 10);
-  ASSERT_EQ(test.results[1].pos.y, 20);
-  ASSERT_EQ(test.results[1].mask, left);
+  EXPECT_EQ(test.results[1].pos.x, 10);
+  EXPECT_EQ(test.results[1].pos.y, 20);
+  EXPECT_EQ(test.results[1].mask, left);
 
-  ASSERT_EQ(test.results[2].pos.x, 10);
-  ASSERT_EQ(test.results[2].pos.y, 20);
-  ASSERT_EQ(test.results[2].mask, both);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 10);
+  EXPECT_EQ(test.results[2].pos.y, 20);
+  EXPECT_EQ(test.results[2].mask, both);
 }
 
-void testBothPressAfterRightTimeout()
+TEST(EmulateMB, bothPressAfterRightTimeout)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({10, 20}, right);
@@ -362,26 +314,22 @@ void testBothPressAfterRightTimeout()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 10);
-  ASSERT_EQ(test.results[0].pos.y, 20);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 10);
+  EXPECT_EQ(test.results[0].pos.y, 20);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 10);
-  ASSERT_EQ(test.results[1].pos.y, 20);
-  ASSERT_EQ(test.results[1].mask, right);
+  EXPECT_EQ(test.results[1].pos.x, 10);
+  EXPECT_EQ(test.results[1].pos.y, 20);
+  EXPECT_EQ(test.results[1].mask, right);
 
-  ASSERT_EQ(test.results[2].pos.x, 10);
-  ASSERT_EQ(test.results[2].pos.y, 20);
-  ASSERT_EQ(test.results[2].mask, both);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 10);
+  EXPECT_EQ(test.results[2].pos.y, 20);
+  EXPECT_EQ(test.results[2].mask, both);
 }
 
-void testTimeoutAndDrag()
+TEST(EmulateMB, timeoutAndDrag)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({0, 0}, left);
@@ -391,26 +339,22 @@ void testTimeoutAndDrag()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 0);
-  ASSERT_EQ(test.results[0].pos.y, 0);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 0);
+  EXPECT_EQ(test.results[0].pos.y, 0);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 0);
-  ASSERT_EQ(test.results[1].pos.y, 0);
-  ASSERT_EQ(test.results[1].mask, left);
+  EXPECT_EQ(test.results[1].pos.x, 0);
+  EXPECT_EQ(test.results[1].pos.y, 0);
+  EXPECT_EQ(test.results[1].mask, left);
 
-  ASSERT_EQ(test.results[2].pos.x, 10);
-  ASSERT_EQ(test.results[2].pos.y, 10);
-  ASSERT_EQ(test.results[2].mask, left);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 10);
+  EXPECT_EQ(test.results[2].pos.y, 10);
+  EXPECT_EQ(test.results[2].mask, left);
 }
 
-void testDragAndTimeout()
+TEST(EmulateMB, dragAndTimeout)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({10, 10}, left);
@@ -420,26 +364,22 @@ void testDragAndTimeout()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 10);
-  ASSERT_EQ(test.results[0].pos.y, 10);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 10);
+  EXPECT_EQ(test.results[0].pos.y, 10);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 10);
-  ASSERT_EQ(test.results[1].pos.y, 10);
-  ASSERT_EQ(test.results[1].mask, left);
+  EXPECT_EQ(test.results[1].pos.x, 10);
+  EXPECT_EQ(test.results[1].pos.y, 10);
+  EXPECT_EQ(test.results[1].mask, left);
 
-  ASSERT_EQ(test.results[2].pos.x, 30);
-  ASSERT_EQ(test.results[2].pos.y, 30);
-  ASSERT_EQ(test.results[2].mask, left);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 30);
+  EXPECT_EQ(test.results[2].pos.y, 30);
+  EXPECT_EQ(test.results[2].mask, left);
 }
 
-void testDragAndRelease()
+TEST(EmulateMB, dragAndRelease)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   emulateMiddleButton.setParam(true);
   test.filterPointerEvent({10, 10}, left);
@@ -447,46 +387,21 @@ void testDragAndRelease()
 
   ASSERT_EQ(test.results.size(), 3);
 
-  ASSERT_EQ(test.results[0].pos.x, 10);
-  ASSERT_EQ(test.results[0].pos.y, 10);
-  ASSERT_EQ(test.results[0].mask, empty);
+  EXPECT_EQ(test.results[0].pos.x, 10);
+  EXPECT_EQ(test.results[0].pos.y, 10);
+  EXPECT_EQ(test.results[0].mask, empty);
 
-  ASSERT_EQ(test.results[1].pos.x, 10);
-  ASSERT_EQ(test.results[1].pos.y, 10);
-  ASSERT_EQ(test.results[1].mask, left);
+  EXPECT_EQ(test.results[1].pos.x, 10);
+  EXPECT_EQ(test.results[1].pos.y, 10);
+  EXPECT_EQ(test.results[1].mask, left);
 
-  ASSERT_EQ(test.results[2].pos.x, 20);
-  ASSERT_EQ(test.results[2].pos.y, 20);
-  ASSERT_EQ(test.results[2].mask, empty);
-
-  printf("OK\n");
+  EXPECT_EQ(test.results[2].pos.x, 20);
+  EXPECT_EQ(test.results[2].pos.y, 20);
+  EXPECT_EQ(test.results[2].mask, empty);
 }
 
-int main(int /*argc*/, char** /*argv*/)
+int main(int argc, char** argv)
 {
-  testDisabledOption();
-
-  testLeftClick();
-
-  testNormalLeftPress();
-  testNormalMiddlePress();
-  testNormalRightPress();
-
-  testEmulateMiddleMouseButton();
-
-  testLeftReleaseAfterEmulate();
-  testRightReleaseAfterEmulate();
-
-  testLeftRepressAfterEmulate();
-  testRightRepressAfterEmulate();
-
-  testBothPressAfterLeftTimeout();
-  testBothPressAfterRightTimeout();
-
-  testTimeoutAndDrag();
-
-  testDragAndTimeout();
-  testDragAndRelease();
-
-  return 0;
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tests/unit/gesturehandler.cxx
+++ b/tests/unit/gesturehandler.cxx
@@ -1,4 +1,4 @@
-/* Copyright 2020 Pierre Ossman <ossman@cendio.se> for Cendio AB
+/* Copyright 2020-2025 Pierre Ossman <ossman@cendio.se> for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,10 +20,11 @@
 #include <config.h>
 #endif
 
-#include <stdio.h>
 #include <unistd.h>
 
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include "../../vncviewer/GestureHandler.h"
 
@@ -41,17 +42,9 @@ void TestClass::handleGestureEvent(const GestureEvent& event)
   events.push_back(event);
 }
 
-// FIXME: handle doubles
-#define ASSERT_EQ(expr, val) if ((expr) != (val)) { \
-  printf("FAILED on line %d (%s equals %d, expected %d)\n", __LINE__, #expr, (int)(expr), (int)(val)); \
-  return; \
-}
-
-void testOneTapNormal()
+TEST(GestureHandler, oneTapNormal)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
 
@@ -61,24 +54,20 @@ void testOneTapNormal()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureOneTap);
-  ASSERT_EQ(test.events[0].eventX, 20.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureOneTap);
+  EXPECT_EQ(test.events[0].eventX, 20.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
 
-  ASSERT_EQ(test.events[1].type, GestureEnd);
-  ASSERT_EQ(test.events[1].gesture, GestureOneTap);
-  ASSERT_EQ(test.events[1].eventX, 20.0);
-  ASSERT_EQ(test.events[1].eventY, 30.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureEnd);
+  EXPECT_EQ(test.events[1].gesture, GestureOneTap);
+  EXPECT_EQ(test.events[1].eventX, 20.0);
+  EXPECT_EQ(test.events[1].eventY, 30.0);
 }
 
-void testTwoTapNormal()
+TEST(GestureHandler, twoTapNormal)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -93,24 +82,20 @@ void testTwoTapNormal()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoTap);
-  ASSERT_EQ(test.events[0].eventX, 25.0);
-  ASSERT_EQ(test.events[0].eventY, 40.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoTap);
+  EXPECT_EQ(test.events[0].eventX, 25.0);
+  EXPECT_EQ(test.events[0].eventY, 40.0);
 
-  ASSERT_EQ(test.events[1].type, GestureEnd);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoTap);
-  ASSERT_EQ(test.events[1].eventX, 25.0);
-  ASSERT_EQ(test.events[1].eventY, 40.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureEnd);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoTap);
+  EXPECT_EQ(test.events[1].eventX, 25.0);
+  EXPECT_EQ(test.events[1].eventY, 40.0);
 }
 
-void testTwoTapSlowBegin()
+TEST(GestureHandler, twoTapSlowBegin)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
 
@@ -122,15 +107,11 @@ void testTwoTapSlowBegin()
   test.handleTouchEnd(2);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testTwoTapSlowEnd()
+TEST(GestureHandler, twoTapSlowEnd)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -142,15 +123,11 @@ void testTwoTapSlowEnd()
   test.handleTouchEnd(2);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testTwoTapTimeout()
+TEST(GestureHandler, twoTapTimeout)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -162,15 +139,11 @@ void testTwoTapTimeout()
   test.handleTouchEnd(2);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testThreeTapNormal()
+TEST(GestureHandler, threeTapNormal)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -190,24 +163,20 @@ void testThreeTapNormal()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureThreeTap);
-  ASSERT_EQ(test.events[0].eventX, 30.0);
-  ASSERT_EQ(test.events[0].eventY, 40.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureThreeTap);
+  EXPECT_EQ(test.events[0].eventX, 30.0);
+  EXPECT_EQ(test.events[0].eventY, 40.0);
 
-  ASSERT_EQ(test.events[1].type, GestureEnd);
-  ASSERT_EQ(test.events[1].gesture, GestureThreeTap);
-  ASSERT_EQ(test.events[1].eventX, 30.0);
-  ASSERT_EQ(test.events[1].eventY, 40.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureEnd);
+  EXPECT_EQ(test.events[1].gesture, GestureThreeTap);
+  EXPECT_EQ(test.events[1].eventX, 30.0);
+  EXPECT_EQ(test.events[1].eventY, 40.0);
 }
 
-void testThreeTapSlowBegin()
+TEST(GestureHandler, threeTapSlowBegin)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -221,15 +190,11 @@ void testThreeTapSlowBegin()
   test.handleTouchEnd(3);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testThreeTapSlowEnd()
+TEST(GestureHandler, threeTapSlowEnd)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -243,15 +208,11 @@ void testThreeTapSlowEnd()
   test.handleTouchEnd(3);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testThreeTapDrag()
+TEST(GestureHandler, threeTapDrag)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -266,15 +227,11 @@ void testThreeTapDrag()
   test.handleTouchEnd(3);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testThreeTapTimeout()
+TEST(GestureHandler, threeTapTimeout)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 50.0);
@@ -288,15 +245,11 @@ void testThreeTapTimeout()
   test.handleTouchEnd(3);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testDragHoriz()
+TEST(GestureHandler, dragHoriz)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
 
@@ -310,15 +263,15 @@ void testDragHoriz()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 20.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 20.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureDrag);
-  ASSERT_EQ(test.events[1].eventX, 80.0);
-  ASSERT_EQ(test.events[1].eventY, 30.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureDrag);
+  EXPECT_EQ(test.events[1].eventX, 80.0);
+  EXPECT_EQ(test.events[1].eventY, 30.0);
 
   test.events.clear();
 
@@ -326,19 +279,15 @@ void testDragHoriz()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 80.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 80.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
 }
 
-void testDragVert()
+TEST(GestureHandler, dragVert)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
 
@@ -352,15 +301,15 @@ void testDragVert()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 20.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 20.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureDrag);
-  ASSERT_EQ(test.events[1].eventX, 20.0);
-  ASSERT_EQ(test.events[1].eventY, 90.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureDrag);
+  EXPECT_EQ(test.events[1].eventX, 20.0);
+  EXPECT_EQ(test.events[1].eventY, 90.0);
 
   test.events.clear();
 
@@ -368,19 +317,15 @@ void testDragVert()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 20.0);
-  ASSERT_EQ(test.events[0].eventY, 90.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 20.0);
+  EXPECT_EQ(test.events[0].eventY, 90.0);
 }
 
-void testDragDiag()
+TEST(GestureHandler, dragDiag)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 120.0, 130.0);
 
@@ -394,15 +339,15 @@ void testDragDiag()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 120.0);
-  ASSERT_EQ(test.events[0].eventY, 130.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 120.0);
+  EXPECT_EQ(test.events[0].eventY, 130.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureDrag);
-  ASSERT_EQ(test.events[1].eventX, 60.0);
-  ASSERT_EQ(test.events[1].eventY, 70.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureDrag);
+  EXPECT_EQ(test.events[1].eventX, 60.0);
+  EXPECT_EQ(test.events[1].eventY, 70.0);
 
   test.events.clear();
 
@@ -410,19 +355,15 @@ void testDragDiag()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 60.0);
-  ASSERT_EQ(test.events[0].eventY, 70.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 60.0);
+  EXPECT_EQ(test.events[0].eventY, 70.0);
 }
 
-void testLongPressNormal()
+TEST(GestureHandler, longPressNormal)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
 
@@ -433,10 +374,10 @@ void testLongPressNormal()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureLongPress);
-  ASSERT_EQ(test.events[0].eventX, 20.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureLongPress);
+  EXPECT_EQ(test.events[0].eventX, 20.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
 
   test.events.clear();
 
@@ -444,19 +385,15 @@ void testLongPressNormal()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureLongPress);
-  ASSERT_EQ(test.events[0].eventX, 20.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureLongPress);
+  EXPECT_EQ(test.events[0].eventX, 20.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
 }
 
-void testLongPressDrag()
+TEST(GestureHandler, longPressDrag)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
 
@@ -467,10 +404,10 @@ void testLongPressDrag()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureLongPress);
-  ASSERT_EQ(test.events[0].eventX, 20.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureLongPress);
+  EXPECT_EQ(test.events[0].eventX, 20.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
 
   test.events.clear();
 
@@ -478,10 +415,10 @@ void testLongPressDrag()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureUpdate);
-  ASSERT_EQ(test.events[0].gesture, GestureLongPress);
-  ASSERT_EQ(test.events[0].eventX, 120.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
+  EXPECT_EQ(test.events[0].type, GestureUpdate);
+  EXPECT_EQ(test.events[0].gesture, GestureLongPress);
+  EXPECT_EQ(test.events[0].eventX, 120.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
 
   test.events.clear();
 
@@ -489,19 +426,15 @@ void testLongPressDrag()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureLongPress);
-  ASSERT_EQ(test.events[0].eventX, 120.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureLongPress);
+  EXPECT_EQ(test.events[0].eventX, 120.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
 }
 
-void testTwoDragFastDistinctHoriz()
+TEST(GestureHandler, twoDragFastDistinctHoriz)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 30.0);
@@ -521,19 +454,19 @@ void testTwoDragFastDistinctHoriz()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 25.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 25.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[1].eventX, 25.0);
-  ASSERT_EQ(test.events[1].eventY, 30.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 60.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 0.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[1].eventX, 25.0);
+  EXPECT_EQ(test.events[1].eventY, 30.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 60.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 0.0);
 
   test.events.clear();
 
@@ -541,21 +474,17 @@ void testTwoDragFastDistinctHoriz()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 25.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 60.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 25.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 60.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 }
 
-void testTwoDragFastDistinctVert()
+TEST(GestureHandler, twoDragFastDistinctVert)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 30.0);
@@ -574,19 +503,19 @@ void testTwoDragFastDistinctVert()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 25.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 25.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[1].eventX, 25.0);
-  ASSERT_EQ(test.events[1].eventY, 30.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 65.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[1].eventX, 25.0);
+  EXPECT_EQ(test.events[1].eventY, 30.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 65.0);
 
   test.events.clear();
 
@@ -594,21 +523,17 @@ void testTwoDragFastDistinctVert()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 25.0);
-  ASSERT_EQ(test.events[0].eventY, 30.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 65.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 25.0);
+  EXPECT_EQ(test.events[0].eventY, 30.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 65.0);
 }
 
-void testTwoDragFastDistinctDiag()
+TEST(GestureHandler, twoDragFastDistinctDiag)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 120.0, 130.0);
   test.handleTouchBegin(2, 130.0, 130.0);
@@ -627,19 +552,19 @@ void testTwoDragFastDistinctDiag()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 125.0);
-  ASSERT_EQ(test.events[0].eventY, 130.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 125.0);
+  EXPECT_EQ(test.events[0].eventY, 130.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[1].eventX, 125.0);
-  ASSERT_EQ(test.events[1].eventY, 130.0);
-  ASSERT_EQ(test.events[1].magnitudeX, -55.0);
-  ASSERT_EQ(test.events[1].magnitudeY, -50.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[1].eventX, 125.0);
+  EXPECT_EQ(test.events[1].eventY, 130.0);
+  EXPECT_EQ(test.events[1].magnitudeX, -55.0);
+  EXPECT_EQ(test.events[1].magnitudeY, -50.0);
 
   test.events.clear();
 
@@ -647,21 +572,17 @@ void testTwoDragFastDistinctDiag()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 125.0);
-  ASSERT_EQ(test.events[0].eventY, 130.0);
-  ASSERT_EQ(test.events[0].magnitudeX, -55.0);
-  ASSERT_EQ(test.events[0].magnitudeY, -50.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 125.0);
+  EXPECT_EQ(test.events[0].eventY, 130.0);
+  EXPECT_EQ(test.events[0].magnitudeX, -55.0);
+  EXPECT_EQ(test.events[0].magnitudeY, -50.0);
 }
 
-void testTwoDragFastAlmost()
+TEST(GestureHandler, twoDragFastAlmost)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 30.0);
@@ -676,15 +597,11 @@ void testTwoDragFastAlmost()
   core::Timer::checkTimeouts();
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testTwoDragSlowHoriz()
+TEST(GestureHandler, twoDragSlowHoriz)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 50.0, 40.0);
   test.handleTouchBegin(2, 60.0, 40.0);
@@ -697,28 +614,25 @@ void testTwoDragSlowHoriz()
   core::Timer::checkTimeouts();
 
   ASSERT_EQ(test.events.size(), 2);
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 55.0);
-  ASSERT_EQ(test.events[0].eventY, 40.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[1].eventX, 55.0);
-  ASSERT_EQ(test.events[1].eventY, 40.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 40.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 0.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 55.0);
+  EXPECT_EQ(test.events[0].eventY, 40.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[1].eventX, 55.0);
+  EXPECT_EQ(test.events[1].eventY, 40.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 40.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 0.0);
 }
 
-void testTwoDragSlowVert()
+TEST(GestureHandler, twoDragSlowVert)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 40.0, 40.0);
   test.handleTouchBegin(2, 40.0, 60.0);
@@ -731,28 +645,25 @@ void testTwoDragSlowVert()
   core::Timer::checkTimeouts();
 
   ASSERT_EQ(test.events.size(), 2);
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 40.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[1].eventX, 40.0);
-  ASSERT_EQ(test.events[1].eventY, 50.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 40.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 40.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[1].eventX, 40.0);
+  EXPECT_EQ(test.events[1].eventY, 50.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 40.0);
 }
 
-void testTwoDragSlowDiag()
+TEST(GestureHandler, twoDragSlowDiag)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 50.0, 40.0);
   test.handleTouchBegin(2, 40.0, 60.0);
@@ -765,28 +676,25 @@ void testTwoDragSlowDiag()
   core::Timer::checkTimeouts();
 
   ASSERT_EQ(test.events.size(), 2);
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[0].eventX, 45.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 0.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoDrag);
-  ASSERT_EQ(test.events[1].eventX, 45.0);
-  ASSERT_EQ(test.events[1].eventY, 50.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 35.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 35.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].eventX, 45.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 0.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[1].eventX, 45.0);
+  EXPECT_EQ(test.events[1].eventY, 50.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 35.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 35.0);
 }
 
-void testTwoDragTooSlow()
+TEST(GestureHandler, twoDragTooSlow)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
 
@@ -798,15 +706,11 @@ void testTwoDragTooSlow()
   test.handleTouchUpdate(1, 80.0, 30.0);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testPinchFastDistinctIn()
+TEST(GestureHandler, pinchFastDistinctIn)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 0.0, 0.0);
   test.handleTouchBegin(2, 130.0, 130.0);
@@ -822,19 +726,19 @@ void testPinchFastDistinctIn()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GesturePinch);
-  ASSERT_EQ(test.events[0].eventX, 65.0);
-  ASSERT_EQ(test.events[0].eventY, 65.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 130.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 130.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GesturePinch);
+  EXPECT_EQ(test.events[0].eventX, 65.0);
+  EXPECT_EQ(test.events[0].eventY, 65.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 130.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 130.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GesturePinch);
-  ASSERT_EQ(test.events[1].eventX, 65.0);
-  ASSERT_EQ(test.events[1].eventY, 65.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 10.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 30.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GesturePinch);
+  EXPECT_EQ(test.events[1].eventX, 65.0);
+  EXPECT_EQ(test.events[1].eventY, 65.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 10.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 30.0);
 
   test.events.clear();
 
@@ -842,21 +746,17 @@ void testPinchFastDistinctIn()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GesturePinch);
-  ASSERT_EQ(test.events[0].eventX, 65.0);
-  ASSERT_EQ(test.events[0].eventY, 65.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 10.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 30.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GesturePinch);
+  EXPECT_EQ(test.events[0].eventX, 65.0);
+  EXPECT_EQ(test.events[0].eventY, 65.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 10.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 30.0);
 }
 
-void testPinchFastDistinctOut()
+TEST(GestureHandler, pinchFastDistinctOut)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 100.0, 100.0);
   test.handleTouchBegin(2, 110.0, 100.0);
@@ -872,19 +772,19 @@ void testPinchFastDistinctOut()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GesturePinch);
-  ASSERT_EQ(test.events[0].eventX, 105.0);
-  ASSERT_EQ(test.events[0].eventY, 100.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 10.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GesturePinch);
+  EXPECT_EQ(test.events[0].eventX, 105.0);
+  EXPECT_EQ(test.events[0].eventY, 100.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 10.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GesturePinch);
-  ASSERT_EQ(test.events[1].eventX, 105.0);
-  ASSERT_EQ(test.events[1].eventY, 100.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 180.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 180.0);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GesturePinch);
+  EXPECT_EQ(test.events[1].eventX, 105.0);
+  EXPECT_EQ(test.events[1].eventY, 100.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 180.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 180.0);
 
   test.events.clear();
 
@@ -892,21 +792,17 @@ void testPinchFastDistinctOut()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GesturePinch);
-  ASSERT_EQ(test.events[0].eventX, 105.0);
-  ASSERT_EQ(test.events[0].eventY, 100.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 180.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 180.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GesturePinch);
+  EXPECT_EQ(test.events[0].eventX, 105.0);
+  EXPECT_EQ(test.events[0].eventY, 100.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 180.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 180.0);
 }
 
-void testPinchFastAlmost()
+TEST(GestureHandler, pinchFastAlmost)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 130.0, 130.0);
@@ -920,15 +816,11 @@ void testPinchFastAlmost()
   core::Timer::checkTimeouts();
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testPinchSlowIn()
+TEST(GestureHandler, pinchSlowIn)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 0.0, 0.0);
   test.handleTouchBegin(2, 130.0, 130.0);
@@ -945,28 +837,24 @@ void testPinchSlowIn()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GesturePinch);
-  ASSERT_EQ(test.events[0].eventX, 65.0);
-  ASSERT_EQ(test.events[0].eventY, 65.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 130.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 130.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GesturePinch);
+  EXPECT_EQ(test.events[0].eventX, 65.0);
+  EXPECT_EQ(test.events[0].eventY, 65.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 130.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 130.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GesturePinch);
-  ASSERT_EQ(test.events[1].eventX, 65.0);
-  ASSERT_EQ(test.events[1].eventY, 65.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 50.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 90.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GesturePinch);
+  EXPECT_EQ(test.events[1].eventX, 65.0);
+  EXPECT_EQ(test.events[1].eventY, 65.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 50.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 90.0);
 }
 
-void testPinchSlowOut()
+TEST(GestureHandler, pinchSlowOut)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 100.0, 130.0);
   test.handleTouchBegin(2, 110.0, 130.0);
@@ -982,28 +870,24 @@ void testPinchSlowOut()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GesturePinch);
-  ASSERT_EQ(test.events[0].eventX, 105.0);
-  ASSERT_EQ(test.events[0].eventY, 130.0);
-  ASSERT_EQ(test.events[0].magnitudeX, 10.0);
-  ASSERT_EQ(test.events[0].magnitudeY, 0.0);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GesturePinch);
+  EXPECT_EQ(test.events[0].eventX, 105.0);
+  EXPECT_EQ(test.events[0].eventY, 130.0);
+  EXPECT_EQ(test.events[0].magnitudeX, 10.0);
+  EXPECT_EQ(test.events[0].magnitudeY, 0.0);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GesturePinch);
-  ASSERT_EQ(test.events[1].eventX, 105.0);
-  ASSERT_EQ(test.events[1].eventY, 130.0);
-  ASSERT_EQ(test.events[1].magnitudeX, 100.0);
-  ASSERT_EQ(test.events[1].magnitudeY, 0.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GesturePinch);
+  EXPECT_EQ(test.events[1].eventX, 105.0);
+  EXPECT_EQ(test.events[1].eventY, 130.0);
+  EXPECT_EQ(test.events[1].magnitudeX, 100.0);
+  EXPECT_EQ(test.events[1].magnitudeY, 0.0);
 }
 
-void testPinchTooSlow()
+TEST(GestureHandler, pinchTooSlow)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 0.0, 0.0);
 
@@ -1015,15 +899,11 @@ void testPinchTooSlow()
   test.handleTouchUpdate(1, 50.0, 40.0);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testExtraIgnore()
+TEST(GestureHandler, extraIgnore)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchUpdate(1, 40.0, 30.0);
@@ -1031,11 +911,11 @@ void testExtraIgnore()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureDrag);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureDrag);
 
   test.events.clear();
 
@@ -1047,10 +927,10 @@ void testExtraIgnore()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureUpdate);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 100.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
+  EXPECT_EQ(test.events[0].type, GestureUpdate);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 100.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
 
   test.events.clear();
 
@@ -1058,19 +938,15 @@ void testExtraIgnore()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 100.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 100.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
 }
 
-void testIgnoreWhenAwaitingGestureEnd()
+TEST(GestureHandler, ignoreWhenAwaitingGestureEnd)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchBegin(2, 30.0, 30.0);
@@ -1080,11 +956,11 @@ void testIgnoreWhenAwaitingGestureEnd()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureTwoDrag);
 
   test.events.clear();
 
@@ -1092,8 +968,8 @@ void testIgnoreWhenAwaitingGestureEnd()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureTwoDrag);
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureTwoDrag);
 
   test.events.clear();
 
@@ -1101,15 +977,11 @@ void testIgnoreWhenAwaitingGestureEnd()
   test.handleTouchEnd(3);
 
   ASSERT_EQ(test.events.size(), 0);
-
-  printf("OK\n");
 }
 
-void testIgnoreAfterGesture()
+TEST(GestureHandler, ignoreAfterGesture)
 {
   TestClass test;
-
-  printf("%s: ", __func__);
 
   test.handleTouchBegin(1, 20.0, 30.0);
   test.handleTouchUpdate(1, 40.0, 30.0);
@@ -1117,11 +989,11 @@ void testIgnoreAfterGesture()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
 
-  ASSERT_EQ(test.events[1].type, GestureUpdate);
-  ASSERT_EQ(test.events[1].gesture, GestureDrag);
+  EXPECT_EQ(test.events[1].type, GestureUpdate);
+  EXPECT_EQ(test.events[1].gesture, GestureDrag);
 
   test.events.clear();
 
@@ -1134,10 +1006,10 @@ void testIgnoreAfterGesture()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureUpdate);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 100.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
+  EXPECT_EQ(test.events[0].type, GestureUpdate);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 100.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
 
   test.events.clear();
 
@@ -1145,10 +1017,10 @@ void testIgnoreAfterGesture()
 
   ASSERT_EQ(test.events.size(), 1);
 
-  ASSERT_EQ(test.events[0].type, GestureEnd);
-  ASSERT_EQ(test.events[0].gesture, GestureDrag);
-  ASSERT_EQ(test.events[0].eventX, 100.0);
-  ASSERT_EQ(test.events[0].eventY, 50.0);
+  EXPECT_EQ(test.events[0].type, GestureEnd);
+  EXPECT_EQ(test.events[0].gesture, GestureDrag);
+  EXPECT_EQ(test.events[0].eventX, 100.0);
+  EXPECT_EQ(test.events[0].eventY, 50.0);
 
   // End ignored event
   test.handleTouchEnd(2);
@@ -1161,88 +1033,14 @@ void testIgnoreAfterGesture()
 
   ASSERT_EQ(test.events.size(), 2);
 
-  ASSERT_EQ(test.events[0].type, GestureBegin);
-  ASSERT_EQ(test.events[0].gesture, GestureOneTap);
-  ASSERT_EQ(test.events[1].type, GestureEnd);
-  ASSERT_EQ(test.events[1].gesture, GestureOneTap);
-
-  printf("OK\n");
+  EXPECT_EQ(test.events[0].type, GestureBegin);
+  EXPECT_EQ(test.events[0].gesture, GestureOneTap);
+  EXPECT_EQ(test.events[1].type, GestureEnd);
+  EXPECT_EQ(test.events[1].gesture, GestureOneTap);
 }
 
-void testOneTap()
+int main(int argc, char** argv)
 {
-  testOneTapNormal();
-}
-
-void testTwoTap()
-{
-  testTwoTapNormal();
-  testTwoTapSlowBegin();
-  testTwoTapSlowEnd();
-  testTwoTapTimeout();
-}
-
-void testThreeTap()
-{
-  testThreeTapNormal();
-  testThreeTapSlowBegin();
-  testThreeTapSlowEnd();
-  testThreeTapDrag();
-  testThreeTapTimeout();
-}
-
-void testDrag()
-{
-  testDragHoriz();
-  testDragVert();
-  testDragDiag();
-}
-
-void testLongPress()
-{
-  testLongPressNormal();
-  testLongPressDrag();
-}
-
-void testTwoDrag()
-{
-  testTwoDragFastDistinctHoriz();
-  testTwoDragFastDistinctVert();
-  testTwoDragFastDistinctDiag();
-  testTwoDragFastAlmost();
-  testTwoDragSlowHoriz();
-  testTwoDragSlowVert();
-  testTwoDragSlowDiag();
-  testTwoDragTooSlow();
-}
-
-void testPinch()
-{
-  testPinchFastDistinctIn();
-  testPinchFastDistinctOut();
-  testPinchFastAlmost();
-  testPinchSlowIn();
-  testPinchSlowOut();
-  testPinchTooSlow();
-}
-
-void testIgnore()
-{
-  testExtraIgnore();
-  testIgnoreWhenAwaitingGestureEnd();
-  testIgnoreAfterGesture();
-}
-
-int main(int /*argc*/, char** /*argv*/)
-{
-  testOneTap();
-  testTwoTap();
-  testThreeTap();
-  testDrag();
-  testLongPress();
-  testTwoDrag();
-  testPinch();
-  testIgnore();
-
-  return 0;
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tests/unit/pixelformat.cxx
+++ b/tests/unit/pixelformat.cxx
@@ -1,4 +1,4 @@
-/* Copyright 2019 Pierre Ossman <ossman@cendio.se> for Cendio AB
+/* Copyright 2019-2025 Pierre Ossman <ossman@cendio.se> for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,174 +20,233 @@
 #include <config.h>
 #endif
 
-#include <stdio.h>
-
+#include <list>
 #include <stdexcept>
+
+#include <gtest/gtest.h>
 
 #include <rfb/PixelFormat.h>
 
-static void doTest(bool should_fail, int b, int d, bool e, bool t,
-                   int rm, int gm, int bm, int rs, int gs, int bs)
+struct Params {
+  int b;
+  int d;
+  bool e;
+  bool t;
+  int rm;
+  int gm;
+  int bm;
+  int rs;
+  int gs;
+  int bs;
+};
+
+static std::ostream& operator<<(std::ostream& os, const Params& p)
 {
-    rfb::PixelFormat* pf;
-
-    printf("PixelFormat(%d, %d, %s, %s, %d, %d, %d, %d, %d, %d): ",
-           b, d, e ? "true" : "false", t ? "true": "false",
-           rm, gm, bm, rs, gs, bs);
-
-    try {
-        pf = new rfb::PixelFormat(b, d, e, t, rm, gm, bm, rs, gs, bs);
-    } catch(std::exception&) {
-        if (should_fail)
-            printf("OK");
-        else
-            printf("FAILED");
-        printf("\n");
-        fflush(stdout);
-        return;
-    }
-
-    delete pf;
-
-    if (should_fail)
-        printf("FAILED");
-    else
-        printf("OK");
-    printf("\n");
-    fflush(stdout);
+  return os << p.b << ", " << p.d << ", " <<
+         (p.e ? "true" : "false") << " " <<
+         (p.t ? "true" : "false") << ", " <<
+         p.rm << ", " << p.gm << ", " << p.bm << ", "
+         << p.rs << ", " << p.gs << ", " << p.bs;
 }
 
-static void do888Test(bool expected, int b, int d, bool e, bool t,
-                   int rm, int gm, int bm, int rs, int gs, int bs)
+typedef testing::TestWithParam<Params> PixelFormatValid;
+
+TEST_P(PixelFormatValid, constructor)
 {
-    rfb::PixelFormat* pf;
+  Params params;
+  rfb::PixelFormat* pf;
 
-    printf("PixelFormat(%d, %d, %s, %s, %d, %d, %d, %d, %d, %d): ",
-           b, d, e ? "true" : "false", t ? "true": "false",
-           rm, gm, bm, rs, gs, bs);
+  params = GetParam();
+  pf = nullptr;
 
-    pf = new rfb::PixelFormat(b, d, e, t, rm, gm, bm, rs, gs, bs);
+  EXPECT_NO_THROW({
+    pf = new rfb::PixelFormat(params.b, params.d, params.e, params.t,
+                              params.rm, params.gm, params.bm,
+                              params.rs, params.gs, params.bs);
+  });
 
-    if (pf->is888() == expected)
-        printf("OK");
-    else
-        printf("FAILED");
-    printf("\n");
-    fflush(stdout);
-
-    delete pf;
+  delete pf;
 }
 
-static void sanityTests()
+typedef testing::TestWithParam<Params> PixelFormatInvalid;
+
+TEST_P(PixelFormatInvalid, constructor)
 {
-    printf("Sanity checks:\n\n");
+  Params params;
+  rfb::PixelFormat* pf;
 
-    /* Normal true color formats */
+  params = GetParam();
+  pf = nullptr;
 
-    doTest(false, 32, 24, false, true, 255, 255, 255, 0, 8, 16);
-    doTest(false, 32, 24, false, true, 255, 255, 255, 24, 16, 8);
+  EXPECT_THROW({
+    pf = new rfb::PixelFormat(params.b, params.d, params.e, params.t,
+                              params.rm, params.gm, params.bm,
+                              params.rs, params.gs, params.bs);
+  }, std::invalid_argument);
 
-    doTest(false, 16, 16, false, true, 15, 31, 15, 0, 5, 11);
-
-    doTest(false, 8, 8, false, true, 3, 7, 3, 0, 2, 5);
-
-    /* Excessive bpp */
-
-    doTest(false, 32, 16, false, true, 15, 31, 15, 0, 5, 11);
-
-    doTest(false, 16, 16, false, true, 15, 31, 15, 0, 5, 11);
-
-    doTest(false, 32, 8, false, true, 3, 7, 3, 0, 2, 5);
-
-    doTest(false, 16, 8, false, true, 3, 7, 3, 0, 2, 5);
-
-    /* Colour map */
-
-    doTest(false, 8, 8, false, false, 0, 0, 0, 0, 0, 0);
-
-    /* Invalid bpp */
-
-    doTest(true, 64, 24, false, true, 255, 255, 255, 0, 8, 16);
-
-    doTest(true, 18, 16, false, true, 15, 31, 15, 0, 5, 11);
-
-    doTest(true, 3, 3, false, true, 1, 1, 1, 0, 1, 2);
-
-    /* Invalid depth */
-
-    doTest(true, 16, 24, false, true, 15, 31, 15, 0, 5, 11);
-
-    doTest(true, 8, 24, false, true, 3, 7, 3, 0, 2, 5);
-    doTest(true, 8, 16, false, true, 3, 7, 3, 0, 2, 5);
-
-    doTest(true, 32, 24, false, false, 0, 0, 0, 0, 0, 0);
-
-    /* Invalid max values */
-
-    doTest(true, 32, 24, false, true, 254, 255, 255, 0, 8, 16);
-    doTest(true, 32, 24, false, true, 255, 253, 255, 0, 8, 16);
-    doTest(true, 32, 24, false, true, 255, 255, 252, 0, 8, 16);
-
-    doTest(true, 32, 24, false, true, 511, 127, 127, 0, 16, 20);
-    doTest(true, 32, 24, false, true, 127, 511, 127, 0, 4, 20);
-    doTest(true, 32, 24, false, true, 127, 127, 511, 0, 4, 8);
-
-    /* Insufficient depth */
-
-    doTest(true, 32, 16, false, true, 255, 255, 255, 0, 8, 16);
-
-    /* Invalid shift values */
-
-    doTest(true, 32, 24, false, true, 255, 255, 255, 25, 8, 16);
-    doTest(true, 32, 24, false, true, 255, 255, 255, 0, 25, 16);
-    doTest(true, 32, 24, false, true, 255, 255, 255, 0, 8, 25);
-
-    /* Overlapping channels */
-
-    doTest(true, 32, 24, false, true, 255, 255, 255, 0, 7, 16);
-    doTest(true, 32, 24, false, true, 255, 255, 255, 0, 8, 15);
-    doTest(true, 32, 24, false, true, 255, 255, 255, 0, 16, 7);
-
-    printf("\n");
+  delete pf;
 }
 
-void is888Tests()
+typedef testing::TestWithParam<Params> PixelFormatIs888;
+
+TEST_P(PixelFormatIs888, constructor)
 {
-    printf("Simple format detection:\n\n");
+  Params params;
+  rfb::PixelFormat* pf;
 
-    /* Positive cases */
+  params = GetParam();
+  pf = new rfb::PixelFormat(params.b, params.d, params.e, params.t,
+                            params.rm, params.gm, params.bm,
+                            params.rs, params.gs, params.bs);
+  EXPECT_TRUE(pf->is888());
 
-    do888Test(true, 32, 24, false, true, 255, 255, 255, 0, 8, 16);
-    do888Test(true, 32, 24, false, true, 255, 255, 255, 24, 16, 8);
-    do888Test(true, 32, 24, false, true, 255, 255, 255, 24, 8, 0);
-
-    /* Low depth */
-
-    do888Test(false, 32, 16, false, true, 15, 31, 15, 0, 8, 16);
-    do888Test(false, 32, 8, false, true, 3, 7, 3, 0, 8, 16);
-
-    /* Low bpp and depth */
-
-    do888Test(false, 16, 16, false, true, 15, 31, 15, 0, 5, 11);
-    do888Test(false, 8, 8, false, true, 3, 7, 3, 0, 2, 5);
-
-    /* Colour map */
-
-    do888Test(false, 8, 8, false, false, 0, 0, 0, 0, 0, 0);
-
-    /* Odd shifts */
-
-    do888Test(false, 32, 24, false, true, 255, 255, 255, 0, 8, 18);
-    do888Test(false, 32, 24, false, true, 255, 255, 255, 0, 11, 24);
-    do888Test(false, 32, 24, false, true, 255, 255, 255, 4, 16, 24);
-
-    printf("\n");
+  delete pf;
 }
 
-int main(int /*argc*/, char** /*argv*/)
-{
-    sanityTests();
-    is888Tests();
+typedef testing::TestWithParam<Params> PixelFormatNot888;
 
-    return 0;
+TEST_P(PixelFormatNot888, constructor)
+{
+  Params params;
+  rfb::PixelFormat* pf;
+
+  params = GetParam();
+  pf = new rfb::PixelFormat(params.b, params.d, params.e, params.t,
+                            params.rm, params.gm, params.bm,
+                            params.rs, params.gs, params.bs);
+  EXPECT_FALSE(pf->is888());
+
+  delete pf;
+}
+
+static std::list<Params> validFormats()
+{
+  std::list<Params> params;
+
+  /* Normal true color formats */
+
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 8, 16});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 24, 16, 8});
+
+  params.push_back(Params{16, 16, false, true, 15, 31, 15, 0, 5, 11});
+
+  params.push_back(Params{8, 8, false, true, 3, 7, 3, 0, 2, 5});
+
+  /* Excessive bpp */
+
+  params.push_back(Params{32, 16, false, true, 15, 31, 15, 0, 5, 11});
+
+  params.push_back(Params{16, 16, false, true, 15, 31, 15, 0, 5, 11});
+
+  params.push_back(Params{32, 8, false, true, 3, 7, 3, 0, 2, 5});
+
+  params.push_back(Params{16, 8, false, true, 3, 7, 3, 0, 2, 5});
+
+  /* Colour map */
+
+  params.push_back(Params{8, 8, false, false, 0, 0, 0, 0, 0, 0});
+
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(, PixelFormatValid, testing::ValuesIn(validFormats()));
+
+static std::list<Params> invalidFormats()
+{
+  std::list<Params> params;
+
+  params.push_back(Params{64, 24, false, true, 255, 255, 255, 0, 8, 16});
+
+  params.push_back(Params{18, 16, false, true, 15, 31, 15, 0, 5, 11});
+
+  params.push_back(Params{3, 3, false, true, 1, 1, 1, 0, 1, 2});
+
+  /* Invalid depth */
+
+  params.push_back(Params{16, 24, false, true, 15, 31, 15, 0, 5, 11});
+
+  params.push_back(Params{8, 24, false, true, 3, 7, 3, 0, 2, 5});
+  params.push_back(Params{8, 16, false, true, 3, 7, 3, 0, 2, 5});
+
+  params.push_back(Params{32, 24, false, false, 0, 0, 0, 0, 0, 0});
+
+  /* Invalid max values */
+
+  params.push_back(Params{32, 24, false, true, 254, 255, 255, 0, 8, 16});
+  params.push_back(Params{32, 24, false, true, 255, 253, 255, 0, 8, 16});
+  params.push_back(Params{32, 24, false, true, 255, 255, 252, 0, 8, 16});
+
+  params.push_back(Params{32, 24, false, true, 511, 127, 127, 0, 16, 20});
+  params.push_back(Params{32, 24, false, true, 127, 511, 127, 0, 4, 20});
+  params.push_back(Params{32, 24, false, true, 127, 127, 511, 0, 4, 8});
+
+  /* Insufficient depth */
+
+  params.push_back(Params{32, 16, false, true, 255, 255, 255, 0, 8, 16});
+
+  /* Invalid shift values */
+
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 25, 8, 16});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 25, 16});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 8, 25});
+
+  /* Overlapping channels */
+
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 7, 16});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 8, 15});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 16, 7});
+
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(, PixelFormatInvalid, testing::ValuesIn(invalidFormats()));
+
+static std::list<Params> is888Formats()
+{
+  std::list<Params> params;
+
+  /* Positive cases */
+
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 8, 16});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 24, 16, 8});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 24, 8, 0});
+
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(, PixelFormatIs888, testing::ValuesIn(is888Formats()));
+
+static std::list<Params> not888Formats()
+{
+  std::list<Params> params;
+
+  /* Low depth */
+
+  params.push_back(Params{32, 16, false, true, 15, 31, 15, 0, 8, 16});
+  params.push_back(Params{32, 8, false, true, 3, 7, 3, 0, 8, 16});
+
+  /* Low bpp and depth */
+
+  params.push_back(Params{16, 16, false, true, 15, 31, 15, 0, 5, 11});
+  params.push_back(Params{8, 8, false, true, 3, 7, 3, 0, 2, 5});
+
+  /* Colour map */
+
+  params.push_back(Params{8, 8, false, false, 0, 0, 0, 0, 0, 0});
+
+  /* Odd shifts */
+
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 8, 18});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 0, 11, 24});
+  params.push_back(Params{32, 24, false, true, 255, 255, 255, 4, 16, 24});
+
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(, PixelFormatNot888, testing::ValuesIn(not888Formats()));
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Mainly to give us a bit more flexibility in things like integrating with GitHub actions. But it also gives us more features in checks where it can print the values that caused tests to fail.

I looked at a few C++ unit test frameworks, and Google's seem to be the most popular. It's available in all distros, and in MSYS and Homebrew.

It does require C++14 (soon (C++17)), though, which is more than our current C++11 requirement. Because of this, I made it an optional thing. Unit tests are mostly for the developers anyway.