### PR TITLE
w0vncserver: Detect updates to keymap

### DIFF
--- a/unix/w0vncserver/wayland/objects/Keyboard.h
+++ b/unix/w0vncserver/wayland/objects/Keyboard.h
@@ -36,8 +36,8 @@ namespace wayland {
     ~Keyboard();
 
     uint32_t getFormat() const { return keyboardFormat; }
-    int getFd() const { return keyboardFd; }
-    int getSize() const { return keyboardSize; }
+    int32_t getFd() const { return keyboardFd; }
+    uint32_t getSize() const { return keyboardSize; }
     bool hasKeymap() const { return keyMap != nullptr; }
 
     // Get the current LED state
@@ -63,8 +63,8 @@ namespace wayland {
 
   private:
     uint32_t keyboardFormat;
-    int keyboardFd;
-    int keyboardSize;
+    int32_t keyboardFd;
+    uint32_t keyboardSize;
     wl_keyboard* keyboard;
     char* keyMap;
     static const wl_keyboard_listener listener;

--- a/unix/w0vncserver/wayland/objects/VirtualKeyboard.h
+++ b/unix/w0vncserver/wayland/objects/VirtualKeyboard.h
@@ -40,6 +40,10 @@ namespace wayland {
     void key(uint32_t keysym, uint32_t keycode, bool down);
 
   private:
+    bool keymapUpdated();
+    void setupKeyboard();
+
+  private:
     zwp_virtual_keyboard_manager_v1* manager;
     zwp_virtual_keyboard_v1* keyboard;
     Seat* seat;


### PR DESCRIPTION
There is currently a race where the `VirtualKeyboard` can be created before `Keyboard::handleKeyMap()` has been triggered (#2042).

This PR makes the keyboard handling more robust by disabling the keyboard if no keymap is set, and by detecting updates to the keymap and updating the virtual keyboard.

Note that this is only for the `WaylandDesktop`.