### PR TITLE
Handle invalid SNI names, and sort out TLS alert handling

### DIFF
--- a/common/network/Socket.cxx
+++ b/common/network/Socket.cxx
@@ -120,7 +120,7 @@ void Socket::shutdown()
   }
 
   isShutdown_ = true;
-  ::shutdown(getFd(), SHUT_RDWR);
+  ::shutdown(getFd(), SHUT_WR);
 }
 
 bool Socket::isShutdown() const

--- a/common/rdr/CMakeLists.txt
+++ b/common/rdr/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(rdr STATIC
   TLSException.cxx
   TLSInStream.cxx
   TLSOutStream.cxx
+  TLSSocket.cxx
   ZlibInStream.cxx
   ZlibOutStream.cxx)
 

--- a/common/rdr/InStream.h
+++ b/common/rdr/InStream.h
@@ -187,9 +187,7 @@ namespace rdr {
   private:
 
     const uint8_t* restorePoint;
-#ifdef RFB_INSTREAM_CHECK
     size_t checkedBytes;
-#endif
 
     inline void check(size_t bytes) {
 #ifdef RFB_INSTREAM_CHECK
@@ -209,11 +207,7 @@ namespace rdr {
 
   protected:
 
-    InStream() : restorePoint(nullptr)
-#ifdef RFB_INSTREAM_CHECK
-      ,checkedBytes(0)
-#endif
-     {}
+    InStream() : restorePoint(nullptr), checkedBytes(0) {}
     const uint8_t* ptr;
     const uint8_t* end;
   };

--- a/common/rdr/TLSException.cxx
+++ b/common/rdr/TLSException.cxx
@@ -35,11 +35,28 @@
 using namespace rdr;
 
 #ifdef HAVE_GNUTLS
-tls_error::tls_error(const char* s, int err_) noexcept
+tls_error::tls_error(const char* s, int err_, int alert_) noexcept
   : std::runtime_error(core::format("%s: %s (%d)", s,
-                                    gnutls_strerror(err_), err_)),
-    err(err_)
+                                    strerror(err_, alert_), err_)),
+    err(err_), alert(alert_)
 {
+}
+
+const char* tls_error::strerror(int err_, int alert_) const noexcept
+{
+  const char* msg;
+
+  msg = nullptr;
+
+  if ((alert_ != -1) &&
+      ((err_ == GNUTLS_E_WARNING_ALERT_RECEIVED) ||
+       (err_ == GNUTLS_E_FATAL_ALERT_RECEIVED)))
+    msg = gnutls_alert_get_name((gnutls_alert_description_t)alert_);
+
+  if (msg == nullptr)
+    msg = gnutls_strerror(err_);
+
+  return msg;
 }
 #endif /* HAVE_GNUTLS */
 

--- a/common/rdr/TLSException.h
+++ b/common/rdr/TLSException.h
@@ -27,8 +27,10 @@ namespace rdr {
 
   class tls_error : public std::runtime_error {
   public:
-    int err;
-    tls_error(const char* s, int err_) noexcept;
+    int err, alert;
+    tls_error(const char* s, int err_, int alert_=-1) noexcept;
+  private:
+    const char* strerror(int err_, int alert_) const noexcept;
   };
 
 }

--- a/common/rdr/TLSInStream.cxx
+++ b/common/rdr/TLSInStream.cxx
@@ -1,7 +1,7 @@
 /* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
  * Copyright (C) 2005 Martin Koegler
  * Copyright (C) 2010 TigerVNC Team
- * Copyright (C) 2012-2021 Pierre Ossman for Cendio AB
+ * Copyright 2012-2025 Pierre Ossman for Cendio AB
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,109 +23,30 @@
 #include <config.h>
 #endif
 
-#include <core/Exception.h>
-#include <core/LogWriter.h>
-
-#include <rdr/TLSException.h>
 #include <rdr/TLSInStream.h>
+#include <rdr/TLSSocket.h>
 
-#include <errno.h>
+#ifdef HAVE_GNUTLS
 
-#ifdef HAVE_GNUTLS 
 using namespace rdr;
 
-static core::LogWriter vlog("TLSInStream");
-
-ssize_t TLSInStream::pull(gnutls_transport_ptr_t str, void* data, size_t size)
+TLSInStream::TLSInStream(TLSSocket* sock_)
+  : sock(sock_)
 {
-  TLSInStream* self= (TLSInStream*) str;
-  InStream *in = self->in;
-
-  self->streamEmpty = false;
-  self->saved_exception = nullptr;
-
-  try {
-    if (!in->hasData(1)) {
-      self->streamEmpty = true;
-      gnutls_transport_set_errno(self->session, EAGAIN);
-      return -1;
-    }
-
-    if (in->avail() < size)
-      size = in->avail();
-  
-    in->readBytes((uint8_t*)data, size);
-  } catch (end_of_stream&) {
-    return 0;
-  } catch (std::exception& e) {
-    core::socket_error* se;
-    vlog.error("Failure reading TLS data: %s", e.what());
-    se = dynamic_cast<core::socket_error*>(&e);
-    if (se)
-      gnutls_transport_set_errno(self->session, se->err);
-    else
-      gnutls_transport_set_errno(self->session, EINVAL);
-    self->saved_exception = std::current_exception();
-    return -1;
-  }
-
-  return size;
-}
-
-TLSInStream::TLSInStream(InStream* _in, gnutls_session_t _session)
-  : session(_session), in(_in)
-{
-  gnutls_transport_ptr_t recv, send;
-
-  gnutls_transport_set_pull_function(session, pull);
-  gnutls_transport_get_ptr2(session, &recv, &send);
-  gnutls_transport_set_ptr2(session, this, send);
 }
 
 TLSInStream::~TLSInStream()
 {
-  gnutls_transport_set_pull_function(session, nullptr);
 }
 
 bool TLSInStream::fillBuffer()
 {
-  size_t n = readTLS((uint8_t*) end, availSpace());
+  size_t n = sock->readTLS((uint8_t*) end, availSpace());
   if (n == 0)
     return false;
   end += n;
 
   return true;
-}
-
-size_t TLSInStream::readTLS(uint8_t* buf, size_t len)
-{
-  int n;
-
-  while (true) {
-    streamEmpty = false;
-    n = gnutls_record_recv(session, (void *) buf, len);
-    if (n == GNUTLS_E_INTERRUPTED || n == GNUTLS_E_AGAIN) {
-      // GnuTLS returns GNUTLS_E_AGAIN for a bunch of other scenarios
-      // other than the pull function returning EAGAIN, so we have to
-      // double check that the underlying stream really is empty
-      if (!streamEmpty)
-        continue;
-      else
-        return 0;
-    }
-    break;
-  };
-
-  if (n == GNUTLS_E_PULL_ERROR)
-    std::rethrow_exception(saved_exception);
-
-  if (n < 0)
-    throw tls_error("readTLS", n);
-
-  if (n == 0)
-    throw end_of_stream();
-
-  return n;
 }
 
 #endif

--- a/common/rdr/TLSInStream.h
+++ b/common/rdr/TLSInStream.h
@@ -1,5 +1,6 @@
 /* Copyright (C) 2005 Martin Koegler
  * Copyright (C) 2010 TigerVNC Team
+ * Copyright 2012-2025 Pierre Ossman for Cendio AB
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,28 +23,25 @@
 
 #ifdef HAVE_GNUTLS
 
-#include <gnutls/gnutls.h>
 #include <rdr/BufferedInStream.h>
 
 namespace rdr {
 
+  class TLSSocket;
+
   class TLSInStream : public BufferedInStream {
   public:
-    TLSInStream(InStream* in, gnutls_session_t session);
+    TLSInStream(TLSSocket* sock);
     virtual ~TLSInStream();
 
   private:
     bool fillBuffer() override;
-    size_t readTLS(uint8_t* buf, size_t len);
-    static ssize_t pull(gnutls_transport_ptr_t str, void* data, size_t size);
 
-    gnutls_session_t session;
-    InStream* in;
-
-    bool streamEmpty;
-    std::exception_ptr saved_exception;
+    TLSSocket* sock;
   };
-};
+
+}
 
 #endif
+
 #endif

--- a/common/rdr/TLSOutStream.cxx
+++ b/common/rdr/TLSOutStream.cxx
@@ -1,7 +1,7 @@
 /* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
  * Copyright (C) 2005 Martin Koegler
  * Copyright (C) 2010 TigerVNC Team
- * Copyright (C) 2012-2021 Pierre Ossman for Cendio AB
+ * Copyright 2012-2025 Pierre Ossman for Cendio AB
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,103 +23,42 @@
 #include <config.h>
 #endif
 
-#include <core/Exception.h>
-#include <core/LogWriter.h>
-
-#include <rdr/TLSException.h>
 #include <rdr/TLSOutStream.h>
-
-#include <errno.h>
+#include <rdr/TLSSocket.h>
 
 #ifdef HAVE_GNUTLS
+
 using namespace rdr;
 
-static core::LogWriter vlog("TLSOutStream");
-
-ssize_t TLSOutStream::push(gnutls_transport_ptr_t str, const void* data,
-				   size_t size)
+TLSOutStream::TLSOutStream(TLSSocket* sock_)
+  : sock(sock_)
 {
-  TLSOutStream* self= (TLSOutStream*) str;
-  OutStream *out = self->out;
-
-  self->saved_exception = nullptr;
-
-  try {
-    out->writeBytes((const uint8_t*)data, size);
-    out->flush();
-  } catch (std::exception& e) {
-    core::socket_error* se;
-    vlog.error("Failure sending TLS data: %s", e.what());
-    se = dynamic_cast<core::socket_error*>(&e);
-    if (se)
-      gnutls_transport_set_errno(self->session, se->err);
-    else
-      gnutls_transport_set_errno(self->session, EINVAL);
-    self->saved_exception = std::current_exception();
-    return -1;
-  }
-
-  return size;
-}
-
-TLSOutStream::TLSOutStream(OutStream* _out, gnutls_session_t _session)
-  : session(_session), out(_out)
-{
-  gnutls_transport_ptr_t recv, send;
-
-  gnutls_transport_set_push_function(session, push);
-  gnutls_transport_get_ptr2(session, &recv, &send);
-  gnutls_transport_set_ptr2(session, recv, this);
 }
 
 TLSOutStream::~TLSOutStream()
 {
-#if 0
-  try {
-//    flush();
-  } catch (Exception&) {
-  }
-#endif
-  gnutls_transport_set_push_function(session, nullptr);
 }
 
 void TLSOutStream::flush()
 {
   BufferedOutStream::flush();
-  out->flush();
+  sock->out->flush();
 }
 
 void TLSOutStream::cork(bool enable)
 {
   BufferedOutStream::cork(enable);
-  out->cork(enable);
+  sock->out->cork(enable);
 }
 
 bool TLSOutStream::flushBuffer()
 {
   while (sentUpTo < ptr) {
-    size_t n = writeTLS(sentUpTo, ptr - sentUpTo);
+    size_t n = sock->writeTLS(sentUpTo, ptr - sentUpTo);
     sentUpTo += n;
   }
 
   return true;
-}
-
-size_t TLSOutStream::writeTLS(const uint8_t* data, size_t length)
-{
-  int n;
-
-  n = gnutls_record_send(session, data, length);
-  if (n == GNUTLS_E_INTERRUPTED || n == GNUTLS_E_AGAIN)
-    return 0;
-
-  if (n == GNUTLS_E_PUSH_ERROR)
-    std::rethrow_exception(saved_exception);
-
-  if (n < 0)
-    throw tls_error("writeTLS", n);
-
-  return n;
 }
 
 #endif

--- a/common/rdr/TLSOutStream.h
+++ b/common/rdr/TLSOutStream.h
@@ -21,14 +21,16 @@
 #define __RDR_TLSOUTSTREAM_H__
 
 #ifdef HAVE_GNUTLS
-#include <gnutls/gnutls.h>
+
 #include <rdr/BufferedOutStream.h>
 
 namespace rdr {
 
+  class TLSSocket;
+
   class TLSOutStream : public BufferedOutStream {
   public:
-    TLSOutStream(OutStream* out, gnutls_session_t session);
+    TLSOutStream(TLSSocket* out);
     virtual ~TLSOutStream();
 
     void flush() override;
@@ -36,15 +38,12 @@ namespace rdr {
 
   private:
     bool flushBuffer() override;
-    size_t writeTLS(const uint8_t* data, size_t length);
-    static ssize_t push(gnutls_transport_ptr_t str, const void* data, size_t size);
 
-    gnutls_session_t session;
-    OutStream* out;
-
-    std::exception_ptr saved_exception;
+    TLSSocket* sock;
   };
-};
+
+}
 
 #endif
+
 #endif

--- a/common/rdr/TLSSocket.cxx
+++ b/common/rdr/TLSSocket.cxx
@@ -67,6 +67,9 @@ bool TLSSocket::handshake()
 
   err = gnutls_handshake(session);
   if (err != GNUTLS_E_SUCCESS) {
+    if ((err == GNUTLS_E_PULL_ERROR) || (err == GNUTLS_E_PUSH_ERROR))
+      std::rethrow_exception(saved_exception);
+
     if (!gnutls_error_is_fatal(err)) {
       vlog.debug("Deferring completion of TLS handshake: %s", gnutls_strerror(err));
       return false;

--- a/common/rdr/TLSSocket.cxx
+++ b/common/rdr/TLSSocket.cxx
@@ -61,6 +61,28 @@ TLSSocket::~TLSSocket()
   gnutls_transport_set_ptr(session, nullptr);
 }
 
+void TLSSocket::shutdown()
+{
+  int ret;
+
+  try {
+    if (tlsout.hasBufferedData()) {
+      tlsout.cork(false);
+      tlsout.flush();
+      if (tlsout.hasBufferedData())
+        vlog.error("Failed to flush remaining socket data on close");
+    }
+  } catch (std::exception& e) {
+    vlog.error("Failed to flush remaining socket data on close: %s", e.what());
+  }
+
+  // FIXME: We can't currently wait for the response, so we only send
+  //        our close and hope for the best
+  ret = gnutls_bye(session, GNUTLS_SHUT_WR);
+  if ((ret != GNUTLS_E_SUCCESS) && (ret != GNUTLS_E_INVALID_SESSION))
+    vlog.error("TLS shutdown failed: %s", gnutls_strerror(ret));
+}
+
 size_t TLSSocket::readTLS(uint8_t* buf, size_t len)
 {
   int n;

--- a/common/rdr/TLSSocket.cxx
+++ b/common/rdr/TLSSocket.cxx
@@ -61,6 +61,24 @@ TLSSocket::~TLSSocket()
   gnutls_transport_set_ptr(session, nullptr);
 }
 
+bool TLSSocket::handshake()
+{
+  int err;
+
+  err = gnutls_handshake(session);
+  if (err != GNUTLS_E_SUCCESS) {
+    if (!gnutls_error_is_fatal(err)) {
+      vlog.debug("Deferring completion of TLS handshake: %s", gnutls_strerror(err));
+      return false;
+    }
+
+    vlog.error("TLS Handshake failed: %s\n", gnutls_strerror (err));
+    throw rdr::tls_error("TLS Handshake failed", err);
+  }
+
+  return true;
+}
+
 void TLSSocket::shutdown()
 {
   int ret;

--- a/common/rdr/TLSSocket.h
+++ b/common/rdr/TLSSocket.h
@@ -55,10 +55,8 @@ namespace rdr {
     friend TLSOutStream;
 
   private:
-    static ssize_t pull(gnutls_transport_ptr_t str, void* data,
-                        size_t size);
-    static ssize_t push(gnutls_transport_ptr_t str, const void* data,
-                        size_t size);
+    ssize_t pull(void* data, size_t size);
+    ssize_t push(const void* data, size_t size);
 
     gnutls_session_t session;
 

--- a/common/rdr/TLSSocket.h
+++ b/common/rdr/TLSSocket.h
@@ -46,6 +46,7 @@ namespace rdr {
     TLSInStream& inStream() { return tlsin; }
     TLSOutStream& outStream() { return tlsout; }
 
+    bool handshake();
     void shutdown();
 
   protected:

--- a/common/rdr/TLSSocket.h
+++ b/common/rdr/TLSSocket.h
@@ -1,0 +1,80 @@
+/* Copyright (C) 2005 Martin Koegler
+ * Copyright (C) 2010 TigerVNC Team
+ * Copyright 2012-2025 Pierre Ossman for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+ * USA.
+ */
+
+#ifndef __RDR_TLSSOCKET_H__
+#define __RDR_TLSSOCKET_H__
+
+#ifdef HAVE_GNUTLS
+
+#include <exception>
+
+#include <gnutls/gnutls.h>
+
+#include <rdr/TLSInStream.h>
+#include <rdr/TLSOutStream.h>
+
+namespace rdr {
+
+  class InStream;
+  class OutStream;
+
+  class TLSInStream;
+  class TLSOutStream;
+
+  class TLSSocket {
+  public:
+    TLSSocket(InStream* in, OutStream* out, gnutls_session_t session);
+    virtual ~TLSSocket();
+
+    TLSInStream& inStream() { return tlsin; }
+    TLSOutStream& outStream() { return tlsout; }
+
+  protected:
+    /* Used by the stream classes */
+    size_t readTLS(uint8_t* buf, size_t len);
+    size_t writeTLS(const uint8_t* data, size_t length);
+
+    friend TLSInStream;
+    friend TLSOutStream;
+
+  private:
+    static ssize_t pull(gnutls_transport_ptr_t str, void* data,
+                        size_t size);
+    static ssize_t push(gnutls_transport_ptr_t str, const void* data,
+                        size_t size);
+
+    gnutls_session_t session;
+
+    InStream* in;
+    OutStream* out;
+
+    TLSInStream tlsin;
+    TLSOutStream tlsout;
+
+    bool streamEmpty;
+
+    std::exception_ptr saved_exception;
+  };
+
+}
+
+#endif
+
+#endif

--- a/common/rdr/TLSSocket.h
+++ b/common/rdr/TLSSocket.h
@@ -46,6 +46,8 @@ namespace rdr {
     TLSInStream& inStream() { return tlsin; }
     TLSOutStream& outStream() { return tlsout; }
 
+    void shutdown();
+
   protected:
     /* Used by the stream classes */
     size_t readTLS(uint8_t* buf, size_t len);

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -147,25 +147,18 @@ bool CSecurityTLS::processMsg()
 
     setParam();
 
-    // Create this early as it sets up the push/pull functions for
-    // GnuTLS
     tlssock = new rdr::TLSSocket(is, os, session);
 
     rawis = is;
     rawos = os;
   }
 
-  int err;
-  err = gnutls_handshake(session);
-  if (err != GNUTLS_E_SUCCESS) {
-    if (!gnutls_error_is_fatal(err)) {
-      vlog.debug("Deferring completion of TLS handshake: %s", gnutls_strerror(err));
+  try {
+    if (!tlssock->handshake())
       return false;
-    }
-
-    vlog.error("TLS Handshake failed: %s\n", gnutls_strerror (err));
+  } catch (std::exception&) {
     shutdown();
-    throw rdr::tls_error("TLS Handshake failed", err);
+    throw;
   }
 
   vlog.debug("TLS handshake completed with %s",

--- a/common/rfb/CSecurityTLS.cxx
+++ b/common/rfb/CSecurityTLS.cxx
@@ -84,27 +84,8 @@ CSecurityTLS::CSecurityTLS(CConnection* cc_, bool _anon)
 
 void CSecurityTLS::shutdown()
 {
-  if (tlssock) {
-    try {
-      if (tlssock->outStream().hasBufferedData()) {
-        tlssock->outStream().cork(false);
-        tlssock->outStream().flush();
-        if (tlssock->outStream().hasBufferedData())
-          vlog.error("Failed to flush remaining socket data on close");
-      }
-    } catch (std::exception& e) {
-      vlog.error("Failed to flush remaining socket data on close: %s", e.what());
-    }
-  }
-
-  if (session) {
-    int ret;
-    // FIXME: We can't currently wait for the response, so we only send
-    //        our close and hope for the best
-    ret = gnutls_bye(session, GNUTLS_SHUT_WR);
-    if ((ret != GNUTLS_E_SUCCESS) && (ret != GNUTLS_E_INVALID_SESSION))
-      vlog.error("TLS shutdown failed: %s", gnutls_strerror(ret));
-  }
+  if (tlssock)
+    tlssock->shutdown();
 
   if (anon_cred) {
     gnutls_anon_free_client_credentials(anon_cred);

--- a/common/rfb/CSecurityTLS.h
+++ b/common/rfb/CSecurityTLS.h
@@ -2,6 +2,7 @@
  * Copyright (C) 2004 Red Hat Inc.
  * Copyright (C) 2005 Martin Koegler
  * Copyright (C) 2010 TigerVNC Team
+ * Copyright 2012-2025 Pierre Ossman for Cendio AB
  *    
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,8 +35,7 @@
 namespace rdr {
   class InStream;
   class OutStream;
-  class TLSInStream;
-  class TLSOutStream;
+  class TLSSocket;
 }
 
 namespace rfb {
@@ -63,8 +63,7 @@ namespace rfb {
     gnutls_certificate_credentials_t cert_cred;
     bool anon;
 
-    rdr::TLSInStream* tlsis;
-    rdr::TLSOutStream* tlsos;
+    rdr::TLSSocket* tlssock;
 
     rdr::InStream* rawis;
     rdr::OutStream* rawos;

--- a/common/rfb/SSecurityTLS.cxx
+++ b/common/rfb/SSecurityTLS.cxx
@@ -2,7 +2,7 @@
  * Copyright (C) 2004 Red Hat Inc.
  * Copyright (C) 2005 Martin Koegler
  * Copyright (C) 2010 TigerVNC Team
- * Copyright (C) 2012-2021 Pierre Ossman for Cendio AB
+ * Copyright 2012-2025 Pierre Ossman for Cendio AB
  *    
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,8 +37,7 @@
 #include <rfb/Exception.h>
 
 #include <rdr/TLSException.h>
-#include <rdr/TLSInStream.h>
-#include <rdr/TLSOutStream.h>
+#include <rdr/TLSSocket.h>
 
 #include <gnutls/x509.h>
 
@@ -72,7 +71,7 @@ static core::LogWriter vlog("TLS");
 
 SSecurityTLS::SSecurityTLS(SConnection* sc_, bool _anon)
   : SSecurity(sc_), session(nullptr), anon_cred(nullptr),
-    cert_cred(nullptr), anon(_anon), tlsis(nullptr), tlsos(nullptr),
+    cert_cred(nullptr), anon(_anon), tlssock(nullptr),
     rawis(nullptr), rawos(nullptr)
 {
   int ret;
@@ -88,12 +87,12 @@ SSecurityTLS::SSecurityTLS(SConnection* sc_, bool _anon)
 
 void SSecurityTLS::shutdown()
 {
-  if (tlsos) {
+  if (tlssock) {
     try {
-      if (tlsos->hasBufferedData()) {
-        tlsos->cork(false);
-        tlsos->flush();
-        if (tlsos->hasBufferedData())
+      if (tlssock->outStream().hasBufferedData()) {
+        tlssock->outStream().cork(false);
+        tlssock->outStream().flush();
+        if (tlssock->outStream().hasBufferedData())
           vlog.error("Failed to flush remaining socket data on close");
       }
     } catch (std::exception& e) {
@@ -133,13 +132,9 @@ void SSecurityTLS::shutdown()
     rawos = nullptr;
   }
 
-  if (tlsis) {
-    delete tlsis;
-    tlsis = nullptr;
-  }
-  if (tlsos) {
-    delete tlsos;
-    tlsos = nullptr;
+  if (tlssock) {
+    delete tlssock;
+    tlssock = nullptr;
   }
 
   if (session) {
@@ -185,10 +180,9 @@ bool SSecurityTLS::processMsg()
     os->writeU8(1);
     os->flush();
 
-    // Create these early as they set up the push/pull functions
-    // for GnuTLS
-    tlsis = new rdr::TLSInStream(is, session);
-    tlsos = new rdr::TLSOutStream(os, session);
+    // Create this early as it sets up the push/pull functions for
+    // GnuTLS
+    tlssock = new rdr::TLSSocket(is, os, session);
 
     rawis = is;
     rawos = os;
@@ -208,7 +202,7 @@ bool SSecurityTLS::processMsg()
   vlog.debug("TLS handshake completed with %s",
              gnutls_session_get_desc(session));
 
-  sc->setStreams(tlsis, tlsos);
+  sc->setStreams(&tlssock->inStream(), &tlssock->outStream());
 
   return true;
 }

--- a/common/rfb/SSecurityTLS.cxx
+++ b/common/rfb/SSecurityTLS.cxx
@@ -87,27 +87,8 @@ SSecurityTLS::SSecurityTLS(SConnection* sc_, bool _anon)
 
 void SSecurityTLS::shutdown()
 {
-  if (tlssock) {
-    try {
-      if (tlssock->outStream().hasBufferedData()) {
-        tlssock->outStream().cork(false);
-        tlssock->outStream().flush();
-        if (tlssock->outStream().hasBufferedData())
-          vlog.error("Failed to flush remaining socket data on close");
-      }
-    } catch (std::exception& e) {
-      vlog.error("Failed to flush remaining socket data on close: %s", e.what());
-    }
-  }
-
-  if (session) {
-    int ret;
-    // FIXME: We can't currently wait for the response, so we only send
-    //        our close and hope for the best
-    ret = gnutls_bye(session, GNUTLS_SHUT_WR);
-    if ((ret != GNUTLS_E_SUCCESS) && (ret != GNUTLS_E_INVALID_SESSION))
-      vlog.error("TLS shutdown failed: %s", gnutls_strerror(ret));
-  }
+  if (tlssock)
+    tlssock->shutdown();
 
 #if defined (SSECURITYTLS__USE_DEPRECATED_DH)
   if (dh_params) {

--- a/common/rfb/SSecurityTLS.cxx
+++ b/common/rfb/SSecurityTLS.cxx
@@ -161,23 +161,18 @@ bool SSecurityTLS::processMsg()
     os->writeU8(1);
     os->flush();
 
-    // Create this early as it sets up the push/pull functions for
-    // GnuTLS
     tlssock = new rdr::TLSSocket(is, os, session);
 
     rawis = is;
     rawos = os;
   }
 
-  err = gnutls_handshake(session);
-  if (err != GNUTLS_E_SUCCESS) {
-    if (!gnutls_error_is_fatal(err)) {
-      vlog.debug("Deferring completion of TLS handshake: %s", gnutls_strerror(err));
+  try {
+    if (!tlssock->handshake())
       return false;
-    }
-    vlog.error("TLS Handshake failed: %s", gnutls_strerror (err));
+  } catch (std::exception&) {
     shutdown();
-    throw rdr::tls_error("TLS Handshake failed", err);
+    throw;
   }
 
   vlog.debug("TLS handshake completed with %s",

--- a/common/rfb/SSecurityTLS.h
+++ b/common/rfb/SSecurityTLS.h
@@ -2,6 +2,7 @@
  * Copyright (C) 2004 Red Hat Inc.
  * Copyright (C) 2005 Martin Koegler
  * Copyright (C) 2010 TigerVNC Team
+ * Copyright 2012-2025 Pierre Ossman for Cendio AB
  *    
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,8 +42,7 @@
 namespace rdr {
   class InStream;
   class OutStream;
-  class TLSInStream;
-  class TLSOutStream;
+  class TLSSocket;
 }
 
 namespace rfb {
@@ -72,8 +72,7 @@ namespace rfb {
 
     bool anon;
 
-    rdr::TLSInStream* tlsis;
-    rdr::TLSOutStream* tlsos;
+    rdr::TLSSocket* tlssock;
 
     rdr::InStream* rawis;
     rdr::OutStream* rawos;

--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -138,6 +138,8 @@ CConn::~CConn()
   if (desktop)
     delete desktop;
 
+  sock->shutdown();
+
   if (sock)
     Fl::remove_fd(sock->getFd());
   delete sock;


### PR DESCRIPTION
Primarily this fixes #1966. But it also exposed a need to handle TLS alerts better. Which in turn required a general cleanup of the TLS handling.