### PR TITLE
Rename display choice parameter in w0vncserver

### DIFF
--- a/unix/w0vncserver/portals/RemoteDesktop.cxx
+++ b/unix/w0vncserver/portals/RemoteDesktop.cxx
@@ -59,9 +59,9 @@ core::BoolParameter
               false);
 
 core::EnumParameter
-  askDisplayChoice("AskDisplayChoice",
-                   "Ask which displays to share when user connects (Always, Once, Never)",
-                   {"Always", "Once", "Never"}, "Once");
+  rememberDisplayChoice("RememberDisplayChoice",
+                        "Remember display choice when user connects (Always, Never, Session)",
+                        {"Always", "Never", "Session"}, "Session");
 
 // Sync with w0vncserver-forget
 static const char* RESTORE_TOKEN_FILENAME =  "restoretoken";
@@ -281,7 +281,7 @@ void RemoteDesktop::selectDevices()
   g_variant_builder_add(&optionsBuilder, "{sv}", "types",
                         g_variant_new_uint32(DEV_KEYBOARD | DEV_POINTER));
 
-  if (askDisplayChoice != "Always") {
+  if (rememberDisplayChoice != "Never") {
     g_variant_builder_add(&optionsBuilder, "{sv}", "persist_mode",
                           g_variant_new_uint32(PERSIST_UNTIL_REVOKED));
   }
@@ -560,14 +560,14 @@ bool RemoteDesktop::loadRestoreToken()
   const char* stateDir;
   char restoreToken_[37];
 
-  if (askDisplayChoice == "Always")
+  if (rememberDisplayChoice == "Never")
     return false;
 
   // restoreToken will be empty the first time, we want to prompt the user
-  if (askDisplayChoice == "Once")
+  if (rememberDisplayChoice == "Session")
     return !restoreToken.empty();
 
-  assert(askDisplayChoice == "Never");
+  assert(rememberDisplayChoice == "Always");
 
   // Only load from disk the first time
   if (!restoreToken.empty())
@@ -616,16 +616,16 @@ bool RemoteDesktop::storeRestoreToken(const char* newToken)
     return false;
 
   // Don't store anything
-  if (askDisplayChoice == "Always")
+  if (rememberDisplayChoice == "Never")
     return true;
 
   // Store token in memory
   restoreToken = newToken;
 
-  if (askDisplayChoice == "Once")
+  if (rememberDisplayChoice == "Session")
     return true;
 
-  assert(askDisplayChoice == "Never");
+  assert(rememberDisplayChoice == "Always");
 
   // Store token to file so it can be re-used on next startup
   stateDir = core::getvncstatedir();

--- a/unix/w0vncserver/w0vncserver.man
+++ b/unix/w0vncserver/w0vncserver.man
@@ -57,16 +57,6 @@ Always treat incoming connections as shared, regardless of the client-specified
 setting. Default is off.
 .
 .TP
-.B \-AskDisplayChoice \fImode\fP
-Ask which displays to share when a user connects. Can be either
-\fBAlways\fP, \fBOnce\fP, or \fBNever\fP. Choosing \fBAlways\fP means a
-prompt dialog will be be shown every time a user connects to the server.
-\fBOnce\fP means a prompt will be shown only once during the program's
-lifetime. When choosing \fBNever\fP, the choice you make will be
-remembered and persist. To reset your choice, see
-\fBw0vncserver-forget\fP(1). Default is \fBOnce\fP.
-.
-.TP
 .B \-BlacklistThreshold \fIcount\fP
 The number of unauthenticated connection attempts allowed from any individual
 host before that host is black-listed.  Default is 5.
@@ -210,6 +200,16 @@ is a hexadecimal keysym. For example, to exchange the " and @ symbols you would 
 .RS 10
 RemapKeys=0x22<>0x40
 .RE
+.
+.TP
+.B \-RememberDisplayChoice \fImode\fP
+Remember display choice when a user connects. Can be either
+\fBAlways\fP, \fBNever\fP, or \fBSession\fP. Choosing \fBNever\fP means
+a prompt dialog will be be shown every time a user connects to the
+server. \fBSession\fP means a prompt will be shown only once during the
+program's lifetime. When choosing \fBAlways\fP, the choice you make will
+be remembered and persist. To reset your choice, see
+\fBw0vncserver-forget\fP(1). Default is \fBSession\fP.
 .
 .TP
 .B \-RequireUsername


### PR DESCRIPTION
We had a user report that the display choice parameter option "Never" was misleading : #2031.

This PR changes the parameter from `askDisplayChoice` to `saveDisplayChoice`, with the options `Yes`, `No`, and `Session`.

I am not fully content with the option name `Session`, but cannot think of something more fitting. Also, I am debating whether `Yes` should be the default instead of `Session`. What do you think?