### PR TITLE
Add support for FLTK 1.4.x

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -17,7 +17,7 @@ Development kits for the following packages:
 
 -- pixman
 
--- FLTK 1.3.3 or later
+-- FLTK 1.3.3 or later (1.4.x also supported)
 
 -- If building TLS support:
    * GnuTLS 3.x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,9 +304,9 @@ if(BUILD_VIEWER)
     set(CMAKE_REQUIRED_INCLUDES ${FLTK_INCLUDE_DIR})
     set(CMAKE_REQUIRED_LIBRARIES ${FLTK_LIBRARIES})
 
-    check_cxx_source_compiles("#include <FL/Fl.H>\n#if FL_MAJOR_VERSION != 1 || FL_MINOR_VERSION != 3\n#error Wrong FLTK version\n#endif\nint main(int, char**) { return 0; }" OK_FLTK_VERSION)
+    check_cxx_source_compiles("#include <FL/Fl.H>\n#if FL_MAJOR_VERSION != 1 || (FL_MINOR_VERSION != 3 && FL_MINOR_VERSION != 4)\n#error Wrong FLTK version\n#endif\nint main(int, char**) { return 0; }" OK_FLTK_VERSION)
     if(NOT OK_FLTK_VERSION)
-      message(FATAL_ERROR "Incompatible version of FLTK")
+      message(FATAL_ERROR "Incompatible version of FLTK (requires 1.3.x or 1.4.x)")
     endif()
 
     set(CMAKE_REQUIRED_FLAGS)


### PR DESCRIPTION
## Overview
This PR adds support for FLTK 1.4.x while maintaining compatibility with FLTK 1.3.x.

## Changes
- Updated CMake version check to accept both FLTK 1.3.x and 1.4.x
- Updated BUILDING.txt documentation to reflect FLTK 1.4.x support
- Improved error message to clarify version requirements

## Background
FLTK 1.4 is mostly source-compatible with FLTK 1.3. The main differences are:
- ABI changes requiring recompilation (no runtime compatibility)
- Header cleanup (may require explicit includes in some cases)
- Improved HighDPI support and modern features

According to the [FLTK migration guide](https://www.fltk.org/doc-1.5/migration_1_4.html), most FLTK 1.3 applications will compile with minimal or no changes.

## Testing
- Successfully built TigerVNC viewer on macOS with FLTK 1.4.4
- Debug build with all features enabled (NLS, H264, GnuTLS, Nettle)
- All compilation warnings addressed

## Compatibility
- Maintains backward compatibility with FLTK 1.3.3+
- Forward compatible with FLTK 1.4.x releases
- No changes to existing functionality or API usage