### PR TITLE
Fix socket cleanup in GSocketSource

### DIFF
--- a/unix/w0vncserver/GSocketSource.cxx
+++ b/unix/w0vncserver/GSocketSource.cxx
@@ -175,7 +175,7 @@ int GSocketSource::prepare(int* timeout)
         g_source_remove_unix_fd(source, state->tag);
         server->removeSocket(sock);
         delete sock;
-        assert(fdMap.erase(fd));
+        fdMap.erase(fd);
       }
       continue;
     }
@@ -220,7 +220,7 @@ int GSocketSource::dispatch()
       g_source_remove_unix_fd(source, state.tag);
       server->removeSocket(sock);
       delete sock;
-      assert(fdMap.erase(fd));
+      fdMap.erase(fd);
       continue;
     }
 


### PR DESCRIPTION
This matches the cleanup that happens in Xvnc and x0vncserver and should have been part of cd1521f0af2437505fe415ffff088e7c5dad017d