### PR TITLE
PortalDesktop: Enable using restore_token

### DIFF
--- a/unix/w0vncserver/PortalDesktop.cxx
+++ b/unix/w0vncserver/PortalDesktop.cxx
@@ -22,13 +22,12 @@
 
 #include <assert.h>
 
-#include <exception>
-
 #include <gio/gio.h>
 
 #include <rfb/ScreenSet.h>
 #include <rfb/VNCServerST.h>
 #include <core/LogWriter.h>
+#include <core/xdgdirs.h>
 
 #include "w0vncserver.h"
 #include "portals/RemoteDesktop.h"
@@ -39,7 +38,8 @@
 static core::LogWriter vlog("PortalDesktop");
 
 PortalDesktop::PortalDesktop()
-  : server(nullptr), remoteDesktop(nullptr), pb(nullptr)
+  : server(nullptr), remoteDesktop(nullptr), pb(nullptr),
+    restoreToken("")
 {
 }
 
@@ -72,7 +72,7 @@ void PortalDesktop::start()
     server->closeClients(reason);
   };
 
-  remoteDesktop = new RemoteDesktop(startPipewire, cancelStart);
+  remoteDesktop = new RemoteDesktop(restoreToken, startPipewire, cancelStart);
   remoteDesktop->createSession();
 }
 
@@ -83,6 +83,7 @@ void PortalDesktop::stop()
   delete pb;
   pb = nullptr;
 
+  restoreToken = remoteDesktop->getRestoreToken();
   delete remoteDesktop;
   remoteDesktop = nullptr;
 }

--- a/unix/w0vncserver/PortalDesktop.h
+++ b/unix/w0vncserver/PortalDesktop.h
@@ -21,6 +21,8 @@
 
 #include <glib.h>
 
+#include <string>
+
 #include <rfb/SDesktop.h>
 
 class PipeWirePixelBuffer;
@@ -56,6 +58,9 @@ protected:
 
   RemoteDesktop* remoteDesktop;
   PipeWirePixelBuffer* pb;
+
+private:
+  std::string restoreToken;
 };
 
 #endif // __PORTAL_DESKTOP_H__

--- a/unix/w0vncserver/portals/RemoteDesktop.cxx
+++ b/unix/w0vncserver/portals/RemoteDesktop.cxx
@@ -21,15 +21,21 @@
 #endif
 
 #include <stdint.h>
+#include <stdio.h>
 #include <assert.h>
 #include <sys/select.h>
+#include <uuid/uuid.h>
 #include <linux/input-event-codes.h>
+
+#include <string>
 
 #include <glib.h>
 #include <gio/gunixfdlist.h>
 
+#include <core/Configuration.h>
 #include <core/LogWriter.h>
 #include <core/string.h>
+#include <core/xdgdirs.h>
 
 #include "../w0vncserver.h"
 #include "portalConstants.h"
@@ -51,6 +57,12 @@ core::BoolParameter localCursor("experimentalPortalLocalCursor",
                                 "[EXPERIMENTAL] Render cursor locally",
                                 false);
 
+core::EnumParameter askDisplayChoice("portalAskDisplayChoice",
+                                      "Ask about display choice on connect",
+                                      {"Always", "Once", "Never"}, "Once");
+
+static const char* RESTORE_TOKEN_FILENAME =  "tigervnc.restoretoken";
+
 static core::LogWriter vlog("RemoteDesktop");
 
 static int getInputCode(uint32_t button)
@@ -71,13 +83,15 @@ static int getInputCode(uint32_t button)
   }
 }
 
-RemoteDesktop::RemoteDesktop(std::function<void(int fd, uint32_t nodeId)>
+RemoteDesktop::RemoteDesktop(std::string restoreToken_,
+                             std::function<void(int fd, uint32_t nodeId)>
                                startPipewireCb_,
                              std::function<void(const char*)>
                                cancelStartCb_)
   : sessionStarted(false), oldButtonMask(0), selectedDevices(0),
     sessionHandle(""), remoteDesktop(nullptr), screenCast(nullptr),
-    session(nullptr), startPipewireCb(startPipewireCb_),
+    session(nullptr), restoreToken(restoreToken_),
+    startPipewireCb(startPipewireCb_),
     cancelStartCb(cancelStartCb_)
 {
   remoteDesktop = new PortalProxy("org.freedesktop.portal.Desktop",
@@ -239,15 +253,19 @@ void RemoteDesktop::selectDevices()
   requestHandleToken = remoteDesktop->newHandle();
 
   g_variant_builder_init(&optionsBuilder, G_VARIANT_TYPE_VARDICT);
+
   g_variant_builder_add(&optionsBuilder, "{sv}", "types",
                         g_variant_new_uint32(DEV_KEYBOARD | DEV_POINTER));
   g_variant_builder_add(&optionsBuilder, "{sv}", "persist_mode",
-                        g_variant_new_uint32(0));
-
-  // FIXME: Do we want restore_token?
+                        g_variant_new_uint32(PERSIST_UNTIL_REVOKED));
 
   g_variant_builder_add(&optionsBuilder, "{sv}", "handle_token",
                         g_variant_new_string(requestHandleToken.c_str()));
+
+  if (loadRestoreToken()) {
+    g_variant_builder_add(&optionsBuilder, "{sv}", "restore_token",
+                          g_variant_new_string(restoreToken.c_str()));
+  }
 
   params = g_variant_new("(oa{sv})", sessionHandle.c_str(), &optionsBuilder);
 
@@ -375,6 +393,7 @@ void RemoteDesktop::handleStart(GVariant* parameters)
   GVariant* result;
   GVariant* streams_;
   GVariant* devices;
+  GVariant* restoreToken_;
 
   assert(!sessionStarted);
 
@@ -410,6 +429,14 @@ void RemoteDesktop::handleStart(GVariant* parameters)
     g_variant_unref(streams_);
     fatal_error("Failed to parse streams");
     return;
+  }
+
+  restoreToken_ = g_variant_lookup_value(result, "restore_token",
+                                         G_VARIANT_TYPE_STRING);
+
+  if (restoreToken_ && askDisplayChoice == "Never") {
+    storeRestoreToken(g_variant_get_string(restoreToken_, nullptr));
+    g_variant_unref(restoreToken_);
   }
 
   openPipewireRemote();
@@ -497,5 +524,136 @@ bool RemoteDesktop::parseStreams(GVariant* streams)
 
   g_variant_unref(stream);
 
+  return true;
+}
+
+bool RemoteDesktop::loadRestoreToken()
+{
+  char filepath[PATH_MAX];
+  FILE* f;
+  const char* stateDir;
+  char restoreToken_[37];
+
+  // Allows users to reset the restore token by not choosing "Never"
+  if (askDisplayChoice != "Never")
+    clearRestoreToken();
+
+  if (askDisplayChoice == "Always")
+    return false;
+
+  // restoreToken will be empty the first time, we want to prompt the user
+  if (askDisplayChoice == "Once")
+    return !restoreToken.empty();
+
+  assert(askDisplayChoice == "Never");
+
+  // Only load from disk the first time
+  if (!restoreToken.empty())
+    return true;
+
+  stateDir = core::getvncstatedir();
+  if (!stateDir) {
+    vlog.error("Could not get state directory");
+    return false;
+  }
+
+  snprintf(filepath, sizeof(filepath), "%s/%s", stateDir, RESTORE_TOKEN_FILENAME);
+  f = fopen(filepath, "r");
+  if (!f) {
+    vlog.error("Could not open \"%s\": %s", filepath, strerror(errno));
+    return false;
+  }
+
+  if (fgets(restoreToken_, sizeof(restoreToken_), f)) {
+    uuid_t uuid;
+
+    fclose(f);
+    if (uuid_parse(restoreToken_, uuid) < 0) {
+      vlog.error("Invalid restore token, not a valid UUID string \"%s\"", restoreToken_);
+      return clearRestoreToken();
+    }
+    restoreToken = restoreToken_;
+    return true;
+  }
+  fclose(f);
+
+  vlog.error("Could not read restore token from \"%s\"", filepath);
+  return false;
+}
+
+bool RemoteDesktop::storeRestoreToken(const char* restoreToken_)
+{
+  char filepath[PATH_MAX];
+  FILE* f;
+  const char* stateDir;
+
+  assert(restoreToken_ != nullptr);
+
+  // Don't store anything
+  if (askDisplayChoice == "Always")
+    return true;
+
+  // Store token in memory
+  restoreToken = restoreToken_;
+
+  if (askDisplayChoice == "Once")
+    return true;
+
+  assert(askDisplayChoice == "Never");
+
+  // Store token to file so it can be re-used on next startup
+  stateDir = core::getvncstatedir();
+  if (!stateDir) {
+    vlog.error("Could not determine VNC state directory path, cannot store restore token");
+    return false;
+  }
+
+  if (core::mkdir_p(stateDir, 0755) == -1) {
+    if (errno != EEXIST) {
+      vlog.error("Could not create VNC config directory \"%s\": %s",
+                  stateDir, strerror(errno));
+      return false;
+    }
+  }
+
+  snprintf(filepath, sizeof(filepath), "%s/%s", stateDir,
+           RESTORE_TOKEN_FILENAME);
+
+  f = fopen(filepath, "w");
+  if (!f) {
+    vlog.error("Could not restore token from \"%s\": %s", filepath, strerror(errno));
+    return false;
+  }
+
+  fprintf(f, "%s", restoreToken_);
+  fclose(f);
+
+  return true;
+}
+
+
+bool RemoteDesktop::clearRestoreToken()
+{
+  char filepath[PATH_MAX];
+  const char* stateDir;
+  FILE* f;
+
+  restoreToken = "";
+
+  stateDir = core::getvncstatedir();
+  if (!stateDir) {
+    vlog.error("Could not get state directory");
+    return false;
+  }
+
+  snprintf(filepath, sizeof(filepath), "%s/%s", stateDir, RESTORE_TOKEN_FILENAME);
+
+  f = fopen(filepath, "w");
+  if (!f) {
+    vlog.error("Could not restore token from \"%s\": %s", filepath, strerror(errno));
+    return false;
+  }
+
+  fclose(f);
   return true;
 }

--- a/unix/w0vncserver/portals/RemoteDesktop.h
+++ b/unix/w0vncserver/portals/RemoteDesktop.h
@@ -32,7 +32,8 @@ class PortalProxy;
 
 class RemoteDesktop {
 public:
-  RemoteDesktop(std::function<void(int fd, uint32_t nodeId)> startPipewireCb,
+  RemoteDesktop(std::string restoreToken,
+                std::function<void(int fd, uint32_t nodeId)> startPipewireCb,
                 std::function<void(const char*)> cancelStartCb);
   ~RemoteDesktop();
 
@@ -42,6 +43,8 @@ public:
 
   // Create a Portal session
   void createSession();
+
+  std::string getRestoreToken() const { return restoreToken; }
 
 private:
   // Portal methods
@@ -65,6 +68,13 @@ private:
   // Parses ScreenCast streams. Returns false on error
   bool parseStreams(GVariant* streams);
 
+  // Loads the restore token, returns false on error
+  bool loadRestoreToken();
+  // Stores the restore token, returns false on error
+  bool storeRestoreToken(const char* restoreToken);
+  // Resets the restore token, returns false on error
+  bool clearRestoreToken();
+
 private:
   bool sessionStarted;
   uint16_t oldButtonMask;
@@ -75,6 +85,8 @@ private:
   PortalProxy* remoteDesktop;
   PortalProxy* screenCast;
   PortalProxy* session;
+
+  std::string restoreToken;
 
   std::function<void(int fd, uint32_t nodeId)> startPipewireCb;
   std::function<void(const char* reason)> cancelStartCb;

--- a/unix/w0vncserver/portals/portalConstants.h
+++ b/unix/w0vncserver/portals/portalConstants.h
@@ -34,4 +34,9 @@ static const int DEV_KEYBOARD =    (1 << 0);
 static const int DEV_POINTER =     (1 << 1);
 static const int DEV_TOUCHSCREEN = (1 << 2);
 
+// Persist modes
+static const int DO_NOT_PERSIST = 0;
+static const int PERSIST_WHILE_RUNNING = 1;
+static const int PERSIST_UNTIL_REVOKED = 2;
+
 #endif // __PORTAL_CONSTANTS_H__


### PR DESCRIPTION
Restore tokens can be used to save/restore a DBus session. This makes it possible to re-use a previous session, bypassing the remote desktop dialog that pops up.

In this commit, a new parameter "portalAskDisplayChoice" is added where users can choose between three options:

  1. "Always" - The remote desktop dialog will always pop up and restore tokens are not used. This is identical to the behaviour prior to this commit.

  2. "Once" - Only display the remote desktop dialogue the first time a user connects. Subsequent connections will re-use the same session that was created when the first user connected. The session is valid as long as the server is not closed. Users have to restart the server to get the dialogue again.

  3. "Never" - Display the remote desktop dialogue once, and remember the choice even after restarts. The restore token is stored to disk and can be loaded when the RemoteDesktop session starts. Users have to clear the file, or use another option to get the dialogue again.

The default option right now is "Once", which should be helpful for most users. Having "Never" as the default can be problematic as it might not be obvious to users how to "reset" their display choice.