### PR TITLE
Fix crash on x0vncserver startup

### DIFF
--- a/common/network/TcpSocket.cxx
+++ b/common/network/TcpSocket.cxx
@@ -698,7 +698,7 @@ TcpFilter::Pattern TcpFilter::parsePattern(const char* p) {
   if (parts.size() > 2)
     throw std::invalid_argument("Invalid filter specified");
 
-  if (parts[0].empty()) {
+  if (parts.empty() || parts[0].empty()) {
     // Match any address
     memset (&pattern.address, 0, sizeof (pattern.address));
     pattern.address.u.sa.sa_family = AF_UNSPEC;


### PR DESCRIPTION
Test if the "parts" vector is not empty in TcpFilter::parsePattern() before attempting to access its first element.

Fixes: https://github.com/TigerVNC/tigervnc/issues/1958