### PR TITLE
Fix cmake add_dependencies call

### DIFF
--- a/release/CMakeLists.txt
+++ b/release/CMakeLists.txt
@@ -57,14 +57,14 @@ if(UNIX)
 
 configure_file(maketarball.in maketarball)
 
+if(BUILD_JAVA)
+  set(TARBALL_JAVA_DEPENDENCY java)
+endif()
+
 set(PACKAGE_FILE ${CMAKE_PROJECT_NAME}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}-${VERSION}.tar.gz)
 add_custom_command(OUTPUT ${PACKAGE_FILE}
   COMMAND bash maketarball
-  DEPENDS maketarball vncviewer vncpasswd vncconfig)
-
-if(BUILD_JAVA)
-  add_dependencies(${PACKAGE_FILE} java)
-endif()
+  DEPENDS maketarball vncviewer vncpasswd vncconfig ${TARBALL_JAVA_DEPENDENCY})
 
 add_custom_target(tarball DEPENDS ${PACKAGE_FILE})
 


### PR DESCRIPTION
Try to fix this error:

CMake Error at release/CMakeLists.txt:66 (add_dependencies):
  Cannot add target-level dependencies to non-existent target
  "tigervnc-Linux-x86_64-1.15.80.tar.gz".

  The add_dependencies works for top-level logical targets created by the
  add_executable, add_library, or add_custom_target commands.  If you want to
  add file-level dependencies see the DEPENDS option of the add_custom_target
  and add_custom_command commands.

I get this error with cmake 3.31.7 and with cmake 4.0.2.