### PR TITLE
w0vncserver: add image copy capture support

### DIFF
--- a/unix/w0vncserver/CMakeLists.txt
+++ b/unix/w0vncserver/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(w0vncserver
   wayland/objects/DataControl.cxx
   wayland/objects/Display.cxx
   wayland/objects/Keyboard.cxx
+  wayland/objects/Pointer.cxx
   wayland/objects/Seat.cxx
   wayland/objects/Shm.cxx
   wayland/objects/ShmPool.cxx
@@ -25,6 +26,7 @@ add_executable(w0vncserver
   wayland/objects/ImageCaptureSource.cxx
   wayland/objects/ImageCopyCaptureManager.cxx
   wayland/objects/ImageCopyCaptureSession.cxx
+  wayland/objects/ImageCopyCaptureCursorSession.cxx
   wayland/objects/ScreencopyManager.cxx
   wayland/WaylandDesktop.cxx
   wayland/WaylandPixelBuffer.cxx

--- a/unix/w0vncserver/CMakeLists.txt
+++ b/unix/w0vncserver/CMakeLists.txt
@@ -22,6 +22,9 @@ add_executable(w0vncserver
   wayland/objects/ShmPool.cxx
   wayland/objects/VirtualPointer.cxx
   wayland/objects/VirtualKeyboard.cxx
+  wayland/objects/ImageCaptureSource.cxx
+  wayland/objects/ImageCopyCaptureManager.cxx
+  wayland/objects/ImageCopyCaptureSession.cxx
   wayland/objects/ScreencopyManager.cxx
   wayland/WaylandDesktop.cxx
   wayland/WaylandPixelBuffer.cxx
@@ -40,6 +43,9 @@ add_executable(w0vncserver-forget
 # Generate protocol headers
 set(GEN_WAYLAND_SRCS "")
 set(WAYLAND_PROTOCOLS
+  ext-foreign-toplevel-list-v1
+  ext-image-capture-source-v1
+  ext-image-copy-capture-v1
   wlr-screencopy-unstable-v1
   wlr-virtual-pointer-unstable-v1
   virtual-keyboard-unstable-v1

--- a/unix/w0vncserver/wayland/WaylandDesktop.cxx
+++ b/unix/w0vncserver/wayland/WaylandDesktop.cxx
@@ -115,7 +115,7 @@ void WaylandDesktop::start()
   };
 
   try {
-    pb = new WaylandPixelBuffer(display, output, server, desktopReadyCb);
+    pb = new WaylandPixelBuffer(display, output, seat, server, desktopReadyCb);
   } catch (std::exception& e) {
     vlog.error("Error initializing pixel buffer: %s", e.what());
     server->closeClients("Failed to start remote desktop session");

--- a/unix/w0vncserver/wayland/WaylandDesktop.cxx
+++ b/unix/w0vncserver/wayland/WaylandDesktop.cxx
@@ -1,4 +1,4 @@
-/* Copyright 2025 Adam Halim for Cendio AB
+/* Copyright 2025-2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -224,7 +224,12 @@ bool WaylandDesktop::available()
 {
   wayland::Display display;
 
-  return display.interfaceAvailable("zwlr_screencopy_manager_v1") &&
+  // We need either wlr-screencopy OR ext-image-copy-capture
+  return (display.interfaceAvailable("zwlr_screencopy_manager_v1") ||
+         (
+            display.interfaceAvailable("ext_image_copy_capture_manager_v1") &&
+            display.interfaceAvailable("ext_output_image_capture_source_manager_v1")
+         )) &&
          display.interfaceAvailable("zwlr_virtual_pointer_manager_v1") &&
          display.interfaceAvailable("zwp_virtual_keyboard_manager_v1");
 }

--- a/unix/w0vncserver/wayland/WaylandDesktop.h
+++ b/unix/w0vncserver/wayland/WaylandDesktop.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Adam Halim for Cendio AB
+/* Copyright 2025-2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
@@ -48,6 +48,7 @@ static core::LogWriter vlog("WaylandPixelBuffer");
 
 WaylandPixelBuffer::WaylandPixelBuffer(wayland::Display* display,
                                        wayland::Output* output_,
+                                       wayland::Seat* seat,
                                        rfb::VNCServer* server_,
                                        std::function<void()> desktopReadyCallback_)
   : firstFrame(true), desktopReadyCallback(desktopReadyCallback_),
@@ -59,6 +60,15 @@ WaylandPixelBuffer::WaylandPixelBuffer(wayland::Display* display,
     std::bind(&WaylandPixelBuffer::bufferEvent, this, std::placeholders::_1,
               std::placeholders::_2, std::placeholders::_3);
 
+  std::function<void(int, int, const core::Point&, uint32_t, const uint8_t*)>
+    cursorImageCb = std::bind(&WaylandPixelBuffer::cursorImageEvent, this,
+                              std::placeholders::_1, std::placeholders::_2,
+                              std::placeholders::_3, std::placeholders::_4,
+                              std::placeholders::_5);
+
+  std::function<void(const core::Point&)> cursorPosCb =
+    std::bind(&WaylandPixelBuffer::cursorPosEvent, this, std::placeholders::_1);
+
   std::function<void()> stoppedCb = [this]() {
     server->closeClients("The remote session stopped");
   };
@@ -69,7 +79,10 @@ WaylandPixelBuffer::WaylandPixelBuffer(wayland::Display* display,
 
     imageCopyCaptureManager = new wayland::ImageCopyCaptureManager(display,
                                                                    imageCaptureSource,
+                                                                   seat,
                                                                    bufferEventCb,
+                                                                   cursorImageCb,
+                                                                   cursorPosCb,
                                                                    stoppedCb);
     imageCopyCaptureManager->createSession();
   } else {
@@ -83,6 +96,29 @@ WaylandPixelBuffer::~WaylandPixelBuffer()
   delete screencopyManager;
   delete imageCopyCaptureManager;
   delete imageCaptureSource;
+}
+
+void WaylandPixelBuffer::cursorImageEvent(int width, int height,
+                                          const core::Point& hotspot,
+                                          uint32_t shmFormat,
+                                          const uint8_t* src)
+{
+  uint8_t* cursorData;
+
+  cursorData = nullptr;
+  try {
+    cursorData = convertCursorBuffer(src, shmFormat, width, height);
+    server->setCursor(width, height, hotspot, cursorData);
+  } catch (std::exception& e) {
+    vlog.error("Failed to set cursor: %s", e.what());
+  }
+
+  delete cursorData;
+}
+
+void WaylandPixelBuffer::cursorPosEvent(const core::Point& pos)
+{
+  server->setCursorPos(pos, true);
 }
 
 void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage,
@@ -162,6 +198,92 @@ void WaylandPixelBuffer::syncBuffers(uint8_t* buffer, core::Region damage)
   }
 
   server->add_changed(damage);
+}
+
+uint8_t* WaylandPixelBuffer::convertCursorBuffer(const uint8_t* src,
+                                                 uint32_t shmFormat,
+                                                 uint32_t width,
+                                                 uint32_t height)
+{
+  const unsigned char* in;
+  uint8_t* out;
+  uint8_t* cursorData;
+  bool hasAlpha;
+
+  cursorData = new uint8_t[width * height * 4];
+
+  in = src;
+  out = cursorData;
+
+  hasAlpha = (shmFormat == WL_SHM_FORMAT_ARGB8888 ||
+              shmFormat == WL_SHM_FORMAT_RGBA8888 ||
+              shmFormat == WL_SHM_FORMAT_ABGR8888);
+
+  for (uint32_t y = 0; y < height; y++) {
+    for (uint32_t x = 0; x < width; x++) {
+      uint8_t r, g, b, a;
+
+      switch (shmFormat) {
+        case WL_SHM_FORMAT_ARGB8888:
+          b = in[0];
+          g = in[1];
+          r = in[2];
+          a = in[3];
+          break;
+        case WL_SHM_FORMAT_XRGB8888:
+          b = in[0];
+          g = in[1];
+          r = in[2];
+          a = 0xff;
+          break;
+        case WL_SHM_FORMAT_RGBA8888:
+          r = in[0];
+          g = in[1];
+          b = in[2];
+          a = in[3];
+          break;
+        case WL_SHM_FORMAT_RGBX8888:
+          r = in[0];
+          g = in[1];
+          b = in[2];
+          a = 0xff;
+          break;
+        case WL_SHM_FORMAT_ABGR8888:
+          a = in[0];
+          b = in[1];
+          g = in[2];
+          r = in[3];
+          break;
+        case WL_SHM_FORMAT_XBGR8888:
+          b = in[1];
+          g = in[2];
+          r = in[3];
+          a = 0xff;
+          break;
+        default:
+          throw std::runtime_error("Unsupported cursor format");
+      }
+
+      if (hasAlpha) {
+        if (a == 0) {
+          r = g = b = 0;
+        } else {
+          r = (uint8_t)((uint16_t)r * 255 / a);
+          g = (uint8_t)((uint16_t)g * 255 / a);
+          b = (uint8_t)((uint16_t)b * 255 / a);
+        }
+      }
+
+      *out++ = r;
+      *out++ = g;
+      *out++ = b;
+      *out++ = a;
+
+      in += 4;
+    }
+  }
+
+  return cursorData;
 }
 
 rfb::PixelFormat WaylandPixelBuffer::convertPixelformat(uint32_t shmFormat)

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
@@ -56,15 +56,15 @@ WaylandPixelBuffer::WaylandPixelBuffer(wayland::Display* display,
     imageCaptureSource(nullptr), imageCopyCaptureManager(nullptr),
     resized(false)
 {
-  std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb =
+  std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)> bufferEventCb =
     std::bind(&WaylandPixelBuffer::bufferEvent, this, std::placeholders::_1,
-              std::placeholders::_2, std::placeholders::_3);
+              std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
 
-  std::function<void(int, int, const core::Point&, uint32_t, const uint8_t*)>
+  std::function<void(int, int, const core::Point&, uint32_t, uint32_t, const uint8_t*)>
     cursorImageCb = std::bind(&WaylandPixelBuffer::cursorImageEvent, this,
                               std::placeholders::_1, std::placeholders::_2,
                               std::placeholders::_3, std::placeholders::_4,
-                              std::placeholders::_5);
+                              std::placeholders::_5, std::placeholders::_6);
 
   std::function<void(const core::Point&)> cursorPosCb =
     std::bind(&WaylandPixelBuffer::cursorPosEvent, this, std::placeholders::_1);
@@ -101,19 +101,31 @@ WaylandPixelBuffer::~WaylandPixelBuffer()
 void WaylandPixelBuffer::cursorImageEvent(int width, int height,
                                           const core::Point& hotspot,
                                           uint32_t shmFormat,
+                                          uint32_t transform,
                                           const uint8_t* src)
 {
+  const uint8_t* cursorSrc;
   uint8_t* cursorData;
+  uint8_t* transformedCursorData;
 
   cursorData = nullptr;
+  transformedCursorData = nullptr;
+  cursorSrc = src;
   try {
-    cursorData = convertCursorBuffer(src, shmFormat, width, height);
+    if (transform != WL_OUTPUT_TRANSFORM_NORMAL) {
+      transformedCursorData = undoTransformation(src, width, height,
+                                                 width * 4, shmFormat,
+                                                 transform);
+      cursorSrc = transformedCursorData;
+    }
+    cursorData = convertCursorBuffer(cursorSrc, shmFormat, width, height);
     server->setCursor(width, height, hotspot, cursorData);
   } catch (std::exception& e) {
     vlog.error("Failed to set cursor: %s", e.what());
   }
 
-  delete cursorData;
+  delete [] cursorData;
+  delete [] transformedCursorData;
 }
 
 void WaylandPixelBuffer::cursorPosEvent(const core::Point& pos)
@@ -122,10 +134,31 @@ void WaylandPixelBuffer::cursorPosEvent(const core::Point& pos)
 }
 
 void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage,
-                                     uint32_t shmFormat)
+                                     uint32_t shmFormat, uint32_t transform)
 {
-  if (output->getWidth() != (uint32_t)width() ||
-      output->getHeight() != (uint32_t)height()) {
+  uint32_t bufferWidth;
+  uint32_t bufferHeight;
+  bool transformed;
+  bool rotated;
+
+  bufferWidth = output->getWidth();
+  bufferHeight = output->getHeight();
+  transformed = false;
+  rotated = false;
+
+  transformed = transform != WL_OUTPUT_TRANSFORM_NORMAL;
+
+  rotated = transform == WL_OUTPUT_TRANSFORM_90 ||
+            transform == WL_OUTPUT_TRANSFORM_270 ||
+            transform == WL_OUTPUT_TRANSFORM_FLIPPED_90 ||
+            transform == WL_OUTPUT_TRANSFORM_FLIPPED_270;
+
+  if (rotated) {
+    bufferWidth = output->getHeight();
+    bufferHeight = output->getWidth();
+  }
+
+  if (bufferWidth != (uint32_t)width() || bufferHeight != (uint32_t)height()) {
     if (!firstFrame && !resized) {
       resized = true;
       if (screencopyManager)
@@ -139,19 +172,34 @@ void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage,
   // FIXME: Can we query the compositor instead of doing this?
   if (firstFrame) {
     try {
-      format = convertPixelformat(shmFormat);
+      format = shmToRfbFormat(shmFormat);
     } catch (std::exception& e) {
       vlog.error("Failed to convert pixelformat: %s", e.what());
       server->closeClients("Failed to start remote session");
       return;
     }
-    setSize(output->getWidth(), output->getHeight());
+
+    if (rotated)
+      setSize(output->getHeight(), output->getWidth());
+    else
+      setSize(output->getWidth(), output->getHeight());
+
     desktopReadyCallback();
   }
 
   firstFrame = false;
 
-  syncBuffers(buffer, damage);
+  if (transformed) {
+    try {
+      syncBuffersTransformed(buffer, damage, shmFormat, transform);
+    } catch (std::exception& e) {
+      vlog.error("Failed to sync transformed buffers: %s", e.what());
+      server->closeClients("Error copying buffers");
+      return;
+    }
+  } else {
+    syncBuffers(buffer, damage);
+  }
 }
 
 void WaylandPixelBuffer::syncBuffers(uint8_t* buffer, core::Region damage)
@@ -198,6 +246,159 @@ void WaylandPixelBuffer::syncBuffers(uint8_t* buffer, core::Region damage)
   }
 
   server->add_changed(damage);
+}
+
+void WaylandPixelBuffer::syncBuffersTransformed(uint8_t* buffer,
+                                                core::Region damage,
+                                                uint32_t shmFormat,
+                                                uint32_t transform)
+{
+  int srcWidth;
+  int srcHeight;
+  int dstWidth;
+  int dstHeight;
+  bool wasResized;
+  core::Region region;
+  std::vector<core::Rect> rects;
+  std::vector<core::Rect> transformedRects;
+  core::Region transformedDamage;
+  bool rotated;
+  pixman_format_code_t pixmanFormat;
+  pixman_image_t* srcImg;
+
+  assert(transform != WL_OUTPUT_TRANSFORM_NORMAL);
+
+  rotated = transform == WL_OUTPUT_TRANSFORM_90 ||
+            transform == WL_OUTPUT_TRANSFORM_270 ||
+            transform == WL_OUTPUT_TRANSFORM_FLIPPED_90 ||
+            transform == WL_OUTPUT_TRANSFORM_FLIPPED_270;
+
+  wasResized = resized;
+  if (resized) {
+    if (rotated)
+      setSize(output->getHeight(), output->getWidth());
+    else
+      setSize(output->getWidth(), output->getHeight());
+    server->setPixelBuffer(this);
+    resized = false;
+  }
+
+  region = damage;
+
+  if (region.is_empty())
+    region = getRect();
+
+  dstWidth = width();
+  dstHeight = height();
+  if (rotated) {
+    srcWidth = dstHeight;
+    srcHeight = dstWidth;
+  } else {
+    srcWidth = dstWidth;
+    srcHeight = dstHeight;
+  }
+
+  region.get_rects(&rects);
+
+  if (!wasResized) {
+    // Transform the damage rects
+    for (core::Rect &rect : rects) {
+      int x;
+      int y;
+      int w;
+      int h;
+      int dx;
+      int dy;
+      int dw;
+      int dh;
+
+      x = rect.tl.x;
+      y = rect.tl.y;
+      w = rect.width();
+      h = rect.height();
+
+      switch (transform) {
+      case WL_OUTPUT_TRANSFORM_NORMAL:
+        dx = x;
+        dy = y;
+        break;
+      case WL_OUTPUT_TRANSFORM_90:
+        dx = srcHeight - y - h;
+        dy = x;
+        break;
+      case WL_OUTPUT_TRANSFORM_180:
+        dx = srcWidth - x - w;
+        dy = srcHeight - y - h;
+        break;
+      case WL_OUTPUT_TRANSFORM_270:
+        dx = y;
+        dy = srcWidth - x - w;
+        break;
+      case WL_OUTPUT_TRANSFORM_FLIPPED:
+        dx = srcWidth - x - w;
+        dy = y;
+        break;
+      case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+        dx = y;
+        dy = x;
+        break;
+      case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+        dx = x;
+        dy = srcHeight - y - h;
+        break;
+      case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+        dx = srcHeight - y - h;
+        dy = srcWidth - x - w;
+        break;
+      default:
+        throw std::runtime_error(core::format("Unknown transform: %d", transform));
+      }
+
+      if (rotated) {
+        dw = h;
+        dh = w;
+      } else {
+        dw = w;
+        dh = h;
+      }
+
+      transformedDamage.assign_union({{dx, dy, dx + dw, dy + dh}});
+    }
+  } else {
+    // Mark entire screen as dirty when we resize
+    transformedDamage = getRect();
+  }
+
+  pixmanFormat = shmToPixmanFormat(shmFormat);
+
+  srcImg = pixman_image_create_bits(pixmanFormat, srcWidth, srcHeight,
+                                   (uint32_t*)(buffer), srcWidth * 4);
+
+  transformedDamage.get_rects(&transformedRects);
+  for (core::Rect &rect : transformedRects) {
+    uint8_t* dstBuffer;
+    int dstStride;
+    pixman_image_t* dstImg;
+    pixman_transform_t inverseTransform;
+
+    dstBuffer = getBufferRW(getRect(), &dstStride);
+
+    dstImg = pixman_image_create_bits(pixmanFormat, dstWidth, dstHeight,
+                                     (uint32_t*)(dstBuffer), dstStride * 4);
+
+    inverseTransform = wlToPixmanInverseTransform(transform, srcWidth, srcHeight);
+    pixman_image_set_transform(srcImg, &inverseTransform);
+
+    pixman_image_composite32(PIXMAN_OP_SRC, srcImg, nullptr, dstImg,
+                             rect.tl.x, rect.tl.y, 0, 0, rect.tl.x,
+                             rect.tl.y, rect.width(), rect.height());
+
+    pixman_image_unref(dstImg);
+    commitBufferRW(rect);
+  }
+
+  pixman_image_unref(srcImg);
+  server->add_changed(transformedDamage);
 }
 
 uint8_t* WaylandPixelBuffer::convertCursorBuffer(const uint8_t* src,
@@ -286,7 +487,7 @@ uint8_t* WaylandPixelBuffer::convertCursorBuffer(const uint8_t* src,
   return cursorData;
 }
 
-rfb::PixelFormat WaylandPixelBuffer::convertPixelformat(uint32_t shmFormat)
+rfb::PixelFormat WaylandPixelBuffer::shmToRfbFormat(uint32_t shmFormat)
 {
   switch (shmFormat) {
     case WL_SHM_FORMAT_XRGB8888:
@@ -304,5 +505,118 @@ rfb::PixelFormat WaylandPixelBuffer::convertPixelformat(uint32_t shmFormat)
     default:
       throw std::runtime_error(core::format("format %d not supported",
                                             shmFormat));
+  }
+}
+
+pixman_format_code_t WaylandPixelBuffer::shmToPixmanFormat(uint32_t shmFormat)
+{
+  switch (shmFormat) {
+    case WL_SHM_FORMAT_XRGB8888:
+      return PIXMAN_x8r8g8b8;
+    case WL_SHM_FORMAT_ARGB8888:
+      return PIXMAN_a8r8g8b8;
+    case WL_SHM_FORMAT_RGBX8888:
+      return PIXMAN_r8g8b8x8;
+    case WL_SHM_FORMAT_RGBA8888:
+      return PIXMAN_r8g8b8a8;
+    case WL_SHM_FORMAT_XBGR8888:
+      return PIXMAN_x8b8g8r8;
+    case WL_SHM_FORMAT_ABGR8888:
+      return PIXMAN_a8b8g8r8;
+   default:
+    throw std::runtime_error(core::format("format %d not supported", shmFormat));
+  }
+}
+
+uint8_t* WaylandPixelBuffer::undoTransformation(const uint8_t* srcBuffer,
+                                                int srcWidth,
+                                                int srcHeight,
+                                                int srcStride,
+                                                uint32_t shmFormat,
+                                                uint32_t transform)
+{
+  pixman_image_t* srcImg;
+  pixman_image_t* dstImg;
+  pixman_format_code_t pixmanFormat;
+  pixman_transform_t pxTransform;
+  uint8_t* dstBuffer;
+  int dstWidth;
+  int dstHeight;
+  int dstStride;
+
+  if (transform == WL_OUTPUT_TRANSFORM_NORMAL ||
+      transform == WL_OUTPUT_TRANSFORM_FLIPPED) {
+    dstWidth = srcWidth;
+    dstHeight = srcHeight;
+  } else {
+    dstWidth = srcHeight;
+    dstHeight = srcWidth;
+  }
+
+  dstStride = dstWidth * 4;
+  dstBuffer = new uint8_t[dstHeight * dstStride];
+
+  pixmanFormat = shmToPixmanFormat(shmFormat);
+  srcImg = pixman_image_create_bits(pixmanFormat, srcWidth, srcHeight,
+                                   (uint32_t*)(srcBuffer), srcStride);
+  dstImg = pixman_image_create_bits(pixmanFormat, dstWidth, dstHeight,
+                                   (uint32_t*)(dstBuffer), dstStride);
+
+  pxTransform = wlToPixmanInverseTransform(transform, srcWidth, srcHeight);
+  pixman_image_set_transform(srcImg, &pxTransform);
+
+  pixman_image_composite32(PIXMAN_OP_SRC, srcImg, nullptr, dstImg,
+                           0, 0, 0, 0, 0, 0, dstWidth, dstHeight);
+
+  pixman_image_unref(srcImg);
+  pixman_image_unref(dstImg);
+
+  return dstBuffer;
+}
+
+pixman_transform_t WaylandPixelBuffer::wlToPixmanInverseTransform(uint32_t transform,
+                                                                  int srcWidth, int srcHeight)
+{
+  pixman_fixed_t w;
+  pixman_fixed_t h;
+
+  w = srcWidth * pixman_fixed_1;
+  h = srcHeight * pixman_fixed_1;
+
+  switch (transform) {
+  case WL_OUTPUT_TRANSFORM_NORMAL:
+    return {{{pixman_fixed_1, 0, 0},
+             {0, pixman_fixed_1, 0},
+             {0, 0, pixman_fixed_1}}};
+  case WL_OUTPUT_TRANSFORM_90:
+    return {{{0, pixman_fixed_1, 0},
+             {-pixman_fixed_1, 0, h},
+             {0, 0, pixman_fixed_1}}};
+  case WL_OUTPUT_TRANSFORM_180:
+    return {{{-pixman_fixed_1, 0, w},
+             {0, -pixman_fixed_1, h},
+             {0, 0, pixman_fixed_1}}};
+  case WL_OUTPUT_TRANSFORM_270:
+    return {{{0, -pixman_fixed_1, w},
+             {pixman_fixed_1, 0, 0},
+             {0, 0, pixman_fixed_1}}};
+  case WL_OUTPUT_TRANSFORM_FLIPPED:
+    return {{{-pixman_fixed_1, 0, w},
+             {0, pixman_fixed_1, 0},
+             {0, 0, pixman_fixed_1}}};
+  case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+    return {{{0, pixman_fixed_1, 0},
+             {pixman_fixed_1, 0, 0},
+             {0, 0, pixman_fixed_1}}};
+  case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+    return {{{pixman_fixed_1, 0, 0},
+             {0, -pixman_fixed_1, h},
+             {0, 0, pixman_fixed_1}}};
+  case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+    return {{{0, -pixman_fixed_1, w},
+             {-pixman_fixed_1, 0, h},
+             {0, 0, pixman_fixed_1}}};
+  default:
+    assert(false);
   }
 }

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
@@ -33,12 +33,15 @@
 #include <core/Region.h>
 #include <core/string.h>
 #include <core/LogWriter.h>
+#include <core/Rect.h>
 #include <rfb/VNCServerST.h>
 
 #include "../w0vncserver.h"
 #include "objects/Output.h"
 #include "objects/Display.h"
 #include "objects/ScreencopyManager.h"
+#include "objects/ImageCaptureSource.h"
+#include "objects/ImageCopyCaptureManager.h"
 #include "WaylandPixelBuffer.h"
 
 static core::LogWriter vlog("WaylandPixelBuffer");
@@ -48,7 +51,9 @@ WaylandPixelBuffer::WaylandPixelBuffer(wayland::Display* display,
                                        rfb::VNCServer* server_,
                                        std::function<void()> desktopReadyCallback_)
   : firstFrame(true), desktopReadyCallback(desktopReadyCallback_),
-    server(server_), output(output_), resized(false)
+    server(server_), output(output_), screencopyManager(nullptr),
+    imageCaptureSource(nullptr), imageCopyCaptureManager(nullptr),
+    resized(false)
 {
   std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb =
     std::bind(&WaylandPixelBuffer::bufferEvent, this, std::placeholders::_1,
@@ -58,14 +63,26 @@ WaylandPixelBuffer::WaylandPixelBuffer(wayland::Display* display,
     server->closeClients("The remote session stopped");
   };
 
-  screencopyManager = new wayland::ScreencopyManager(display, output_,
-                                                     bufferEventCb,
-                                                     stoppedCb);
+  if (display->interfaceAvailable("ext_image_copy_capture_manager_v1") &&
+      display->interfaceAvailable("ext_output_image_capture_source_manager_v1")) {
+    imageCaptureSource = new wayland::OutputImageCaptureSource(display, output_);
+
+    imageCopyCaptureManager = new wayland::ImageCopyCaptureManager(display,
+                                                                   imageCaptureSource,
+                                                                   bufferEventCb,
+                                                                   stoppedCb);
+    imageCopyCaptureManager->createSession();
+  } else {
+    screencopyManager = new wayland::ScreencopyManager(display, output_,
+                                                       bufferEventCb, stoppedCb);
+  }
 }
 
 WaylandPixelBuffer::~WaylandPixelBuffer()
 {
   delete screencopyManager;
+  delete imageCopyCaptureManager;
+  delete imageCaptureSource;
 }
 
 void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage,
@@ -74,9 +91,9 @@ void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage,
   if (output->getWidth() != (uint32_t)width() ||
       output->getHeight() != (uint32_t)height()) {
     if (!firstFrame && !resized) {
-      vlog.debug("Detected resize, calling resize()");
-      screencopyManager->resize();
       resized = true;
+      if (screencopyManager)
+        screencopyManager->resize();
       return;
     }
   }

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.cxx
@@ -1,4 +1,4 @@
-/* Copyright 2025 Adam Halim for Cendio AB
+/* Copyright 2025-2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,12 +23,15 @@
 #include <assert.h>
 #include <unistd.h>
 
+#include <stdexcept>
+
 #include <pixman.h>
 #include <wayland-client-core.h>
 #include <wayland-client-protocol.h>
 #include <wayland-client.h>
 
 #include <core/Region.h>
+#include <core/string.h>
 #include <core/LogWriter.h>
 #include <rfb/VNCServerST.h>
 
@@ -47,7 +50,7 @@ WaylandPixelBuffer::WaylandPixelBuffer(wayland::Display* display,
   : firstFrame(true), desktopReadyCallback(desktopReadyCallback_),
     server(server_), output(output_), resized(false)
 {
-  std::function<void(uint8_t*, core::Region, rfb::PixelFormat)> bufferEventCb =
+  std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb =
     std::bind(&WaylandPixelBuffer::bufferEvent, this, std::placeholders::_1,
               std::placeholders::_2, std::placeholders::_3);
 
@@ -65,7 +68,8 @@ WaylandPixelBuffer::~WaylandPixelBuffer()
   delete screencopyManager;
 }
 
-void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage, rfb::PixelFormat pf)
+void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage,
+                                     uint32_t shmFormat)
 {
   if (output->getWidth() != (uint32_t)width() ||
       output->getHeight() != (uint32_t)height()) {
@@ -81,7 +85,13 @@ void WaylandPixelBuffer::bufferEvent(uint8_t* buffer, core::Region damage, rfb::
   // the display is using.
   // FIXME: Can we query the compositor instead of doing this?
   if (firstFrame) {
-    format = pf;
+    try {
+      format = convertPixelformat(shmFormat);
+    } catch (std::exception& e) {
+      vlog.error("Failed to convert pixelformat: %s", e.what());
+      server->closeClients("Failed to start remote session");
+      return;
+    }
     setSize(output->getWidth(), output->getHeight());
     desktopReadyCallback();
   }
@@ -135,4 +145,25 @@ void WaylandPixelBuffer::syncBuffers(uint8_t* buffer, core::Region damage)
   }
 
   server->add_changed(damage);
+}
+
+rfb::PixelFormat WaylandPixelBuffer::convertPixelformat(uint32_t shmFormat)
+{
+  switch (shmFormat) {
+    case WL_SHM_FORMAT_XRGB8888:
+    case WL_SHM_FORMAT_ARGB8888:
+      return rfb::PixelFormat(32, 24, false, true, 255, 255, 255,
+                              16, 8, 0);
+    case WL_SHM_FORMAT_RGBX8888:
+    case WL_SHM_FORMAT_RGBA8888:
+      return rfb::PixelFormat(32, 24, false, true, 255, 255, 255,
+                              24, 16, 8);
+    case WL_SHM_FORMAT_XBGR8888:
+    case WL_SHM_FORMAT_ABGR8888:
+      return rfb::PixelFormat(32, 24, false, true, 255, 255, 255,
+                              0, 8, 16);
+    default:
+      throw std::runtime_error(core::format("format %d not supported",
+                                            shmFormat));
+  }
 }

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.h
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.h
@@ -30,13 +30,14 @@ namespace wayland {
   class Display;
   class ScreencopyManager;
   class ImageCaptureSource;
+  class Seat;
   class ImageCopyCaptureManager;
 };
 
 class WaylandPixelBuffer : public rfb::ManagedPixelBuffer {
 public:
   WaylandPixelBuffer(wayland::Display* display, wayland::Output* output,
-                     rfb::VNCServer* server,
+                     wayland::Seat* seat, rfb::VNCServer* server,
                      std::function<void()> desktopReadyCallback);
   ~WaylandPixelBuffer();
 
@@ -45,8 +46,19 @@ protected:
   void bufferEvent(uint8_t* buffer, core::Region damage, uint32_t format);
 
 private:
+  // Called when the cursor image is updated
+  void cursorImageEvent(int width, int height, const core::Point& hotspot,
+                        uint32_t shmFormat, const uint8_t* src);
+  // Called when the cursor position is updated
+  void cursorPosEvent(const core::Point& pos);
+
   // Sync the shadow framebuffer to the actual framebuffer
   void syncBuffers(uint8_t* buffer, core::Region damage);
+
+  // Convert from wl_shm_format to RGB. Will un-premultiply alpha when
+  // applicable. Caller owns returned buffer
+  uint8_t* convertCursorBuffer(const uint8_t* src, uint32_t format,
+                               uint32_t width, uint32_t height);
 
   // Convert from wl_shm_format to rfb::PixelFormat
   rfb::PixelFormat convertPixelformat(uint32_t format);

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.h
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.h
@@ -21,6 +21,8 @@
 
 #include <functional>
 
+#include <pixman.h>
+
 #include <rfb/PixelBuffer.h>
 
 namespace rfb { class VNCServer; class PixelFormat; }
@@ -43,17 +45,19 @@ public:
 
 protected:
   // Called when there is pixel data available to read
-  void bufferEvent(uint8_t* buffer, core::Region damage, uint32_t format);
+  void bufferEvent(uint8_t* buffer, core::Region damage, uint32_t format,
+                   uint32_t transform);
 
 private:
   // Called when the cursor image is updated
   void cursorImageEvent(int width, int height, const core::Point& hotspot,
-                        uint32_t shmFormat, const uint8_t* src);
+                        uint32_t shmFormat, uint32_t transform, const uint8_t* src);
   // Called when the cursor position is updated
   void cursorPosEvent(const core::Point& pos);
 
   // Sync the shadow framebuffer to the actual framebuffer
   void syncBuffers(uint8_t* buffer, core::Region damage);
+  void syncBuffersTransformed(uint8_t* buffer, core::Region damage, uint32_t shmFormat, uint32_t transform);
 
   // Convert from wl_shm_format to RGB. Will un-premultiply alpha when
   // applicable. Caller owns returned buffer
@@ -61,7 +65,21 @@ private:
                                uint32_t width, uint32_t height);
 
   // Convert from wl_shm_format to rfb::PixelFormat
-  rfb::PixelFormat convertPixelformat(uint32_t format);
+  rfb::PixelFormat shmToRfbFormat(uint32_t shmFormat);
+
+  // Converts a wl_shm_format to a pixman format
+  pixman_format_code_t shmToPixmanFormat(uint32_t shmFormat);
+
+  // Takes a transformed buffer and will return a new buffer that has
+  // undone the transformation
+  uint8_t* undoTransformation(const uint8_t* srcBuffer, int srcWidth, int srcHeight,
+                              int srcStride, uint32_t shmFormat,
+                              uint32_t transform);
+
+  // Returns an inverse pixman transform for the given wayland transform.
+  // The inverse transform can be used to undo the transform
+  pixman_transform_t wlToPixmanInverseTransform(uint32_t transform,
+                                                int srcWidth, int srcHeight);
 
 private:
   bool firstFrame;

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.h
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.h
@@ -23,13 +23,14 @@
 
 #include <rfb/PixelBuffer.h>
 
-#include "objects/ScreencopyManager.h"
-
 namespace rfb { class VNCServer; class PixelFormat; }
 
 namespace wayland {
   class Output;
   class Display;
+  class ScreencopyManager;
+  class ImageCaptureSource;
+  class ImageCopyCaptureManager;
 };
 
 class WaylandPixelBuffer : public rfb::ManagedPixelBuffer {
@@ -55,7 +56,14 @@ private:
   std::function<void()> desktopReadyCallback;
   rfb::VNCServer* server;
   wayland::Output* output;
+
+  // wlr-screencopy
   wayland::ScreencopyManager* screencopyManager;
+
+  // ext-image-copy-capture-v1
+  wayland::ImageCaptureSource* imageCaptureSource;
+  wayland::ImageCopyCaptureManager* imageCopyCaptureManager;
+
   bool resized;
 };
 

--- a/unix/w0vncserver/wayland/WaylandPixelBuffer.h
+++ b/unix/w0vncserver/wayland/WaylandPixelBuffer.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Adam Halim for Cendio AB
+/* Copyright 2025-2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,11 +41,14 @@ public:
 
 protected:
   // Called when there is pixel data available to read
-  void bufferEvent(uint8_t* buffer, core::Region damage, rfb::PixelFormat pf);
+  void bufferEvent(uint8_t* buffer, core::Region damage, uint32_t format);
 
 private:
   // Sync the shadow framebuffer to the actual framebuffer
   void syncBuffers(uint8_t* buffer, core::Region damage);
+
+  // Convert from wl_shm_format to rfb::PixelFormat
+  rfb::PixelFormat convertPixelformat(uint32_t format);
 
 private:
   bool firstFrame;

--- a/unix/w0vncserver/wayland/objects/ImageCaptureSource.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCaptureSource.cxx
@@ -1,0 +1,81 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdexcept>
+
+#include <ext-image-capture-source-v1.h>
+
+#include <core/LogWriter.h>
+
+#include "Display.h"
+#include "Output.h"
+#include "ImageCaptureSource.h"
+
+using namespace wayland;
+
+static core::LogWriter vlog("WaylandImageCaptureSource");
+
+ImageCaptureSource::~ImageCaptureSource()
+{
+  if (source)
+    ext_image_capture_source_v1_destroy(source);
+}
+
+OutputImageCaptureSource::OutputImageCaptureSource(Display* display,
+                                                   Output* output)
+  : Object(display, "ext_output_image_capture_source_manager_v1",
+           &ext_output_image_capture_source_manager_v1_interface)
+{
+  manager = (ext_output_image_capture_source_manager_v1*)boundObject;
+  source = ext_output_image_capture_source_manager_v1_create_source(manager, output->getOutput());
+  if (!source) {
+    ext_output_image_capture_source_manager_v1_destroy(manager);
+    throw std::runtime_error("Failed to create capture source");
+  }
+}
+
+OutputImageCaptureSource::~OutputImageCaptureSource()
+{
+  if (manager)
+    ext_output_image_capture_source_manager_v1_destroy(manager);
+}
+
+// FIXME: Create a ext_foreign_toplevel_handle_v1 object wrapper
+ForeignToplevelImageCaptureSource::ForeignToplevelImageCaptureSource(Display* display_,
+                                                                     ext_foreign_toplevel_handle_v1* toplevel)
+  : Object(display_, "ext_foreign_toplevel_image_capture_source_manager_v1",
+           &ext_foreign_toplevel_image_capture_source_manager_v1_interface),
+    manager(nullptr)
+{
+  manager = (ext_foreign_toplevel_image_capture_source_manager_v1*)boundObject;
+  source = ext_foreign_toplevel_image_capture_source_manager_v1_create_source(manager, toplevel);
+  if (!source) {
+    ext_foreign_toplevel_image_capture_source_manager_v1_destroy(manager);
+    throw std::runtime_error("Failed to create capture source");
+  }
+}
+
+ForeignToplevelImageCaptureSource::~ForeignToplevelImageCaptureSource()
+{
+  if (manager)
+    ext_foreign_toplevel_image_capture_source_manager_v1_destroy(manager);
+}

--- a/unix/w0vncserver/wayland/objects/ImageCaptureSource.h
+++ b/unix/w0vncserver/wayland/objects/ImageCaptureSource.h
@@ -1,0 +1,67 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifndef __WAYLAND_IMAGE_CAPTURE_SOURCE_H__
+#define __WAYLAND_IMAGE_CAPTURE_SOURCE_H__
+
+#include "Object.h"
+
+struct ext_foreign_toplevel_handle_v1;
+struct ext_image_capture_source_v1;
+struct ext_output_image_capture_source_manager_v1;
+struct ext_foreign_toplevel_image_capture_source_manager_v1;
+
+namespace wayland {
+  class Display;
+  class Output;
+
+  class ImageCaptureSource {
+  protected:
+    ImageCaptureSource() {};
+  public:
+    virtual ~ImageCaptureSource();
+
+    ext_image_capture_source_v1* getSource() { return source; }
+
+  protected:
+    ext_image_capture_source_v1* source;
+  };
+
+  class OutputImageCaptureSource : public Object,
+                                   public ImageCaptureSource {
+  public:
+    OutputImageCaptureSource(Display* display, Output* output);
+    ~OutputImageCaptureSource();
+
+  private:
+    ext_output_image_capture_source_manager_v1* manager;
+  };
+
+  class ForeignToplevelImageCaptureSource : public Object,
+                                            public ImageCaptureSource {
+  public:
+    ForeignToplevelImageCaptureSource(Display* display,
+                                      ext_foreign_toplevel_handle_v1* toplevel);
+    ~ForeignToplevelImageCaptureSource();
+
+  private:
+    ext_foreign_toplevel_image_capture_source_manager_v1* manager;
+  };
+};
+
+#endif // __WAYLAND_IMAGE_CAPTURE_SOURCE_H__

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.cxx
@@ -1,0 +1,114 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdexcept>
+
+#include <ext-image-copy-capture-v1.h>
+
+#include <core/LogWriter.h>
+#include <core/Rect.h>
+
+#include "ImageCopyCaptureSession.h"
+#include "ImageCopyCaptureCursorSession.h"
+
+using namespace wayland;
+
+static core::LogWriter vlog("WaylandImageCopyCaptureCursorSession");
+
+const ext_image_copy_capture_cursor_session_v1_listener
+ImageCopyCaptureCursorSession::listener = {
+  .enter = [](void* data, ext_image_copy_capture_cursor_session_v1*) {
+    ((ImageCopyCaptureCursorSession*)data)->handleEnter();
+  },
+  .leave = [](void* data, ext_image_copy_capture_cursor_session_v1*) {
+    ((ImageCopyCaptureCursorSession*)data)->handleLeave();
+  },
+  .position = [](void* data, ext_image_copy_capture_cursor_session_v1*,
+                 int32_t x, int32_t y) {
+    ((ImageCopyCaptureCursorSession*)data)->handlePosition(x, y);
+  },
+  .hotspot = [](void* data, ext_image_copy_capture_cursor_session_v1*,
+                int32_t x, int32_t y) {
+    ((ImageCopyCaptureCursorSession*)data)->handleHotspot(x, y);
+  },
+};
+
+ImageCopyCaptureCursorSession::ImageCopyCaptureCursorSession(Display* display_,
+                                                             ext_image_copy_capture_cursor_session_v1* session_,
+                                                             std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)>
+                                                               cursorFrameCb_,
+                                                             std::function<void(const core::Point&)>
+                                                               cursorPosCb_,
+                                                             std::function<void()>
+                                                               stoppedCb_)
+  : session(session_), captureSession(nullptr),
+    cursorFrameCb(cursorFrameCb_), cursorPosCb(cursorPosCb_),
+    hotspot({0, 0})
+{
+  ext_image_copy_capture_cursor_session_v1_add_listener(session, &listener, this);
+
+  ext_image_copy_capture_session_v1* captureSessionHandle =
+    ext_image_copy_capture_cursor_session_v1_get_capture_session(session);
+
+  if (!captureSessionHandle) {
+    ext_image_copy_capture_cursor_session_v1_destroy(session);
+    throw std::runtime_error("Could not create cursor capture session");
+  }
+
+  std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb =
+    [this](uint8_t*, core::Region, uint32_t) {
+      cursorFrameCb(captureSession->getWidth(),
+                    captureSession->getHeight(),
+                    hotspot, captureSession->getFormat(),
+                    captureSession->getBufferData());
+  };
+
+  captureSession = new ImageCopyCaptureSession(display_,
+                                               captureSessionHandle,
+                                               bufferEventCb,
+                                               stoppedCb_);
+}
+
+ImageCopyCaptureCursorSession::~ImageCopyCaptureCursorSession()
+{
+  delete captureSession;
+  if (session)
+    ext_image_copy_capture_cursor_session_v1_destroy(session);
+}
+
+void ImageCopyCaptureCursorSession::handleEnter()
+{
+}
+
+void ImageCopyCaptureCursorSession::handleLeave()
+{
+}
+
+void ImageCopyCaptureCursorSession::handlePosition(int32_t x, int32_t y)
+{
+  cursorPosCb({x, y});
+}
+
+void ImageCopyCaptureCursorSession::handleHotspot(int32_t x, int32_t y)
+{
+  hotspot = {x, y};
+}

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.cxx
@@ -54,7 +54,7 @@ ImageCopyCaptureCursorSession::listener = {
 
 ImageCopyCaptureCursorSession::ImageCopyCaptureCursorSession(Display* display_,
                                                              ext_image_copy_capture_cursor_session_v1* session_,
-                                                             std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)>
+                                                             std::function<void(int, int, const core::Point&, uint32_t, uint32_t, const uint8_t*)>
                                                                cursorFrameCb_,
                                                              std::function<void(const core::Point&)>
                                                                cursorPosCb_,
@@ -74,11 +74,12 @@ ImageCopyCaptureCursorSession::ImageCopyCaptureCursorSession(Display* display_,
     throw std::runtime_error("Could not create cursor capture session");
   }
 
-  std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb =
-    [this](uint8_t*, core::Region, uint32_t) {
+  std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)> bufferEventCb =
+    [this](uint8_t*, core::Region, uint32_t, uint32_t) {
       cursorFrameCb(captureSession->getWidth(),
                     captureSession->getHeight(),
                     hotspot, captureSession->getFormat(),
+                    captureSession->getTransform(),
                     captureSession->getBufferData());
   };
 

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.h
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.h
@@ -1,0 +1,61 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifndef __WAYLAND_IMAGE_COPY_CAPTURE_CURSOR_SESSION_H__
+#define __WAYLAND_IMAGE_COPY_CAPTURE_CURSOR_SESSION_H__
+
+#include <functional>
+
+#include <core/Rect.h>
+
+#include "Object.h"
+
+struct ext_image_copy_capture_cursor_session_v1;
+struct ext_image_copy_capture_cursor_session_v1_listener;
+
+namespace wayland {
+  class Display;
+  class ImageCopyCaptureSession;
+
+  class ImageCopyCaptureCursorSession {
+  public:
+    ImageCopyCaptureCursorSession(Display* display,
+                                  ext_image_copy_capture_cursor_session_v1* session,
+                                  std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)>
+                                    cursorFrameCb,
+                                  std::function<void(const core::Point&)> cursorPosCb,
+                                  std::function<void()> stoppedCb);
+    ~ImageCopyCaptureCursorSession();
+
+  private:
+    void handleEnter();
+    void handleLeave();
+    void handlePosition(int32_t x, int32_t y);
+    void handleHotspot(int32_t x, int32_t y);
+
+  private:
+    ext_image_copy_capture_cursor_session_v1* session;
+    ImageCopyCaptureSession* captureSession;
+    std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)> cursorFrameCb;
+    std::function<void(const core::Point&)> cursorPosCb;
+    core::Point hotspot;
+    static const ext_image_copy_capture_cursor_session_v1_listener listener;
+  };
+};
+
+#endif // __WAYLAND_IMAGE_COPY_CAPTURE_CURSOR_SESSION_H__

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.h
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureCursorSession.h
@@ -36,7 +36,7 @@ namespace wayland {
   public:
     ImageCopyCaptureCursorSession(Display* display,
                                   ext_image_copy_capture_cursor_session_v1* session,
-                                  std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)>
+                                  std::function<void(int, int, const core::Point&, uint32_t, uint32_t, const uint8_t*)>
                                     cursorFrameCb,
                                   std::function<void(const core::Point&)> cursorPosCb,
                                   std::function<void()> stoppedCb);
@@ -51,7 +51,7 @@ namespace wayland {
   private:
     ext_image_copy_capture_cursor_session_v1* session;
     ImageCopyCaptureSession* captureSession;
-    std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)> cursorFrameCb;
+    std::function<void(int, int, const core::Point&, uint32_t, uint32_t, const uint8_t*)> cursorFrameCb;
     std::function<void(const core::Point&)> cursorPosCb;
     core::Point hotspot;
     static const ext_image_copy_capture_cursor_session_v1_listener listener;

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.cxx
@@ -28,9 +28,11 @@
 #include <core/string.h>
 
 #include "Display.h"
+#include "Pointer.h"
 #include "Seat.h"
 #include "ImageCaptureSource.h"
 #include "ImageCopyCaptureSession.h"
+#include "ImageCopyCaptureCursorSession.h"
 #include "ImageCopyCaptureManager.h"
 
 using namespace wayland;
@@ -39,21 +41,28 @@ static core::LogWriter vlog("WaylandImageCopyCaptureManager");
 
 ImageCopyCaptureManager::ImageCopyCaptureManager(Display* display_,
                                                  ImageCaptureSource* source_,
+                                                 Seat* seat_,
                                                  std::function<void(uint8_t*, core::Region, uint32_t)>
                                                    bufferEventCb_,
+                                                 std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)>
+                                                   cursorImageCb_,
+                                                 std::function<void(const core::Point&)>
+                                                   cursorPosCb_,
                                                  std::function<void()>
                                                    stoppedCb_)
   : Object(display_, "ext_image_copy_capture_manager_v1",
            &ext_image_copy_capture_manager_v1_interface),
     manager(nullptr), display(display_), source(source_),
-    session(nullptr), bufferEventCb(bufferEventCb_),
-    stoppedCb(stoppedCb_)
+    session(nullptr), seat(seat_), cursorSession(nullptr),
+    bufferEventCb(bufferEventCb_), cursorImageCb(cursorImageCb_),
+    cursorPosCb(cursorPosCb_), stoppedCb(stoppedCb_)
 {
   manager = (ext_image_copy_capture_manager_v1*)boundObject;
 }
 
 ImageCopyCaptureManager::~ImageCopyCaptureManager()
 {
+  delete cursorSession;
   delete session;
   if (manager)
     ext_image_copy_capture_manager_v1_destroy(manager);
@@ -62,14 +71,37 @@ ImageCopyCaptureManager::~ImageCopyCaptureManager()
 void ImageCopyCaptureManager::createSession()
 {
   ext_image_copy_capture_session_v1* sessionHandle;
+  ext_image_copy_capture_cursor_session_v1* cursorSessionHandle;
+  Pointer* pointer;
 
   sessionHandle =
-    ext_image_copy_capture_manager_v1_create_session(manager, source->getSource(),
-                                                     EXT_IMAGE_COPY_CAPTURE_MANAGER_V1_OPTIONS_PAINT_CURSORS);
+    ext_image_copy_capture_manager_v1_create_session(manager, source->getSource(), 0);
   if (!sessionHandle)
     throw std::runtime_error("Unable to create image copy capture session");
 
   session = new ImageCopyCaptureSession(display, sessionHandle,
                                         bufferEventCb, stoppedCb);
-}
 
+  pointer = seat->getPointer();
+  // FIXME: Make it possible to re-enable this if a cursor is added in
+  // the future like we do in VirtualKeyboard
+  if (!pointer) {
+    vlog.error("Unable to create cursor capture session: no pointer found - cursor will be invisible");
+    return;
+  }
+
+  cursorSessionHandle =
+    ext_image_copy_capture_manager_v1_create_pointer_cursor_session(manager,
+                                                                    source->getSource(),
+                                                                    pointer->getPointer());
+  if (!cursorSessionHandle) {
+    vlog.error("Unable to create image copy capture session - cursor will be invisible");
+    return;
+  }
+
+  cursorSession = new ImageCopyCaptureCursorSession(display,
+                                                    cursorSessionHandle,
+                                                    cursorImageCb,
+                                                    cursorPosCb,
+                                                    stoppedCb);
+}

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.cxx
@@ -1,0 +1,75 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdexcept>
+
+#include <ext-image-copy-capture-v1.h>
+
+#include <core/LogWriter.h>
+#include <core/string.h>
+
+#include "Display.h"
+#include "Seat.h"
+#include "ImageCaptureSource.h"
+#include "ImageCopyCaptureSession.h"
+#include "ImageCopyCaptureManager.h"
+
+using namespace wayland;
+
+static core::LogWriter vlog("WaylandImageCopyCaptureManager");
+
+ImageCopyCaptureManager::ImageCopyCaptureManager(Display* display_,
+                                                 ImageCaptureSource* source_,
+                                                 std::function<void(uint8_t*, core::Region, uint32_t)>
+                                                   bufferEventCb_,
+                                                 std::function<void()>
+                                                   stoppedCb_)
+  : Object(display_, "ext_image_copy_capture_manager_v1",
+           &ext_image_copy_capture_manager_v1_interface),
+    manager(nullptr), display(display_), source(source_),
+    session(nullptr), bufferEventCb(bufferEventCb_),
+    stoppedCb(stoppedCb_)
+{
+  manager = (ext_image_copy_capture_manager_v1*)boundObject;
+}
+
+ImageCopyCaptureManager::~ImageCopyCaptureManager()
+{
+  delete session;
+  if (manager)
+    ext_image_copy_capture_manager_v1_destroy(manager);
+}
+
+void ImageCopyCaptureManager::createSession()
+{
+  ext_image_copy_capture_session_v1* sessionHandle;
+
+  sessionHandle =
+    ext_image_copy_capture_manager_v1_create_session(manager, source->getSource(),
+                                                     EXT_IMAGE_COPY_CAPTURE_MANAGER_V1_OPTIONS_PAINT_CURSORS);
+  if (!sessionHandle)
+    throw std::runtime_error("Unable to create image copy capture session");
+
+  session = new ImageCopyCaptureSession(display, sessionHandle,
+                                        bufferEventCb, stoppedCb);
+}
+

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.cxx
@@ -42,9 +42,9 @@ static core::LogWriter vlog("WaylandImageCopyCaptureManager");
 ImageCopyCaptureManager::ImageCopyCaptureManager(Display* display_,
                                                  ImageCaptureSource* source_,
                                                  Seat* seat_,
-                                                 std::function<void(uint8_t*, core::Region, uint32_t)>
+                                                 std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)>
                                                    bufferEventCb_,
-                                                 std::function<void(int, int, const core::Point&, uint32_t,const uint8_t*)>
+                                                 std::function<void(int, int, const core::Point&, uint32_t, uint32_t, const uint8_t*)>
                                                    cursorImageCb_,
                                                  std::function<void(const core::Point&)>
                                                    cursorPosCb_,

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.h
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.h
@@ -1,0 +1,59 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifndef __WAYLAND_IMAGE_COPY_CAPTURE_MANAGER_H__
+#define __WAYLAND_IMAGE_COPY_CAPTURE_MANAGER_H__
+
+#include <functional>
+
+#include "Object.h"
+
+struct ext_image_copy_capture_manager_v1;
+
+namespace core { class Region; }
+
+namespace wayland {
+  class Display;
+  class Seat;
+
+  class ImageCaptureSource;
+  class ImageCopyCaptureSession;
+
+  class ImageCopyCaptureManager : public Object {
+  public:
+    ImageCopyCaptureManager(Display* display,
+                            ImageCaptureSource* source,
+                            std::function<void(uint8_t*, core::Region, uint32_t)>
+                              bufferEventCb,
+                            std::function<void()> stoppedCb);
+    ~ImageCopyCaptureManager();
+
+    void createSession();
+
+  private:
+    ext_image_copy_capture_manager_v1* manager;
+    Display* display;
+    ImageCaptureSource* source;
+    ImageCopyCaptureSession* session;
+    std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb;
+    std::function<void()> stoppedCb;
+  };
+
+};
+
+#endif // __WAYLAND_IMAGE_COPY_CAPTURE_MANAGER_H__

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.h
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.h
@@ -25,7 +25,7 @@
 
 struct ext_image_copy_capture_manager_v1;
 
-namespace core { class Region; }
+namespace core { class Region; struct Point; }
 
 namespace wayland {
   class Display;
@@ -33,13 +33,18 @@ namespace wayland {
 
   class ImageCaptureSource;
   class ImageCopyCaptureSession;
+  class ImageCopyCaptureCursorSession;
 
   class ImageCopyCaptureManager : public Object {
   public:
     ImageCopyCaptureManager(Display* display,
                             ImageCaptureSource* source,
+                            Seat* seat,
                             std::function<void(uint8_t*, core::Region, uint32_t)>
                               bufferEventCb,
+                            std::function<void(int, int, const core::Point&, uint32_t, const uint8_t*)>
+                              cursorImageCb,
+                            std::function<void(const core::Point&)> cursorPosCb,
                             std::function<void()> stoppedCb);
     ~ImageCopyCaptureManager();
 
@@ -50,7 +55,11 @@ namespace wayland {
     Display* display;
     ImageCaptureSource* source;
     ImageCopyCaptureSession* session;
+    Seat* seat;
+    ImageCopyCaptureCursorSession* cursorSession;
     std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb;
+    std::function<void(int, int, const core::Point&, uint32_t, const uint8_t*)> cursorImageCb;
+    std::function<void(const core::Point&)> cursorPosCb;
     std::function<void()> stoppedCb;
   };
 

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.h
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureManager.h
@@ -40,9 +40,9 @@ namespace wayland {
     ImageCopyCaptureManager(Display* display,
                             ImageCaptureSource* source,
                             Seat* seat,
-                            std::function<void(uint8_t*, core::Region, uint32_t)>
+                            std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)>
                               bufferEventCb,
-                            std::function<void(int, int, const core::Point&, uint32_t, const uint8_t*)>
+                            std::function<void(int, int, const core::Point&, uint32_t, uint32_t, const uint8_t*)>
                               cursorImageCb,
                             std::function<void(const core::Point&)> cursorPosCb,
                             std::function<void()> stoppedCb);
@@ -57,8 +57,8 @@ namespace wayland {
     ImageCopyCaptureSession* session;
     Seat* seat;
     ImageCopyCaptureCursorSession* cursorSession;
-    std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb;
-    std::function<void(int, int, const core::Point&, uint32_t, const uint8_t*)> cursorImageCb;
+    std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)> bufferEventCb;
+    std::function<void(int, int, const core::Point&, uint32_t, uint32_t, const uint8_t*)> cursorImageCb;
     std::function<void(const core::Point&)> cursorPosCb;
     std::function<void()> stoppedCb;
   };

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.cxx
@@ -102,13 +102,14 @@ const ext_image_copy_capture_frame_v1_listener ImageCopyCaptureSession::frameLis
 
 ImageCopyCaptureSession::ImageCopyCaptureSession(Display* display_,
                                                  ext_image_copy_capture_session_v1* session_,
-                                                 std::function<void(uint8_t*, core::Region, uint32_t)>
+                                                 std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)>
                                                    bufferEventCb_,
                                                  std::function<void()>
                                                    stoppedCb_)
   : display(display_), bufferEventCb(bufferEventCb_), session(session_),
     frame(nullptr), shm(nullptr), pool(nullptr), buffer(nullptr),
-    firstCapture(true), width(0), height(0), stoppedCb(stoppedCb_)
+    firstCapture(true), width(0), height(0), transform(0),
+    stoppedCb(stoppedCb_)
 {
   ext_image_copy_capture_session_v1_add_listener(session, &listener, this);
 }
@@ -235,8 +236,9 @@ void ImageCopyCaptureSession::handleStopped()
   stoppedCb();
 }
 
-void ImageCopyCaptureSession::handleFrameTransform(uint32_t /* transform */)
+void ImageCopyCaptureSession::handleFrameTransform(uint32_t transform_)
 {
+  transform = transform_;
 }
 
 void ImageCopyCaptureSession::handleFrameDamage(int32_t x, int32_t y,
@@ -259,7 +261,7 @@ void ImageCopyCaptureSession::handleFrameReady()
 {
   assert(frame);
 
-  bufferEventCb(pool->getData(), damage, format);
+  bufferEventCb(pool->getData(), damage, format, transform);
 
   ext_image_copy_capture_frame_v1_destroy(frame);
   frame = nullptr;

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.cxx
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.cxx
@@ -1,0 +1,344 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <assert.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include <stdexcept>
+
+#include <ext-image-copy-capture-v1.h>
+
+#include <core/LogWriter.h>
+#include <core/string.h>
+
+#include "Shm.h"
+#include "ShmPool.h"
+
+#include "ImageCaptureSource.h"
+#include "ImageCopyCaptureSession.h"
+
+using namespace wayland;
+
+static core::LogWriter vlog("WaylandImageCopyCaptureSession");
+
+// Preferred pixel formats, in prioritized order
+// FIXME: We probably prefer XRGB8888 in most cases, but we should try
+//        to respect whatever the client has requested if the compositor
+//        also supports it.
+static std::vector<uint32_t> preferredFormats = {
+  WL_SHM_FORMAT_XRGB8888,
+  WL_SHM_FORMAT_ARGB8888,
+  WL_SHM_FORMAT_RGBX8888,
+  WL_SHM_FORMAT_RGBA8888,
+  WL_SHM_FORMAT_XBGR8888,
+  WL_SHM_FORMAT_ABGR8888,
+};
+
+const ext_image_copy_capture_session_v1_listener ImageCopyCaptureSession::listener = {
+  .buffer_size = [](void* data, ext_image_copy_capture_session_v1*,
+                    uint32_t width, uint32_t height) {
+    ((ImageCopyCaptureSession*)data)->handleBufferSize(width, height);
+  },
+  .shm_format = [](void* data, ext_image_copy_capture_session_v1*, uint32_t format) {
+    ((ImageCopyCaptureSession*)data)->handleShmFormat(format);
+  },
+  .dmabuf_device = [](void* data, ext_image_copy_capture_session_v1*, wl_array* device) {
+    ((ImageCopyCaptureSession*)data)->handleDmabufDevice(device);
+  },
+  .dmabuf_format = [](void* data, ext_image_copy_capture_session_v1*,
+                      uint32_t format, wl_array* modifiers) {
+    ((ImageCopyCaptureSession*)data)->handleDmabufFormat(format, modifiers);
+  },
+  .done = [](void* data, ext_image_copy_capture_session_v1*) {
+    ((ImageCopyCaptureSession*)data)->handleDone();
+  },
+  .stopped = [](void* data, ext_image_copy_capture_session_v1*) {
+    ((ImageCopyCaptureSession*)data)->handleStopped();
+  },
+};
+
+const ext_image_copy_capture_frame_v1_listener ImageCopyCaptureSession::frameListener = {
+  .transform = [](void* data, ext_image_copy_capture_frame_v1*, uint32_t transform) {
+    ((ImageCopyCaptureSession*)data)->handleFrameTransform(transform);
+  },
+  .damage = [](void* data, ext_image_copy_capture_frame_v1*,
+               int32_t x, int32_t y, int32_t width, int32_t height) {
+    ((ImageCopyCaptureSession*)data)->handleFrameDamage(x, y, width, height);
+  },
+  .presentation_time = [](void* data, ext_image_copy_capture_frame_v1*,
+                          uint32_t tvSecHi, uint32_t tvSecLo, uint32_t tvNsec) {
+    ((ImageCopyCaptureSession*)data)->handleFramePresentationTime(tvSecHi, tvSecLo, tvNsec);
+  },
+  .ready = [](void* data, ext_image_copy_capture_frame_v1*) {
+    ((ImageCopyCaptureSession*)data)->handleFrameReady();
+  },
+  .failed = [](void* data, ext_image_copy_capture_frame_v1*, uint32_t reason) {
+    ((ImageCopyCaptureSession*)data)->handleFrameFailed(reason);
+  },
+};
+
+
+ImageCopyCaptureSession::ImageCopyCaptureSession(Display* display_,
+                                                 ext_image_copy_capture_session_v1* session_,
+                                                 std::function<void(uint8_t*, core::Region, uint32_t)>
+                                                   bufferEventCb_,
+                                                 std::function<void()>
+                                                   stoppedCb_)
+  : display(display_), bufferEventCb(bufferEventCb_), session(session_),
+    frame(nullptr), shm(nullptr), pool(nullptr), buffer(nullptr),
+    firstCapture(true), width(0), height(0), stoppedCb(stoppedCb_)
+{
+  ext_image_copy_capture_session_v1_add_listener(session, &listener, this);
+}
+
+ImageCopyCaptureSession::~ImageCopyCaptureSession()
+{
+  if (frame)
+    ext_image_copy_capture_frame_v1_destroy(frame);
+  if (buffer)
+    wl_buffer_destroy(buffer);
+
+  ext_image_copy_capture_session_v1_destroy(session);
+
+  delete pool;
+  delete shm;
+}
+
+uint8_t* ImageCopyCaptureSession::getBufferData() const
+{
+  assert(pool);
+
+  return pool->getData();
+}
+
+void ImageCopyCaptureSession::handleBufferSize(uint32_t width_,
+                                               uint32_t height_)
+{
+  width = width_;
+  height = height_;
+}
+
+void ImageCopyCaptureSession::handleShmFormat(uint32_t format_)
+{
+  formatsPending.push_back((uint32_t)format_);
+
+}
+
+void ImageCopyCaptureSession::handleDmabufDevice(wl_array* /* device */)
+{
+}
+
+void ImageCopyCaptureSession::handleDmabufFormat(uint32_t /* format */,
+                                                 wl_array* /* modifiers */)
+{
+}
+
+void ImageCopyCaptureSession::handleDone()
+{
+  size_t size;
+  int fd;
+
+  cleanupBuffers();
+
+  assert(!shm);
+  assert(!pool);
+  assert(!buffer);
+
+  if (formatsPending.empty()) {
+    vlog.error("No shm formats available");
+    stoppedCb();
+    return;
+  }
+
+  // Ensure formats doesn't change during execution
+  formats = formatsPending;
+  formatsPending.clear();
+
+  try {
+    format = preferredFormat();
+  } catch (std::exception& e) {
+    vlog.error("Failed to pick shm format: %s", e.what());
+    stoppedCb();
+    return;
+  }
+
+  fd = memfd_create("w0vncserver-image-copy-shm", FD_CLOEXEC);
+  if (fd < 0) {
+    vlog.error("Failed to allocate shm: %s", strerror(errno));
+    stoppedCb();
+    return;
+  }
+
+  size = width * height * 4;
+  if (ftruncate(fd, size) < 0) {
+    vlog.error("Failed to truncate shm: %s", strerror(errno));
+    close(fd);
+    return;
+  }
+
+  try {
+    shm = new Shm(display);
+    pool = new ShmPool(shm, fd, size);
+  } catch (std::exception& e) {
+    vlog.error("Failed to create shm pool: %s", e.what());
+    close(fd);
+    stoppedCb();
+    return;
+  }
+
+  close(fd);
+
+  buffer = pool->createBuffer(0, width, height, width * 4, format);
+  if (!buffer) {
+    vlog.error("Failed to create buffer");
+    stoppedCb();
+    return;
+  }
+
+  createFrame();
+}
+
+void ImageCopyCaptureSession::handleStopped()
+{
+  vlog.status("Capture session stopped");
+
+  if (frame) {
+    ext_image_copy_capture_frame_v1_destroy(frame);
+    frame = nullptr;
+  }
+
+  ext_image_copy_capture_session_v1_destroy(session);
+  session = nullptr;
+
+  stoppedCb();
+}
+
+void ImageCopyCaptureSession::handleFrameTransform(uint32_t /* transform */)
+{
+}
+
+void ImageCopyCaptureSession::handleFrameDamage(int32_t x, int32_t y,
+                                                int32_t width_,
+                                                int32_t height_)
+{
+  core::Point tl{static_cast<int>(x), static_cast<int>(y)};
+  core::Point br{static_cast<int>(x + width_),
+                 static_cast<int>(y + height_)};
+  damage.assign_union({{tl, br}});
+}
+
+void ImageCopyCaptureSession::handleFramePresentationTime(uint32_t /* tvSecHi */,
+                                                          uint32_t /* tvSecLo */,
+                                                          uint32_t /* tvNsec */)
+{
+}
+
+void ImageCopyCaptureSession::handleFrameReady()
+{
+  assert(frame);
+
+  bufferEventCb(pool->getData(), damage, format);
+
+  ext_image_copy_capture_frame_v1_destroy(frame);
+  frame = nullptr;
+
+  createFrame();
+}
+
+void ImageCopyCaptureSession::handleFrameFailed(uint32_t reason)
+{
+  if (frame) {
+    ext_image_copy_capture_frame_v1_destroy(frame);
+    frame = nullptr;
+  }
+
+  if (reason == EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN) {
+    vlog.error("Could not capture frame: unknown reason - trying again");
+    createFrame();
+  } else if (reason == EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS) {
+    // FIXME: The specification says that we should re-allocate our
+    // buffers and try again. Not sure if that is the right thing to do.
+    // For now, just stop the capture.
+    vlog.error("Invalid buffer constraints, stopping capture session");
+    stoppedCb();
+  } else if (reason == EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_STOPPED) {
+    vlog.error("Could not capture frame, stopping capture session");
+    stoppedCb();
+  } else {
+    vlog.error("Could not capture frame: invalid failure reason %d", reason);
+    stoppedCb();
+  }
+}
+
+void ImageCopyCaptureSession::createFrame()
+{
+  assert(frame == nullptr);
+
+  frame = ext_image_copy_capture_session_v1_create_frame(session);
+  ext_image_copy_capture_frame_v1_add_listener(frame, &frameListener, this);
+
+  damage.clear();
+
+  // The first time a buffer is captured, we need to damage the entire buffer
+  if (firstCapture) {
+    ext_image_copy_capture_frame_v1_damage_buffer(frame, 0, 0, width, height);
+    firstCapture = false;
+  }
+
+  ext_image_copy_capture_frame_v1_attach_buffer(frame, buffer);
+  ext_image_copy_capture_frame_v1_capture(frame);
+}
+
+void ImageCopyCaptureSession::cleanupBuffers()
+{
+  if (frame)
+    ext_image_copy_capture_frame_v1_destroy(frame);
+
+  if (buffer)
+    wl_buffer_destroy(buffer);
+
+  frame = nullptr;
+  buffer = nullptr;
+  firstCapture = true;
+
+  delete pool;
+  pool = nullptr;
+
+  delete shm;
+  shm = nullptr;
+
+  formats.clear();
+  damage.clear();
+}
+
+uint32_t ImageCopyCaptureSession::preferredFormat()
+{
+  for (uint32_t shmFormat : preferredFormats) {
+    if (std::find(formats.begin(), formats.end(), shmFormat) != formats.end())
+      return shmFormat;
+  }
+
+  throw std::runtime_error("No supported shm format found");
+}

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.h
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.h
@@ -43,7 +43,7 @@ namespace wayland {
   public:
     ImageCopyCaptureSession(Display* display,
                             ext_image_copy_capture_session_v1* session,
-                            std::function<void(uint8_t*, core::Region, uint32_t)>
+                            std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)>
                               bufferEventCb,
                             std::function<void()> stoppedCb);
     ~ImageCopyCaptureSession();
@@ -52,6 +52,7 @@ namespace wayland {
     uint32_t getWidth() const { return width; }
     uint32_t getHeight() const { return height; }
     uint32_t getFormat() const { return format; }
+    uint32_t getTransform() const { return transform; }
 
   private:
     void handleBufferSize(uint32_t width, uint32_t height);
@@ -75,7 +76,7 @@ namespace wayland {
 
   private:
     Display* display;
-    std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb;
+    std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)> bufferEventCb;
     ext_image_copy_capture_session_v1* session;
     ext_image_copy_capture_frame_v1* frame;
     Shm* shm;
@@ -85,6 +86,7 @@ namespace wayland {
     uint32_t width;
     uint32_t height;
     uint32_t format;
+    uint32_t transform;
     std::function<void()> stoppedCb;
     std::vector<uint32_t> formatsPending;
     std::vector<uint32_t> formats;

--- a/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.h
+++ b/unix/w0vncserver/wayland/objects/ImageCopyCaptureSession.h
@@ -1,0 +1,98 @@
+/* Copyright 2026 Tobias Fahleson for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifndef __WAYLAND_IMAGE_COPY_CAPTURE_SESSION_H__
+#define __WAYLAND_IMAGE_COPY_CAPTURE_SESSION_H__
+
+#include <functional>
+#include <vector>
+
+#include <core/Region.h>
+
+#include "Object.h"
+
+struct wl_array;
+struct wl_buffer;
+
+struct ext_image_copy_capture_session_v1;
+struct ext_image_copy_capture_frame_v1;
+struct ext_image_copy_capture_session_v1_listener;
+struct ext_image_copy_capture_frame_v1_listener;
+
+namespace wayland {
+  class Display;
+  class Shm;
+  class ShmPool;
+
+  class ImageCopyCaptureSession {
+  public:
+    ImageCopyCaptureSession(Display* display,
+                            ext_image_copy_capture_session_v1* session,
+                            std::function<void(uint8_t*, core::Region, uint32_t)>
+                              bufferEventCb,
+                            std::function<void()> stoppedCb);
+    ~ImageCopyCaptureSession();
+
+    uint8_t* getBufferData() const;
+    uint32_t getWidth() const { return width; }
+    uint32_t getHeight() const { return height; }
+    uint32_t getFormat() const { return format; }
+
+  private:
+    void handleBufferSize(uint32_t width, uint32_t height);
+    void handleShmFormat(uint32_t format);
+    void handleDmabufDevice(wl_array* device);
+    void handleDmabufFormat(uint32_t format, wl_array* modifiers);
+    void handleDone();
+    void handleStopped();
+    void handleFrameTransform(uint32_t transform);
+    void handleFrameDamage(int32_t x, int32_t y, int32_t width,
+                           int32_t height);
+    void handleFramePresentationTime(uint32_t tvSecHi, uint32_t tvSecLo,
+                                     uint32_t tvNsec);
+    void handleFrameReady();
+    void handleFrameFailed(uint32_t reason);
+
+    void createFrame();
+    void cleanupBuffers();
+
+    uint32_t preferredFormat();
+
+  private:
+    Display* display;
+    std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb;
+    ext_image_copy_capture_session_v1* session;
+    ext_image_copy_capture_frame_v1* frame;
+    Shm* shm;
+    ShmPool* pool;
+    wl_buffer* buffer;
+    bool firstCapture;
+    uint32_t width;
+    uint32_t height;
+    uint32_t format;
+    std::function<void()> stoppedCb;
+    std::vector<uint32_t> formatsPending;
+    std::vector<uint32_t> formats;
+    core::Region damage;
+    static const ext_image_copy_capture_session_v1_listener listener;
+    static const ext_image_copy_capture_frame_v1_listener frameListener;
+  };
+
+};
+
+#endif // __WAYLAND_IMAGE_COPY_CAPTURE_SESSION_H__

--- a/unix/w0vncserver/wayland/objects/Output.cxx
+++ b/unix/w0vncserver/wayland/objects/Output.cxx
@@ -63,7 +63,7 @@ static core::LogWriter vlog("WOutput");
 
 Output::Output(Display* display)
   : Object(display, "wl_output", &wl_output_interface), output(nullptr),
-    mode({0, 0, 0, 0})
+    mode({0, 0, 0, 0}), geometry({0, 0, 0, 0, 0, "", "", 0})
 {
   output = (wl_output*) boundObject;
 
@@ -76,17 +76,22 @@ Output::~Output()
   wl_output_destroy(output);
 }
 
-void Output::handleGeometry(int32_t /* x */, int32_t /* y */,
-                            int32_t /* physical_width */,
-                            int32_t /* physical_height */,
-                            int32_t /* subpixel */,
-                            const char* /* make */,
-                            const char*  /* model */,
-                            int32_t /* transform */)
+void Output::handleGeometry(int32_t x, int32_t y,
+                            int32_t physical_width,
+                            int32_t physical_height,
+                            int32_t subpixel, const char* make,
+                            const char* model, int32_t transform)
 {
-  // FIXME: This gives us the position/size etc. of the output
-  // (presumably a screen). Keep track of this when we want to
-  // handle multiple monitors.
+  geometry = {
+    .x = x,
+    .y = y,
+    .physical_width = physical_width,
+    .physical_height = physical_height,
+    .subpixel = subpixel,
+    .make = make,
+    .model = model,
+    .transform = transform
+  };
 }
 
 void Output::handleMode(uint32_t flags, int32_t width, int32_t height,

--- a/unix/w0vncserver/wayland/objects/Output.h
+++ b/unix/w0vncserver/wayland/objects/Output.h
@@ -36,6 +36,17 @@ namespace wayland {
     int32_t refresh;
   };
 
+  struct Geometry {
+    int32_t x;
+    int32_t y;
+    int32_t physical_width;
+    int32_t physical_height;
+    int32_t subpixel;
+    std::string make;
+    std::string model;
+    int32_t transform;
+  };
+
   class Output : public Object {
   public:
     Output(Display* display);
@@ -44,6 +55,7 @@ namespace wayland {
     wl_output* getOutput() const { return output; }
     uint32_t getWidth() const { return mode.width; }
     uint32_t getHeight() const { return mode.height; }
+    int32_t getTransform() const { return geometry.transform; }
 
   private:
     void handleGeometry(int32_t x, int32_t y, int32_t physical_width,
@@ -60,6 +72,7 @@ namespace wayland {
   private:
     wl_output* output;
     Mode mode;
+    Geometry geometry;
     std::string name;
     std::string description;
     static const wl_output_listener listener;

--- a/unix/w0vncserver/wayland/objects/Pointer.cxx
+++ b/unix/w0vncserver/wayland/objects/Pointer.cxx
@@ -1,0 +1,37 @@
+/* Copyright 2026 Adam Halim for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#include <wayland-client-protocol.h>
+
+#include "Pointer.h"
+#include "Seat.h"
+#include "Display.h"
+
+using namespace wayland;
+
+Pointer::Pointer(Display* /* display */, Seat* seat)
+{
+  // FIXME: Implement this class properly
+  pointer = wl_seat_get_pointer(seat->getSeat());
+}
+
+Pointer::~Pointer()
+{
+  if (pointer)
+    wl_pointer_destroy(pointer);
+}

--- a/unix/w0vncserver/wayland/objects/Pointer.h
+++ b/unix/w0vncserver/wayland/objects/Pointer.h
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 Adam Halim for Cendio AB
+/* Copyright 2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,41 +16,25 @@
  * USA.
  */
 
-#ifndef __WAYLAND_SEAT_H__
-#define __WAYLAND_SEAT_H__
+#ifndef __WAYLAND_POINTER_H__
+#define __WAYLAND_POINTER_H__
 
-#include <functional>
-
-#include "Object.h"
-
-struct wl_seat;
-struct wl_seat_listener;
+struct wl_pointer;
 
 namespace wayland {
   class Display;
-  class Keyboard;
-  class Pointer;
+  class Seat;
 
-  class Seat : public Object {
+  class Pointer  {
   public:
-    Seat(Display* display, std::function<void(unsigned int)> setLEDstate);
-    ~Seat();
+    Pointer(Display* display, Seat* seat);
+    ~Pointer();
 
-    wl_seat* getSeat() const { return seat; }
-    Keyboard* getKeyboard() const { return keyboard; }
-    Pointer* getPointer() const { return pointer; }
+    wl_pointer* getPointer() const { return pointer; }
 
   private:
-    void seatCapabilities(uint32_t capabilities);
-
-  private:
-    wl_seat* seat;
-    Display* display;
-    Keyboard* keyboard;
-    Pointer* pointer;
-    static const wl_seat_listener listener;
-    std::function<void(unsigned int)> setLEDstate;
+    wl_pointer* pointer;
   };
-};
+}
 
-#endif // __WAYLAND_SEAT_H__
+#endif // __WAYLAND_POINTER_H__

--- a/unix/w0vncserver/wayland/objects/ScreencopyManager.cxx
+++ b/unix/w0vncserver/wayland/objects/ScreencopyManager.cxx
@@ -1,4 +1,4 @@
-/* Copyright 2025 Adam Halim for Cendio AB
+/* Copyright 2025-2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -86,7 +86,7 @@ struct BufferInfo {
 ScreencopyManager::ScreencopyManager(Display* display, Output* output_,
                                      std::function<void(uint8_t*,
                                                         core::Region,
-                                                        rfb::PixelFormat)>
+                                                        uint32_t)>
                                                           bufferEventCb_,
                                      std::function<void()> stoppedCb_)
  : Object(display, "zwlr_screencopy_manager_v1",
@@ -156,7 +156,7 @@ void ScreencopyManager::captureFrameDone()
   zwlr_screencopy_frame_v1_destroy(frame);
   frame = nullptr;
 
-  bufferEventCb(getBufferData(), accumulatedDamage, pf);
+  bufferEventCb(getBufferData(), accumulatedDamage, info->format);
 
   captureFrame();
 }
@@ -207,27 +207,6 @@ void ScreencopyManager::initBuffers(size_t size)
   close(fd);
 }
 
-rfb::PixelFormat ScreencopyManager::convertPixelformat(uint32_t format)
-{
-  switch (format) {
-    case WL_SHM_FORMAT_XRGB8888:
-    case WL_SHM_FORMAT_ARGB8888:
-      return rfb::PixelFormat(32, 24, false, true, 255, 255, 255,
-                              16, 8, 0);
-    case WL_SHM_FORMAT_RGBX8888:
-    case WL_SHM_FORMAT_RGBA8888:
-      return rfb::PixelFormat(32, 24, false, true, 255, 255, 255,
-                              24, 16, 8);
-    case WL_SHM_FORMAT_XBGR8888:
-    case WL_SHM_FORMAT_ABGR8888:
-      return rfb::PixelFormat(32, 24, false, true, 255, 255, 255,
-                              0, 8, 16);
-    default:
-      throw std::runtime_error(core::format("format %d not supported",
-                                            format));
-  }
-}
-
 void ScreencopyManager::handleScreencopyBuffer(uint32_t format,
                                                uint32_t width,
                                                uint32_t height,
@@ -249,12 +228,6 @@ void ScreencopyManager::handleScreencopyBuffer(uint32_t format,
     .stride = stride
   };
 
-  try {
-    pf = convertPixelformat(info->format);
-  } catch (const std::exception& e) {
-    vlog.error("Failed to convert pixelformat: %s", e.what());
-    stopped();
-  }
 }
 
 void ScreencopyManager::handleScreencopyFlags(uint32_t /* flags */)

--- a/unix/w0vncserver/wayland/objects/ScreencopyManager.cxx
+++ b/unix/w0vncserver/wayland/objects/ScreencopyManager.cxx
@@ -86,7 +86,7 @@ struct BufferInfo {
 ScreencopyManager::ScreencopyManager(Display* display, Output* output_,
                                      std::function<void(uint8_t*,
                                                         core::Region,
-                                                        uint32_t)>
+                                                        uint32_t, uint32_t)>
                                                           bufferEventCb_,
                                      std::function<void()> stoppedCb_)
  : Object(display, "zwlr_screencopy_manager_v1",
@@ -156,7 +156,8 @@ void ScreencopyManager::captureFrameDone()
   zwlr_screencopy_frame_v1_destroy(frame);
   frame = nullptr;
 
-  bufferEventCb(getBufferData(), accumulatedDamage, info->format);
+  bufferEventCb(getBufferData(), accumulatedDamage, info->format,
+                output->getTransform());
 
   captureFrame();
 }

--- a/unix/w0vncserver/wayland/objects/ScreencopyManager.h
+++ b/unix/w0vncserver/wayland/objects/ScreencopyManager.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Adam Halim for Cendio AB
+/* Copyright 2025-2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@ namespace wayland {
   class ScreencopyManager : public Object {
   public:
     ScreencopyManager(Display* display, Output* output,
-                      std::function<void(uint8_t*, core::Region, rfb::PixelFormat)> readyCallback,
+                      std::function<void(uint8_t*, core::Region, uint32_t)> readyCallback,
                       std::function<void()> stoppedCb);
     virtual ~ScreencopyManager();
 
@@ -66,7 +66,6 @@ namespace wayland {
 
   private:
     void initBuffers(size_t size);
-    rfb::PixelFormat convertPixelformat(uint32_t format);
 
     // zwlr_screencopy_frame_v1_listener handlers
     void handleScreencopyBuffer(uint32_t format, uint32_t width, uint32_t height,
@@ -93,7 +92,7 @@ namespace wayland {
     wl_buffer* buffer;
     core::Region accumulatedDamage;
     rfb::PixelFormat pf;
-    std::function<void(uint8_t*, core::Region, rfb::PixelFormat)> bufferEventCb;
+    std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb;
     std::function<void()> stoppedCb;
     static const zwlr_screencopy_frame_v1_listener listener;
   };

--- a/unix/w0vncserver/wayland/objects/ScreencopyManager.h
+++ b/unix/w0vncserver/wayland/objects/ScreencopyManager.h
@@ -44,7 +44,7 @@ namespace wayland {
   class ScreencopyManager : public Object {
   public:
     ScreencopyManager(Display* display, Output* output,
-                      std::function<void(uint8_t*, core::Region, uint32_t)> readyCallback,
+                      std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)> readyCallback,
                       std::function<void()> stoppedCb);
     virtual ~ScreencopyManager();
 
@@ -92,7 +92,7 @@ namespace wayland {
     wl_buffer* buffer;
     core::Region accumulatedDamage;
     rfb::PixelFormat pf;
-    std::function<void(uint8_t*, core::Region, uint32_t)> bufferEventCb;
+    std::function<void(uint8_t*, core::Region, uint32_t, uint32_t)> bufferEventCb;
     std::function<void()> stoppedCb;
     static const zwlr_screencopy_frame_v1_listener listener;
   };

--- a/unix/w0vncserver/wayland/objects/Seat.cxx
+++ b/unix/w0vncserver/wayland/objects/Seat.cxx
@@ -1,4 +1,4 @@
-/* Copyright 2025 Adam Halim for Cendio AB
+/* Copyright 2025-2026 Adam Halim for Cendio AB
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,6 +25,7 @@
 
 #include "Display.h"
 #include "Keyboard.h"
+#include "Pointer.h"
 #include "Seat.h"
 
 using namespace wayland;
@@ -42,7 +43,7 @@ const wl_seat_listener Seat::listener = {
 Seat::Seat(Display* display_, std::function<void(unsigned int)> setLEDstate_)
   : Object(display_, "wl_seat", &wl_seat_interface),
     seat(nullptr), display(display_), keyboard(nullptr),
-    setLEDstate(setLEDstate_)
+    pointer(nullptr), setLEDstate(setLEDstate_)
 {
   seat = (wl_seat*)boundObject;
 
@@ -56,6 +57,7 @@ Seat::~Seat()
     wl_seat_destroy(seat);
 
   delete keyboard;
+  delete pointer;
 }
 
 void Seat::seatCapabilities(uint32_t capabilities)
@@ -64,5 +66,10 @@ void Seat::seatCapabilities(uint32_t capabilities)
     vlog.debug("Keyboard detected");
     delete keyboard;
     keyboard = new Keyboard(display, this, setLEDstate);
+  }
+
+  if (capabilities & WL_SEAT_CAPABILITY_POINTER) {
+      delete pointer;
+      pointer = new Pointer(display, this);
   }
 }

--- a/unix/w0vncserver/wayland/protocols/ext-foreign-toplevel-list-v1.xml
+++ b/unix/w0vncserver/wayland/protocols/ext-foreign-toplevel-list-v1.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_foreign_toplevel_list_v1">
+  <copyright>
+    Copyright © 2018 Ilia Bozhinov
+    Copyright © 2020 Isaac Freund
+    Copyright © 2022 wb9688
+    Copyright © 2023 i509VCB
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="list toplevels">
+    The purpose of this protocol is to provide protocol object handles for
+    toplevels, possibly originating from another client.
+
+    This protocol is intentionally minimalistic and expects additional
+    functionality (e.g. creating a screencopy source from a toplevel handle,
+    getting information about the state of the toplevel) to be implemented
+    in extension protocols.
+
+    The compositor may choose to restrict this protocol to a special client
+    launched by the compositor itself or expose it to all clients,
+    this is compositor policy.
+
+    The key words "must", "must not", "required", "shall", "shall not",
+    "should", "should not", "recommended",  "may", and "optional" in this
+    document are to be interpreted as described in IETF RFC 2119.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_foreign_toplevel_list_v1" version="1">
+    <description summary="list toplevels">
+      A toplevel is defined as a surface with a role similar to xdg_toplevel.
+      XWayland surfaces may be treated like toplevels in this protocol.
+
+      After a client binds the ext_foreign_toplevel_list_v1, each mapped
+      toplevel window will be sent using the ext_foreign_toplevel_list_v1.toplevel
+      event.
+
+      Clients which only care about the current state can perform a roundtrip after
+      binding this global.
+
+      For each instance of ext_foreign_toplevel_list_v1, the compositor must
+      create a new ext_foreign_toplevel_handle_v1 object for each mapped toplevel.
+
+      If a compositor implementation sends the ext_foreign_toplevel_list_v1.finished
+      event after the global is bound, the compositor must not send any
+      ext_foreign_toplevel_list_v1.toplevel events.
+    </description>
+
+    <event name="toplevel">
+      <description summary="a toplevel has been created">
+        This event is emitted whenever a new toplevel window is created. It is
+        emitted for all toplevels, regardless of the app that has created them.
+
+        All initial properties of the toplevel (identifier, title, app_id) will be sent
+        immediately after this event using the corresponding events for
+        ext_foreign_toplevel_handle_v1. The compositor will use the
+        ext_foreign_toplevel_handle_v1.done event to indicate when all data has
+        been sent.
+      </description>
+      <arg name="toplevel" type="new_id" interface="ext_foreign_toplevel_handle_v1"/>
+    </event>
+
+    <event name="finished">
+      <description summary="the compositor has finished with the toplevel manager">
+        This event indicates that the compositor is done sending events
+        to this object. The client should destroy the object.
+        See ext_foreign_toplevel_list_v1.destroy for more information.
+
+        The compositor must not send any more toplevel events after this event.
+      </description>
+    </event>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        This request indicates that the client no longer wishes to receive
+        events for new toplevels.
+
+        The Wayland protocol is asynchronous, meaning the compositor may send
+        further toplevel events until the stop request is processed.
+        The client should wait for a ext_foreign_toplevel_list_v1.finished
+        event before destroying this object.
+      </description>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ext_foreign_toplevel_list_v1 object">
+        This request should be called either when the client will no longer
+        use the ext_foreign_toplevel_list_v1 or after the finished event
+        has been received to allow destruction of the object.
+
+        If a client wishes to destroy this object it should send a
+        ext_foreign_toplevel_list_v1.stop request and wait for a ext_foreign_toplevel_list_v1.finished
+        event, then destroy the handles and then this object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_foreign_toplevel_handle_v1" version="1">
+    <description summary="a mapped toplevel">
+      A ext_foreign_toplevel_handle_v1 object represents a mapped toplevel
+      window. A single app may have multiple mapped toplevels.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ext_foreign_toplevel_handle_v1 object">
+        This request should be used when the client will no longer use the handle
+        or after the closed event has been received to allow destruction of the
+        object.
+
+        When a handle is destroyed, a new handle may not be created by the server
+        until the toplevel is unmapped and then remapped. Destroying a toplevel handle
+        is not recommended unless the client is cleaning up child objects
+        before destroying the ext_foreign_toplevel_list_v1 object, the toplevel
+        was closed or the toplevel handle will not be used in the future.
+
+        Other protocols which extend the ext_foreign_toplevel_handle_v1
+        interface should require destructors for extension interfaces be
+        called before allowing the toplevel handle to be destroyed.
+      </description>
+    </request>
+
+    <event name="closed">
+      <description summary="the toplevel has been closed">
+        The server will emit no further events on the ext_foreign_toplevel_handle_v1
+        after this event. Any requests received aside from the destroy request must
+        be ignored. Upon receiving this event, the client should destroy the handle.
+
+        Other protocols which extend the ext_foreign_toplevel_handle_v1
+        interface must also ignore requests other than destructors.
+      </description>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the toplevel has been sent">
+        This event is sent after all changes in the toplevel state have
+        been sent.
+
+        This allows changes to the ext_foreign_toplevel_handle_v1 properties
+        to be atomically applied. Other protocols which extend the
+        ext_foreign_toplevel_handle_v1 interface may use this event to also
+        atomically apply any pending state.
+
+        This event must not be sent after the ext_foreign_toplevel_handle_v1.closed
+        event.
+      </description>
+    </event>
+
+    <event name="title">
+      <description summary="title change">
+        The title of the toplevel has changed.
+
+        The configured state must not be applied immediately. See
+        ext_foreign_toplevel_handle_v1.done for details.
+      </description>
+      <arg name="title" type="string"/>
+    </event>
+
+    <event name="app_id">
+      <description summary="app_id change">
+        The app id of the toplevel has changed.
+
+        The configured state must not be applied immediately. See
+        ext_foreign_toplevel_handle_v1.done for details.
+      </description>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="identifier">
+      <description summary="a stable identifier for a toplevel">
+        This identifier is used to check if two or more toplevel handles belong
+        to the same toplevel.
+
+        The identifier is useful for command line tools or privileged clients
+        which may need to reference an exact toplevel across processes or
+        instances of the ext_foreign_toplevel_list_v1 global.
+
+        The compositor must only send this event when the handle is created.
+
+        The identifier must be unique per toplevel and it's handles. Two different
+        toplevels must not have the same identifier. The identifier is only valid
+        as long as the toplevel is mapped. If the toplevel is unmapped the identifier
+        must not be reused. An identifier must not be reused by the compositor to
+        ensure there are no races when sharing identifiers between processes.
+
+        An identifier is a string that contains up to 32 printable ASCII bytes.
+        An identifier must not be an empty string. It is recommended that a
+        compositor includes an opaque generation value in identifiers. How the
+        generation value is used when generating the identifier is implementation
+        dependent.
+      </description>
+      <arg name="identifier" type="string"/>
+    </event>
+  </interface>
+</protocol>

--- a/unix/w0vncserver/wayland/protocols/ext-image-capture-source-v1.xml
+++ b/unix/w0vncserver/wayland/protocols/ext-image-capture-source-v1.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_image_capture_source_v1">
+  <copyright>
+    Copyright © 2022 Andri Yngvason
+    Copyright © 2024 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="opaque image capture source objects">
+    This protocol serves as an intermediary between capturing protocols and
+    potential image capture sources such as outputs and toplevels.
+
+    This protocol may be extended to support more image capture sources in the
+    future, thereby adding those image capture sources to other protocols that
+    use the image capture source object without having to modify those
+    protocols.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_image_capture_source_v1" version="1">
+    <description summary="opaque image capture source object">
+      The image capture source object is an opaque descriptor for a capturable
+      resource.  This resource may be any sort of entity from which an image
+      may be derived.
+
+      Note, because ext_image_capture_source_v1 objects are created from multiple
+      independent factory interfaces, the ext_image_capture_source_v1 interface is
+      frozen at version 1.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the image capture source. This request may be sent at any time
+        by the client.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_output_image_capture_source_manager_v1" version="1">
+    <description summary="image capture source manager for outputs">
+      A manager for creating image capture source objects for wl_output objects.
+    </description>
+
+    <request name="create_source">
+      <description summary="create source object for output">
+        Creates a source object for an output. Images captured from this source
+        will show the same content as the output. Some elements may be omitted,
+        such as cursors and overlays that have been marked as transparent to
+        capturing.
+      </description>
+      <arg name="source" type="new_id" interface="ext_image_capture_source_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the manager. This request may be sent at any time by the client
+        and objects created by the manager will remain valid after its
+        destruction.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_foreign_toplevel_image_capture_source_manager_v1" version="1">
+    <description summary="image capture source manager for foreign toplevels">
+      A manager for creating image capture source objects for
+      ext_foreign_toplevel_handle_v1 objects.
+    </description>
+
+    <request name="create_source">
+      <description summary="create source object for foreign toplevel">
+        Creates a source object for a foreign toplevel handle. Images captured
+        from this source will show the same content as the toplevel.
+      </description>
+      <arg name="source" type="new_id" interface="ext_image_capture_source_v1"/>
+      <arg name="toplevel_handle" type="object" interface="ext_foreign_toplevel_handle_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the manager. This request may be sent at any time by the client
+        and objects created by the manager will remain valid after its
+        destruction.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/unix/w0vncserver/wayland/protocols/ext-image-copy-capture-v1.xml
+++ b/unix/w0vncserver/wayland/protocols/ext-image-copy-capture-v1.xml
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_image_copy_capture_v1">
+  <copyright>
+    Copyright © 2021-2023 Andri Yngvason
+    Copyright © 2024 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="image capturing into client buffers">
+    This protocol allows clients to ask the compositor to capture image sources
+    such as outputs and toplevels into user submitted buffers.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_image_copy_capture_manager_v1" version="1">
+    <description summary="manager to inform clients and begin capturing">
+      This object is a manager which offers requests to start capturing from a
+      source.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_option" value="1" summary="invalid option flag"/>
+    </enum>
+
+    <enum name="options" bitfield="true">
+      <entry name="paint_cursors" value="1" summary="paint cursors onto captured frames"/>
+    </enum>
+
+    <request name="create_session">
+      <description summary="capture an image capture source">
+        Create a capturing session for an image capture source.
+
+        If the paint_cursors option is set, cursors shall be composited onto
+        the captured frame. The cursor must not be composited onto the frame
+        if this flag is not set.
+
+        If the options bitfield is invalid, the invalid_option protocol error
+        is sent.
+      </description>
+      <arg name="session" type="new_id" interface="ext_image_copy_capture_session_v1"/>
+      <arg name="source" type="object" interface="ext_image_capture_source_v1"/>
+      <arg name="options" type="uint" enum="options"/>
+    </request>
+
+    <request name="create_pointer_cursor_session">
+      <description summary="capture the pointer cursor of an image capture source">
+        Create a cursor capturing session for the pointer of an image capture
+        source.
+      </description>
+      <arg name="session" type="new_id" interface="ext_image_copy_capture_cursor_session_v1"/>
+      <arg name="source" type="object" interface="ext_image_capture_source_v1"/>
+      <arg name="pointer" type="object" interface="wl_pointer"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object.
+
+        Other objects created via this interface are unaffected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_image_copy_capture_session_v1" version="1">
+    <description summary="image copy capture session">
+      This object represents an active image copy capture session.
+
+      After a capture session is created, buffer constraint events will be
+      emitted from the compositor to tell the client which buffer types and
+      formats are supported for reading from the session. The compositor may
+      re-send buffer constraint events whenever they change.
+
+      To advertise buffer constraints, the compositor must send in no
+      particular order: zero or more shm_format and dmabuf_format events, zero
+      or one dmabuf_device event, and exactly one buffer_size event. Then the
+      compositor must send a done event.
+
+      When the client has received all the buffer constraints, it can create a
+      buffer accordingly, attach it to the capture session using the
+      attach_buffer request, set the buffer damage using the damage_buffer
+      request and then send the capture request.
+    </description>
+
+    <enum name="error">
+      <entry name="duplicate_frame" value="1"
+        summary="create_frame sent before destroying previous frame"/>
+    </enum>
+
+    <event name="buffer_size">
+      <description summary="image capture source dimensions">
+        Provides the dimensions of the source image in buffer pixel coordinates.
+
+        The client must attach buffers that match this size.
+      </description>
+      <arg name="width" type="uint" summary="buffer width"/>
+      <arg name="height" type="uint" summary="buffer height"/>
+    </event>
+
+    <event name="shm_format">
+      <description summary="shm buffer format">
+        Provides the format that must be used for shared-memory buffers.
+
+        This event may be emitted multiple times, in which case the client may
+        choose any given format.
+      </description>
+      <arg name="format" type="uint" enum="wl_shm.format" summary="shm format"/>
+    </event>
+
+    <event name="dmabuf_device">
+      <description summary="dma-buf device">
+        This event advertises the device buffers must be allocated on for
+        dma-buf buffers.
+
+        In general the device is a DRM node. The DRM node type (primary vs.
+        render) is unspecified. Clients must not rely on the compositor sending
+        a particular node type. Clients cannot check two devices for equality
+        by comparing the dev_t value.
+      </description>
+      <arg name="device" type="array" summary="device dev_t value"/>
+    </event>
+
+    <event name="dmabuf_format">
+      <description summary="dma-buf format">
+        Provides the format that must be used for dma-buf buffers.
+
+        The client may choose any of the modifiers advertised in the array of
+        64-bit unsigned integers.
+
+        This event may be emitted multiple times, in which case the client may
+        choose any given format.
+      </description>
+      <arg name="format" type="uint" summary="drm format code"/>
+      <arg name="modifiers" type="array" summary="drm format modifiers"/>
+    </event>
+
+    <event name="done">
+      <description summary="all constraints have been sent">
+        This event is sent once when all buffer constraint events have been
+        sent.
+
+        The compositor must always end a batch of buffer constraint events with
+        this event, regardless of whether it sends the initial constraints or
+        an update.
+      </description>
+    </event>
+
+    <event name="stopped">
+      <description summary="session is no longer available">
+        This event indicates that the capture session has stopped and is no
+        longer available. This can happen in a number of cases, e.g. when the
+        underlying source is destroyed, if the user decides to end the image
+        capture, or if an unrecoverable runtime error has occurred.
+
+        The client should destroy the session after receiving this event.
+      </description>
+    </event>
+
+    <request name="create_frame">
+      <description summary="create a frame">
+        Create a capture frame for this session.
+
+        At most one frame object can exist for a given session at any time. If
+        a client sends a create_frame request before a previous frame object
+        has been destroyed, the duplicate_frame protocol error is raised.
+      </description>
+      <arg name="frame" type="new_id" interface="ext_image_copy_capture_frame_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the session. This request can be sent at any time by the
+        client.
+
+        This request doesn't affect ext_image_copy_capture_frame_v1 objects created by
+        this object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_image_copy_capture_frame_v1" version="1">
+    <description summary="image capture frame">
+      This object represents an image capture frame.
+
+      The client should attach a buffer, damage the buffer, and then send a
+      capture request.
+
+      If the capture is successful, the compositor must send the frame metadata
+      (transform, damage, presentation_time in any order) followed by the ready
+      event.
+
+      If the capture fails, the compositor must send the failed event.
+    </description>
+
+    <enum name="error">
+      <entry name="no_buffer" value="1" summary="capture sent without attach_buffer"/>
+      <entry name="invalid_buffer_damage" value="2" summary="invalid buffer damage"/>
+      <entry name="already_captured" value="3" summary="capture request has been sent"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this object">
+        Destroys the frame. This request can be sent at any time by the
+        client.
+      </description>
+    </request>
+
+    <request name="attach_buffer">
+      <description summary="attach buffer to session">
+        Attach a buffer to the session.
+
+        The wl_buffer.release request is unused.
+
+        The new buffer replaces any previously attached buffer.
+
+        This request must not be sent after capture, or else the
+        already_captured protocol error is raised.
+      </description>
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+    </request>
+
+    <request name="damage_buffer">
+      <description summary="damage buffer">
+        Apply damage to the buffer which is to be captured next. This request
+        may be sent multiple times to describe a region.
+
+        The client indicates the accumulated damage since this wl_buffer was
+        last captured. During capture, the compositor will update the buffer
+        with at least the union of the region passed by the client and the
+        region advertised by ext_image_copy_capture_frame_v1.damage.
+
+        When a wl_buffer is captured for the first time, or when the client
+        doesn't track damage, the client must damage the whole buffer.
+
+        This is for optimisation purposes. The compositor may use this
+        information to reduce copying.
+
+        These coordinates originate from the upper left corner of the buffer.
+
+        If x or y are strictly negative, or if width or height are negative or
+        zero, the invalid_buffer_damage protocol error is raised.
+
+        This request must not be sent after capture, or else the
+        already_captured protocol error is raised.
+      </description>
+      <arg name="x" type="int" summary="region x coordinate"/>
+      <arg name="y" type="int" summary="region y coordinate"/>
+      <arg name="width" type="int" summary="region width"/>
+      <arg name="height" type="int" summary="region height"/>
+    </request>
+
+    <request name="capture">
+      <description summary="capture a frame">
+        Capture a frame.
+
+        Unless this is the first successful captured frame performed in this
+        session, the compositor may wait an indefinite amount of time for the
+        source content to change before performing the copy.
+
+        This request may only be sent once, or else the already_captured
+        protocol error is raised. A buffer must be attached before this request
+        is sent, or else the no_buffer protocol error is raised.
+      </description>
+    </request>
+
+    <event name="transform">
+      <description summary="buffer transform">
+        This event is sent before the ready event and holds the transform that
+        the compositor has applied to the buffer contents.
+      </description>
+      <arg name="transform" type="uint" enum="wl_output.transform"/>
+    </event>
+
+    <event name="damage">
+      <description summary="buffer damaged region">
+        This event is sent before the ready event. It may be generated multiple
+        times to describe a region.
+
+        The first captured frame in a session will always carry full damage.
+        Subsequent frames' damaged regions describe which parts of the buffer
+        have changed since the last ready event.
+
+        These coordinates originate in the upper left corner of the buffer.
+      </description>
+      <arg name="x" type="int" summary="damage x coordinate"/>
+      <arg name="y" type="int" summary="damage y coordinate"/>
+      <arg name="width" type="int" summary="damage width"/>
+      <arg name="height" type="int" summary="damage height"/>
+    </event>
+
+    <event name="presentation_time">
+      <description summary="presentation time of the frame">
+        This event indicates the time at which the frame is presented to the
+        output in system monotonic time. This event is sent before the ready
+        event.
+
+        The timestamp is expressed as tv_sec_hi, tv_sec_lo, tv_nsec triples,
+        each component being an unsigned 32-bit value. Whole seconds are in
+        tv_sec which is a 64-bit value combined from tv_sec_hi and tv_sec_lo,
+        and the additional fractional part in tv_nsec as nanoseconds. Hence,
+        for valid timestamps tv_nsec must be in [0, 999999999].
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <event name="ready">
+      <description summary="frame is available for reading">
+        Called as soon as the frame is copied, indicating it is available
+        for reading.
+
+        The buffer may be re-used by the client after this event.
+
+        After receiving this event, the client must destroy the object.
+      </description>
+    </event>
+
+    <enum name="failure_reason">
+      <entry name="unknown" value="0">
+        <description summary="unknown runtime error">
+          An unspecified runtime error has occurred. The client may retry.
+        </description>
+      </entry>
+      <entry name="buffer_constraints" value="1">
+        <description summary="buffer constraints mismatch">
+          The buffer submitted by the client doesn't match the latest session
+          constraints. The client should re-allocate its buffers and retry.
+        </description>
+      </entry>
+      <entry name="stopped" value="2">
+        <description summary="session is no longer available">
+          The session has stopped. See ext_image_copy_capture_session_v1.stopped.
+        </description>
+      </entry>
+    </enum>
+
+    <event name="failed">
+      <description summary="capture failed">
+        This event indicates that the attempted frame copy has failed.
+
+        After receiving this event, the client must destroy the object.
+      </description>
+      <arg name="reason" type="uint" enum="failure_reason"/>
+    </event>
+  </interface>
+
+  <interface name="ext_image_copy_capture_cursor_session_v1" version="1">
+    <description summary="cursor capture session">
+      This object represents a cursor capture session. It extends the base
+      capture session with cursor-specific metadata.
+    </description>
+
+    <enum name="error">
+      <entry name="duplicate_session" value="1" summary="get_capture_session sent twice"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the session. This request can be sent at any time by the
+        client.
+
+        This request doesn't affect ext_image_copy_capture_frame_v1 objects created by
+        this object.
+      </description>
+    </request>
+
+    <request name="get_capture_session">
+      <description summary="get image copy capturer session">
+        Gets the image copy capture session for this cursor session.
+
+        The session will produce frames of the cursor image. The compositor may
+        pause the session when the cursor leaves the captured area.
+
+        This request must not be sent more than once, or else the
+        duplicate_session protocol error is raised.
+      </description>
+      <arg name="session" type="new_id" interface="ext_image_copy_capture_session_v1"/>
+    </request>
+
+    <event name="enter">
+      <description summary="cursor entered captured area">
+        Sent when a cursor enters the captured area. It shall be generated
+        before the "position" and "hotspot" events when and only when a cursor
+        enters the area.
+
+        The cursor enters the captured area when the cursor image intersects
+        with the captured area. Note, this is different from e.g.
+        wl_pointer.enter.
+      </description>
+    </event>
+
+    <event name="leave">
+      <description summary="cursor left captured area">
+        Sent when a cursor leaves the captured area. No "position" or "hotspot"
+        event is generated for the cursor until the cursor enters the captured
+        area again.
+      </description>
+    </event>
+
+    <event name="position">
+      <description summary="position changed">
+        Cursors outside the image capture source do not get captured and no
+        event will be generated for them.
+
+        The given position is the position of the cursor's hotspot and it is
+        relative to the main buffer's top left corner in transformed buffer
+        pixel coordinates. The coordinates may be negative or greater than the
+        main buffer size.
+      </description>
+      <arg name="x" type="int" summary="position x coordinates"/>
+      <arg name="y" type="int" summary="position y coordinates"/>
+    </event>
+
+    <event name="hotspot">
+      <description summary="hotspot changed">
+        The hotspot describes the offset between the cursor image and the
+        position of the input device.
+
+        The given coordinates are the hotspot's offset from the origin in
+        buffer coordinates.
+
+        Clients should not apply the hotspot immediately: the hotspot becomes
+        effective when the next ext_image_copy_capture_frame_v1.ready event is received.
+
+        Compositors may delay this event until the client captures a new frame.
+      </description>
+      <arg name="x" type="int" summary="hotspot x coordinates"/>
+      <arg name="y" type="int" summary="hotspot y coordinates"/>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
Adds Wayland screen capture support to w0vncserver using the ext-image-copy-capture-v1 protocol (the successor to the deprecated wlr-screencopy-unstable-v1). The latter remains as a fallback for compositors that do not support the new protocol yet.

Also adds support for local cursor capture.

Tested on Fedora43 with Labwc (xfce4 session).