### PR TITLE
Avoid needless resize on reconnect

### DIFF
--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -138,6 +138,7 @@ private:
 
   bool firstUpdate;
   bool delayedFullscreen;
+  bool hasResized;
   bool sentDesktopSize;
 
   bool pendingRemoteResize;

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -138,7 +138,6 @@ private:
 
   bool firstUpdate;
   bool delayedFullscreen;
-  bool hasResized;
   bool sentDesktopSize;
 
   bool pendingRemoteResize;


### PR DESCRIPTION
Apparently, X11 window managers like to resize our window after setting the full-screen state. That means we temporarily resize the session to our windowed size, before switching to the proper full-screen size. If the session was already the correct size, this means two pointless resizes.

This can result in stuff moving around in the session, if the remote window manager is not clever enough to remember window positions across multiple resizes.