### PR TITLE
Refresh framebuffer on options change

### DIFF
--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -584,6 +584,8 @@ void CConn::handleOptions(void *data)
     self->setQualityLevel(-1);
 
   self->updatePixelFormat();
+
+  self->refreshFramebuffer();
 }
 
 void CConn::handleUpdateTimeout(void *data)


### PR DESCRIPTION
Refresh framebuffer on options change.

ISSUE: After quality or color level options were modified only screen regions that changed since were repainted leaving unchanged regions painted using old settings.

Picture attached below.
Remote server is playing a YouTube movie in a browser.
Color level option is changed in TigerVNC viewer's OptionsDialog from Full to Very Low.
Only regions of the screen where the movie picture changed on the remote server were sent for updating and thus were repainted using the new Very Low color setting.
This resulted in TigerVNC window with both previously used Full color and the new Very Low color regions:

![quality-color-level-options-modified-only-screen-regions-that-changed-since-repainted](https://github.com/user-attachments/assets/f2d7f871-93e1-4a92-a7a0-321abba582fd)
