### PR TITLE
Java Viewer: Add zoom controls, arrow key scrolling toggle, and fix FixedRatio saving

### DIFF
--- a/java/com/tigervnc/vncviewer/DesktopWindow.java
+++ b/java/com/tigervnc/vncviewer/DesktopWindow.java
@@ -63,6 +63,19 @@ public class DesktopWindow extends JFrame
     scroll = new JScrollPane(new Viewport(w, h, serverPF, cc));
     viewport = (Viewport)scroll.getViewport().getView();
     scroll.setBorder(BorderFactory.createEmptyBorder(0,0,0,0));
+    if (disableArrowScroll.getValue()) {
+      InputMap im = scroll.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+      if (im != null) {
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, 0), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_HOME, 0), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_END, 0), "none");
+      }
+    }
     getContentPane().add(scroll);
 
     setName(name);

--- a/java/com/tigervnc/vncviewer/DesktopWindow.java
+++ b/java/com/tigervnc/vncviewer/DesktopWindow.java
@@ -625,6 +625,52 @@ public class DesktopWindow extends JFrame
     }
   }
 
+  // Compute current effective scale from the viewport ratio
+  public int getCurrentScalePercent()
+  {
+    return (int)Math.round(viewport.scaleRatioX * 100.0f);
+  }
+
+  public void setNumericScalePercent(int percent)
+  {
+    if (remoteResize.getValue())
+      return;
+
+    int clamped = Math.max(1, percent);
+    scalingFactor.setParam(Integer.toString(clamped));
+    handleOptions();
+  }
+
+  public void adjustRelativeScalePercent(int deltaPercent)
+  {
+    if (remoteResize.getValue())
+      return;
+
+    String scaleString = scalingFactor.getValue();
+    int current;
+    if (scaleString.matches("^[0-9]+$")) {
+      current = Integer.parseInt(scaleString);
+    } else {
+      current = getCurrentScalePercent();
+    }
+    setNumericScalePercent(current + deltaPercent);
+  }
+
+  public void resetZoomToDefault()
+  {
+    if (remoteResize.getValue())
+      return;
+    setNumericScalePercent(100);
+  }
+
+  public void setZoomToFit()
+  {
+    if (remoteResize.getValue())
+      return;
+    scalingFactor.setParam("FixedRatio");
+    handleOptions();
+  }
+
   public void handleFullscreenTimeout()
   {
     DesktopWindow self = (DesktopWindow)this;

--- a/java/com/tigervnc/vncviewer/OptionsDialog.java
+++ b/java/com/tigervnc/vncviewer/OptionsDialog.java
@@ -135,6 +135,7 @@ class OptionsDialog extends Dialog {
   JCheckBox viewOnlyCheckbox;
   JCheckBox acceptClipboardCheckbox;
   JCheckBox sendClipboardCheckbox;
+  JCheckBox disableArrowScrollCheckbox;
   JComboBox menuKeyChoice;
 
   /* Screen */
@@ -417,6 +418,7 @@ class OptionsDialog extends Dialog {
     viewOnlyCheckbox.setSelected(viewOnly.getValue());
     acceptClipboardCheckbox.setSelected(acceptClipboard.getValue());
     sendClipboardCheckbox.setSelected(sendClipboard.getValue());
+    disableArrowScrollCheckbox.setSelected(disableArrowScroll.getValue());
 
     menuKeyChoice.setSelectedIndex(0);
 
@@ -592,6 +594,7 @@ class OptionsDialog extends Dialog {
     viewOnly.setParam(viewOnlyCheckbox.isSelected());
     acceptClipboard.setParam(acceptClipboardCheckbox.isSelected());
     sendClipboard.setParam(sendClipboardCheckbox.isSelected());
+    disableArrowScroll.setParam(disableArrowScrollCheckbox.isSelected());
 
     String menuKeyStr =
       MenuKey.getMenuKeySymbols()[menuKeyChoice.getSelectedIndex()].name;
@@ -1006,6 +1009,7 @@ class OptionsDialog extends Dialog {
     viewOnlyCheckbox = new JCheckBox("View only (ignore mouse and keyboard)");
     acceptClipboardCheckbox = new JCheckBox("Accept clipboard from server");
     sendClipboardCheckbox = new JCheckBox("Send clipboard to server");
+    disableArrowScrollCheckbox = new JCheckBox("Disable arrow-key scrolling when scrollbars visible");
     JLabel menuKeyLabel = new JLabel("Menu key");
     String[] menuKeys = new String[MenuKey.getMenuKeySymbolCount()];
     //menuKeys[0] = "None";
@@ -1034,15 +1038,22 @@ class OptionsDialog extends Dialog {
                                           LINE_START, NONE,
                                           new Insets(0, 0, 4, 0),
                                           NONE, NONE));
-    inputPanel.add(menuKeyLabel,
+    inputPanel.add(disableArrowScrollCheckbox,
                    new GridBagConstraints(0, 3,
+                                          REMAINDER, 1,
+                                          HEAVY, LIGHT,
+                                          LINE_START, NONE,
+                                          new Insets(0, 0, 4, 0),
+                                          NONE, NONE));
+    inputPanel.add(menuKeyLabel,
+                   new GridBagConstraints(0, 4,
                                           1, 1,
                                           LIGHT, LIGHT,
                                           LINE_START, NONE,
                                           new Insets(0, 0, 0, 0),
                                           NONE, NONE));
     inputPanel.add(menuKeyChoice,
-                   new GridBagConstraints(1, 3,
+                   new GridBagConstraints(1, 4,
                                           1, 1,
                                           HEAVY, LIGHT,
                                           LINE_START, NONE,

--- a/java/com/tigervnc/vncviewer/OptionsDialog.java
+++ b/java/com/tigervnc/vncviewer/OptionsDialog.java
@@ -613,7 +613,7 @@ class OptionsDialog extends Dialog {
 
     String scaleStr =
       ((String)scalingFactorInput.getSelectedItem()).replace("%", "");
-    scaleStr.replace("Fixed Aspect Ratio", "FixedRatio");
+    scaleStr = scaleStr.replace("Fixed Aspect Ratio", "FixedRatio");
     scalingFactor.setParam(scaleStr);
 
     /* Misc. */

--- a/java/com/tigervnc/vncviewer/Parameters.java
+++ b/java/com/tigervnc/vncviewer/Parameters.java
@@ -145,6 +145,11 @@ public class Parameters {
     "Send clipboard changes to the server",
     true);
 
+  public static BoolParameter disableArrowScroll
+  = new BoolParameter("DisableArrowScroll",
+    "Disable arrow-key scrolling of the viewer when scrollbars are visible",
+    false);
+
   public static IntParameter maxCutText
   = new IntParameter("MaxCutText",
     "Maximum permitted length of an outgoing clipboard update",
@@ -311,6 +316,7 @@ public class Parameters {
     shared,
     acceptClipboard,
     sendClipboard,
+    disableArrowScroll,
     menuKey,
     noLionFS,
     sendLocalUsername,

--- a/java/com/tigervnc/vncviewer/Viewport.java
+++ b/java/com/tigervnc/vncviewer/Viewport.java
@@ -56,7 +56,8 @@ class Viewport extends JPanel implements ActionListener {
 
   enum ID { EXIT, FULLSCREEN, MINIMIZE, RESIZE, NEWVIEWER,
             CTRL, ALT, MENUKEY, CTRLALTDEL, CLIPBOARD,
-            REFRESH, OPTIONS, INFO, ABOUT, DISMISS }
+            REFRESH, OPTIONS, INFO, ABOUT, DISMISS,
+            ZOOM_IN, ZOOM_OUT, ZOOM_RESET, ZOOM_TO_FIT }
 
   enum MENU { INACTIVE, TOGGLE, VALUE, RADIO,
               INVISIBLE, SUBMENU_POINTER, SUBMENU, DIVIDER }
@@ -650,6 +651,15 @@ class Viewport extends JPanel implements ActionListener {
     menu_add(contextMenu, "About TigerVNC...", KeyEvent.VK_T,
              this, ID.ABOUT, EnumSet.of(MENU.DIVIDER));
 
+    menu_add(contextMenu, "Zoom in", KeyEvent.VK_EQUALS,
+             this, ID.ZOOM_IN, EnumSet.noneOf(MENU.class));
+    menu_add(contextMenu, "Zoom out", KeyEvent.VK_MINUS,
+             this, ID.ZOOM_OUT, EnumSet.noneOf(MENU.class));
+    menu_add(contextMenu, "Reset zoom", KeyEvent.VK_0,
+             this, ID.ZOOM_RESET, EnumSet.noneOf(MENU.class));
+    menu_add(contextMenu, "Zoom to fit (fixed aspect)", KeyEvent.VK_F,
+             this, ID.ZOOM_TO_FIT, EnumSet.of(MENU.DIVIDER));
+
     menu_add(contextMenu, "Dismiss menu", KeyEvent.VK_M,
              this, ID.DISMISS, EnumSet.noneOf(MENU.class));
   }
@@ -767,6 +777,18 @@ class Viewport extends JPanel implements ActionListener {
       break;
     case ABOUT:
       VncViewer.about_vncviewer(cc.desktop);
+      break;
+    case ZOOM_IN:
+      if (!remoteResize.getValue()) window().adjustRelativeScalePercent(5);
+      break;
+    case ZOOM_OUT:
+      if (!remoteResize.getValue()) window().adjustRelativeScalePercent(-5);
+      break;
+    case ZOOM_RESET:
+      if (!remoteResize.getValue()) window().resetZoomToDefault();
+      break;
+    case ZOOM_TO_FIT:
+      if (!remoteResize.getValue()) window().setZoomToFit();
       break;
     case DISMISS:
       break;


### PR DESCRIPTION
This pull request introduces the following enhancements and fixes to the Java Viewer:

### New Features

* **Zoom controls in the viewer menu**

  * *Zoom in*: Increase scale factor by 5%
  * *Zoom out*: Decrease scale factor by 5%
  * *Reset zoom*: Reset scale factor to 100%
  * *Zoom to fit (fixed aspect)*: Set scale factor to `FixedRatio`

* **Option to disable arrow key scrolling**

  * Added a setting in the Options dialog to disable arrow key scrolling when a scrollbar is visible (overrides default `JScrollPane` behavior).

### Bug Fix

* Fixed an issue in `storeOptions` where `Fixed Aspect Ratio` option was not correctly saved as `FixedRatio`.