### PR TITLE
Fix memory leak in Surface_Win32

### DIFF
--- a/vncviewer/Surface_Win32.cxx
+++ b/vncviewer/Surface_Win32.cxx
@@ -147,8 +147,6 @@ void Surface::alloc()
 {
   BITMAPINFOHEADER bih;
 
-  data = new RGBQUAD[width() * height()];
-
   memset(&bih, 0, sizeof(bih));
 
   bih.biSize         = sizeof(BITMAPINFOHEADER);


### PR DESCRIPTION
vncveiwer/Surface_Win32.cxx leaks memory.
I noticed that Surface_Win32 allocates buffer to `data` in `alloc()` but never deletes it.
According to document, `CreateDIBSection` allocates buffer, so removed above allocation.