### PR TITLE
Fix incorrect buffer copy fallback in PipeWire

### DIFF
--- a/unix/w0vncserver/PipeWirePixelBuffer.cxx
+++ b/unix/w0vncserver/PipeWirePixelBuffer.cxx
@@ -122,8 +122,13 @@ void PipeWirePixelBuffer::processFrame(spa_buffer* buffer)
                    rect.tl.y, rect.width(), rect.height());
   commitBufferRW(rect);
 
-  if (!ret)
-    imageRect(pipewirePixelFormat, rect, srcBuffer, srcStride);
+  if (!ret) {
+    uint8_t* damagedBuffer;
+
+    damagedBuffer = &srcBuffer[(pipewirePixelFormat.bpp / 8) *
+                               (rect.tl.y * srcStride + rect.tl.x)];
+    imageRect(pipewirePixelFormat, rect, damagedBuffer, srcStride);
+  }
 
   server->add_changed(rect);
   accumulatedDamage.clear();


### PR DESCRIPTION
This was missed when damage tracking was added in
ca55a89a13731e2e1d016c3742d56a5424417729.