### PR TITLE
fix: vncserver xinit invocation

### DIFF
--- a/unix/vncserver/vncserver.in
+++ b/unix/vncserver/vncserver.in
@@ -242,7 +242,10 @@ $ENV{XAUTHORITY} = $xauthorityFile;
 
 @cmd = ("xinit");
 
-push(@cmd, $Xsession, $session{'Exec'});
+push(@cmd, $Xsession);
+foreach my $word (split(/\s+/, $session{'Exec'})) {
+  push(@cmd, $word);
+}
 
 push(@cmd, '--');
 


### PR DESCRIPTION
**Issue Description:** For an xsession .desktop file containing:

```
[Desktop Entry]
Exec=/etc/X11/xinitrc jwm
```

the xinit invocation was (wrong):

    xinit /etc/X11/Xsession '/etc/X11/xinitrc jwm' -- ...

instead of (correct):

    xinit /etc/X11/Xsession /etc/X11/xinitrc jwm -- ...

according to the xinit manual page (with omissions):

```
SYNOPSIS
       xinit [[client] options ...] [ -- [server] [display] options ...]

       An alternate client and/or server may be specified on the command line.
       The  desired  client  program  and its arguments should be given as the
       first command line arguments to xinit.  To specify a particular  server
       command  line, append a double dash (--) to the xinit command line (af‐
       ter any client and arguments) followed by the desired server command.

       Both the client program name and the server  program  name  must  begin
       with  a  slash  (/) or a period (.).

X Version 11                      xinit 1.4.2                         XINIT(1)
```