### PR TITLE
Fix mouse click event leak on context menu close

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -98,7 +98,7 @@ Viewport::Viewport(int w, int h, CConn* cc_)
     lastPointerPos(0, 0), lastButtonMask(0),
     keyboard(nullptr), shortcutBypass(false), shortcutActive(false),
     firstLEDState(true), pendingClientClipboard(false),
-    menuCtrlKey(false), menuAltKey(false), cursor(nullptr),
+    menuOpened(false), menuCtrlKey(false), menuAltKey(false), cursor(nullptr),
     cursorIsBlank(false)
 {
 #if defined(WIN32)
@@ -481,6 +481,20 @@ int Viewport::handle(int event)
     if (Fl::event_button3())
       buttonMask |= 1 << 2;
 
+    // Suppress handling of mouse events until the context popup menu is closed.
+    // This prevents a situation when closing the context menu by clicking
+    // somewhere on the TigerVNC viewer's window causes a mouse click event
+    // to be sent to the server.
+    if (menuOpened) {
+      if (buttonMask != 0) {
+        vlog.debug("Ignored mouse event %d,(%d,%d),%d while closing the menu.",
+                   event, Fl::event_x(), Fl::event_y(), buttonMask);
+        return 1;
+      }
+      vlog.debug("Allowed mouse event %d,(%d,%d),%d while closing the menu.",
+                 event, Fl::event_x(), Fl::event_y(), buttonMask);
+    }
+
   // The back/forward buttons are not supported by FTLK 1.3 and require
   // a patch which adds these buttons to the FLTK API. These buttons
   // will be part of the upcoming 1.4 API:
@@ -646,6 +660,14 @@ void Viewport::flushPendingClipboard()
   }
 
   pendingClientClipboard = false;
+}
+
+
+void Viewport::handleMenuClosed(void *data)
+{
+  Viewport *self = (Viewport *)data;
+  assert(self);
+  self->menuOpened = false;
 }
 
 
@@ -981,7 +1003,9 @@ void Viewport::popupContextMenu()
   // FLTK also doesn't switch focus properly for menus
   Fl::handle(FL_UNFOCUS, window());
 
+  menuOpened = true;
   m = contextMenu->popup();
+  Fl::add_timeout(0.0, handleMenuClosed, this);
 
   Fl::handle(FL_FOCUS, window());
 

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -103,6 +103,8 @@ private:
   void initContextMenu();
   void popupContextMenu();
 
+  static void handleMenuClosed(void *data);
+
   static void handleOptions(void *data);
 
 private:
@@ -126,6 +128,7 @@ private:
   int clipboardSource;
 
   Fl_Menu_Button *contextMenu;
+  bool menuOpened;
 
   bool menuCtrlKey;
   bool menuAltKey;


### PR DESCRIPTION
When closing the F8 popup menu by clicking somewhere on the TigerVNC viewer's window a mouse click event is sent to the server.
No other toolkit nor application behaves like that when closing a popup menu - the closing click is ignored as an input.
And so it should be ignored here, especially that this input is being sent to a remote machine.

This commit fixes it by relying on FLTK's event loop which lets us know the lifetime of our popup menu and therefore easily filter out the closing mouse click event.