### PR TITLE
Silence several GCC 14 warnings

### DIFF
--- a/common/core/Configuration.h
+++ b/common/core/Configuration.h
@@ -86,6 +86,8 @@ namespace core {
     std::list<VoidParameter*>::iterator begin() { return params.begin(); }
     std::list<VoidParameter*>::iterator end() { return params.end(); }
 
+    // - Returns the number of parameters
+    int size() { return params.size(); }
 
     // - Get the Global Configuration object
     //   NB: This call does NOT lock the Configuration system.

--- a/unix/xserver/hw/vnc/RFBGlue.cc
+++ b/unix/xserver/hw/vnc/RFBGlue.cc
@@ -150,13 +150,7 @@ int vncIsParamBool(const char *name)
 
 int vncGetParamCount(void)
 {
-  int count;
-
-  count = 0;
-  for (core::VoidParameter *param: *core::Configuration::global())
-    count++;
-
-  return count;
+  return core::Configuration::global()->size();
 }
 
 char *vncGetParamList(void)

--- a/unix/xserver/hw/vnc/xvnc.c
+++ b/unix/xserver/hw/vnc/xvnc.c
@@ -463,13 +463,7 @@ ddxProcessArgument(int argc, char *argv[], int i)
         }
     }
 
-    int ret;
-
-    ret = vncHandleParamArg(argc, argv, i);
-    if (ret != 0)
-        return ret;
-
-    return 0;
+    return vncHandleParamArg(argc, argv, i);
 }
 
 static Bool


### PR DESCRIPTION
xvnc.c: remove unnecessary test of function return value
core::Configuration: add a size() method
RFBGlue.cc: use size() obtain the number of configuration parameters