### PR TITLE
Fix WaylandClient find module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,9 +419,9 @@ if(UNIX AND NOT APPLE)
     find_package(Xkbcommon REQUIRED)
   endif()
   if(NOT GLIB_FOUND OR NOT GIO_FOUND OR NOT GOBJECT_FOUND OR NOT PIPEWIRE_FOUND
-     OR NOT UUID_FOUND OR NOT WAYLAND_FOUND OR NOT XKBCOMMON_FOUND)
+     OR NOT UUID_FOUND OR NOT WAYLANDCLIENT_FOUND OR NOT XKBCOMMON_FOUND)
     set(ENABLE_WAYLAND 0)
-    message(WARNING "GLib, Gio, Gobject, PipeWire, Uuid, Wayland or Xkbcommon NOT found. w0vncserver disabled.")
+    message(WARNING "GLib, Gio, Gobject, PipeWire, Uuid, WaylandClient or Xkbcommon NOT found. w0vncserver disabled.")
   endif()
 endif()
 

--- a/cmake/Modules/FindWaylandClient.cmake
+++ b/cmake/Modules/FindWaylandClient.cmake
@@ -1,13 +1,13 @@
 #[=======================================================================[.rst:
-FindWayland
-----------
+FindWaylandClient
+-----------------
 Find the Wayland client library
 Result variables
 ^^^^^^^^^^^^^^^^
 This module will set the following variables if found:
-``WAYLAND_CLIENT_INCLUDE_DIRS``
+``WAYLANDCLIENT_INCLUDE_DIRS``
   where to find wayland-client.h.h, etc.
-``WAYLAND_CLIENT_LIBRARIES``
+``WAYLANDCLIENT_LIBRARIES``
   the libraries to link against to use wayland client.
 ``WAYLAND_CLIENT_FOUND``
   TRUE if found
@@ -16,35 +16,35 @@ This module will set the following variables if found:
 find_package(PkgConfig QUIET)
 
 if (PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_Wayland_client QUIET wayland-client)
+  pkg_check_modules(PC_WaylandClient QUIET wayland-client)
 endif()
 
 find_program(Wayland_scanner_EXECUTABLE
     NAMES wayland-scanner
 )
 
-find_path(Wayland_client_INCLUDE_DIR NAMES wayland-client.h
+find_path(WaylandClient_INCLUDE_DIR NAMES wayland-client.h
   PATH_SUFFIXES
     wayland
   HINTS
-    ${PC_Wayland_client_INCLUDE_DIRS}
+    ${PC_WaylandClient_INCLUDE_DIRS}
 )
-mark_as_advanced(Wayland_client_INCLUDE_DIR)
+mark_as_advanced(WaylandClient_INCLUDE_DIR)
 
-find_library(Wayland_LIBRARIES NAMES wayland-client
+find_library(WaylandClient_LIBRARIES NAMES wayland-client
   HINTS
-    ${PC_Wayland_client_LIBRARY_DIRS}
+    ${PC_WaylandClient_LIBRARY_DIRS}
 )
-mark_as_advanced(Wayland_LIBRARIES)
+mark_as_advanced(WaylandClient_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Wayland
+find_package_handle_standard_args(WaylandClient
   REQUIRED_VARS
-    Wayland_LIBRARIES Wayland_client_INCLUDE_DIR Wayland_scanner_EXECUTABLE
+    WaylandClient_LIBRARIES WaylandClient_INCLUDE_DIR Wayland_scanner_EXECUTABLE
 )
 
-if(Wayland_FOUND)
-  set(WAYLAND_INCLUDE_DIRS ${Wayland_client_INCLUDE_DIR})
-  set(WAYLAND_LIBRARIES ${Wayland_LIBRARIES})
+if(WaylandClient_FOUND)
+  set(WAYLANDCLIENT_INCLUDE_DIRS ${WaylandClient_INCLUDE_DIR})
+  set(WAYLANDCLIENT_LIBRARIES ${WaylandClient_LIBRARIES})
   set(WAYLAND_SCANNER_EXECUTABLE ${Wayland_scanner_EXECUTABLE})
 endif()

--- a/unix/w0vncserver/CMakeLists.txt
+++ b/unix/w0vncserver/CMakeLists.txt
@@ -72,7 +72,7 @@ target_include_directories(w0vncserver SYSTEM PUBLIC ${GOBJECT_INCLUDE_DIRS})
 target_include_directories(w0vncserver SYSTEM PUBLIC ${PIXMAN_INCLUDE_DIRS})
 target_include_directories(w0vncserver SYSTEM PUBLIC ${PIPEWIRE_INCLUDE_DIRS})
 target_include_directories(w0vncserver SYSTEM PUBLIC ${UUID_INCLUDE_DIRS})
-target_include_directories(w0vncserver SYSTEM PUBLIC ${WAYLAND_INCLUDE_DIRS})
+target_include_directories(w0vncserver SYSTEM PUBLIC ${WAYLANDCLIENT_INCLUDE_DIRS})
 target_include_directories(w0vncserver SYSTEM PUBLIC ${XKBCOMMON_INCLUDE_DIRS})
 
 target_link_libraries(w0vncserver core rfb network rdr)
@@ -83,7 +83,7 @@ target_link_libraries(w0vncserver ${PIXMAN_LIBRARIES})
 target_link_libraries(w0vncserver ${PIPEWIRE_LIBRARIES})
 target_link_libraries(w0vncserver ${UUID_LIBRARIES})
 target_link_libraries(w0vncserver ${XKBCOMMON_LIBRARIES})
-target_link_libraries(w0vncserver ${WAYLAND_LIBRARIES})
+target_link_libraries(w0vncserver ${WAYLANDCLIENT_LIBRARIES})
 
 target_link_libraries(w0vncserver-forget core)
 


### PR DESCRIPTION
CMake will complain if the argument passed to
find_package_handle_standard_args doesn't match the argument passed to the find module. In this case, "Wayland" didn't match "WaylandClient".