### PR TITLE
Do not request screen updates while the window is not visible

### DIFF
--- a/common/rfb/CConnection.cxx
+++ b/common/rfb/CConnection.cxx
@@ -67,7 +67,7 @@ CConnection::CConnection()
     supportsDesktopResize(false), supportsLEDState(false),
     is(nullptr), os(nullptr), reader_(nullptr), writer_(nullptr),
     shared(false),
-    state_(RFBSTATE_UNINITIALISED),
+    state_(RFBSTATE_UNINITIALISED), updatesEnabled(true),
     pendingPFChange(false), preferredEncoding(encodingTight),
     compressLevel(2), qualityLevel(-1),
     formatChange(false), encodingChange(false),
@@ -950,10 +950,35 @@ bool CConnection::isSecure() const
   return csecurity ? csecurity->isSecure() : false;
 }
 
+void CConnection::enableUpdates(bool enabled) {
+  if (updatesEnabled == enabled)
+    return;
+
+  updatesEnabled = enabled;
+
+  if (enabled) {
+    if (continuousUpdates)
+      writer()->writeEnableContinuousUpdates(true, 0, 0,
+                                             server.width(),
+                                             server.height());
+    pendingUpdate = true;
+    writer()->writeFramebufferUpdateRequest({0, 0,
+                                             server.width(),
+                                             server.height()},
+                                            !forceNonincremental);
+  } else {
+    if (continuousUpdates)
+      writer()->writeEnableContinuousUpdates(false, 0, 0, 0, 0);
+  }
+}
+
 // requestNewUpdate() requests an update from the server, having set the
 // format and encoding appropriately.
 void CConnection::requestNewUpdate()
 {
+  if (!updatesEnabled)
+    return;
+
   if (formatChange && !pendingPFChange) {
     /* Catch incorrect requestNewUpdate calls */
     assert(!pendingUpdate || continuousUpdates);

--- a/common/rfb/CConnection.h
+++ b/common/rfb/CConnection.h
@@ -194,6 +194,8 @@ namespace rfb {
     virtual bool verifyHostKey(const uint8_t* key, size_t length,
                                const char* fingerprint) = 0;
 
+    void enableUpdates(bool enabled);
+
   protected:
 
     // Methods overridden from CMsgHandler
@@ -320,6 +322,8 @@ namespace rfb {
     stateEnum state_;
 
     std::string serverName;
+
+    bool updatesEnabled;
 
     bool pendingPFChange;
     rfb::PixelFormat pendingPF;

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -940,6 +940,13 @@ int DesktopWindow::handle(int event)
     }
     // Continue processing so that the viewport also gets mouse events
     break;
+
+  case FL_SHOW:
+    cc->enableUpdates(true);
+    break;
+  case FL_HIDE:
+    cc->enableUpdates(false);
+    break;
   }
 
   return Fl_Window::handle(event);


### PR DESCRIPTION
Do not request screen updates while the window is not visible, e.g. minimized.
This saves a lot of bandwidth and CPU.

New option: UpdateOnlyWhenVisible