### PR TITLE
Clear clipboard state when invalid UTF-8 string

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -411,6 +411,14 @@ int Viewport::handle(int event)
   case FL_PASTE:
     if (!isValidUTF8(Fl::event_text(), Fl::event_length())) {
       vlog.error("Invalid UTF-8 sequence in system clipboard");
+      // Reset the state as if we don't have any clipboard data at all
+      this->pendingClientClipboard = false;
+      try {
+        this->cc->announceClipboard(false);
+      } catch (std::exception& e) {
+        vlog.error("%s", e.what());
+        abort_connection_with_unexpected_error(e);
+      }
       return 1;
     }
 


### PR DESCRIPTION
This commit adds another check to ensure that we don't announce clipboard data when the data is invalid.

Running `xclip -sel clip -t STRING image.png` for example would trigger a clipboard announce with invalid content.

This is the same fix as commit 6f6d9406035d59b6a9f59ff0f38206c0c98a0266.