### PR TITLE
Fix for PAM support with w0vncserver

### DIFF
--- a/common/rfb/UnixPasswordValidator.cxx
+++ b/common/rfb/UnixPasswordValidator.cxx
@@ -111,14 +111,15 @@ bool UnixPasswordValidator::validateInternal(SConnection * /* sc */,
     return false;
   }
 #ifdef PAM_XDISPLAY
-  /* At this point, displayName should never be empty */
-  assert(displayName.length() > 0);
-  /* Pass the display name to PAM modules but PAM_XDISPLAY may not be
-   * recognized by modules built with old versions of PAM */
-  ret = pam_set_item(pamh, PAM_XDISPLAY, displayName.c_str());
-  if (ret != PAM_SUCCESS && ret != PAM_BAD_ITEM) {
-    vlog.error("pam_set_item(PAM_XDISPLAY) failed: %d (%s)", ret, pam_strerror(pamh, ret));
-    goto error;
+  /* displayName set set for X but not Wayland sessions */
+  if (displayName.length() > 0) {
+    /* Pass the display name to PAM modules but PAM_XDISPLAY may not be
+    * recognized by modules built with old versions of PAM */
+    ret = pam_set_item(pamh, PAM_XDISPLAY, displayName.c_str());
+    if (ret != PAM_SUCCESS && ret != PAM_BAD_ITEM) {
+      vlog.error("pam_set_item(PAM_XDISPLAY) failed: %d (%s)", ret, pam_strerror(pamh, ret));
+      goto error;
+    }
   }
 #endif
   ret = pam_authenticate(pamh, 0);


### PR DESCRIPTION
The PAM_XDISPLAY item is not applicable to a wayland session so the displayName variable would be unset for w0vncserver which caused the assertion to fail.

To reproduce the problem, run `w0vncserver -rfbport 5902 -PlainUsers $USER -PamService login -SecurityTypes TLSPlain` on the server and then connect with any client.

Using `grep` on other code bases that use PAM to start a Wayland session such as gdm, it appears that the `PAM_XDISPLAY` item is not set at all. There is a `WAYLAND_DISPLAY` environment variable but it doesn't appear to be applicable to use that instead from my basic research. Certainly, throwing an assertion is not helpful. And with this change, I find it to be working perfectly.

As an aside, with PAM authentication and only one user listed with `-PlainUsers`, it still necessary to type a username when connecting. It'd be nice if this was not needed like when connecting using a `vncpasswd` generated password.

I created a systemd user service file for starting w0vncserver (and x0vncserver). These could be useful for others so let me know if I should submit these.