### PR TITLE
Use notepad to open text files

### DIFF
--- a/release/tigervnc.iss.in
+++ b/release/tigervnc.iss.in
@@ -28,6 +28,6 @@ Source: "@CMAKE_SOURCE_DIR@\LICENCE.TXT"; DestDir: "{app}"; Flags: ignoreversion
 Name: "{group}\TigerVNC"; FileName: "{app}\vncviewer.exe";
 Name: "{group}\Listening TigerVNC"; FileName: "{app}\vncviewer.exe"; Parameters: "-listen";
 
-Name: "{group}\License"; FileName: "write.exe"; Parameters: "LICENCE.TXT"; WorkingDir: "{app}"; Flags: "useapppaths"
-Name: "{group}\Read Me"; FileName: "write.exe"; Parameters: "README.rst"; WorkingDir: "{app}"; Flags: "useapppaths"
+Name: "{group}\License"; FileName: "notepad.exe"; Parameters: "LICENCE.TXT"; WorkingDir: "{app}"; Flags: "useapppaths"
+Name: "{group}\Read Me"; FileName: "notepad.exe"; Parameters: "README.rst"; WorkingDir: "{app}"; Flags: "useapppaths"
 Name: "{group}\Uninstall TigerVNC"; FileName: "{uninstallexe}"; WorkingDir: "{app}";


### PR DESCRIPTION
Change ReadMe and License files to open with Notepad instead of WordPad, since [WordPad (`write.exe`) has been removed in new versions of Windows.](https://learn.microsoft.com/en-gb/windows/whats-new/deprecated-features-resources#wordpad)

Currently the Start Menu icons Read Me and License lead to this on Windows 11 24H2 build 26100.4061:

![image](https://github.com/user-attachments/assets/867948a0-6d59-4b09-80b6-954dceee125a)
