### PR TITLE
Nettle4 compat

### DIFF
--- a/common/rdr/AESInStream.cxx
+++ b/common/rdr/AESInStream.cxx
@@ -27,6 +27,9 @@
 #include <rdr/AESInStream.h>
 
 #ifdef HAVE_NETTLE
+
+#include <nettle/version.h>
+
 using namespace rdr;
 
 AESInStream::AESInStream(InStream* _in, const uint8_t* key,
@@ -62,12 +65,20 @@ bool AESInStream::fillBuffer()
     EAX_SET_NONCE(&eaxCtx128, aes128_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx128, aes128_encrypt, 2, ad);
     EAX_DECRYPT(&eaxCtx128, aes128_encrypt, length, (uint8_t*)end, data);
+#if NETTLE_VERSION_MAJOR >= 4
+    EAX_DIGEST(&eaxCtx128, aes128_encrypt, macComputed);
+#else
     EAX_DIGEST(&eaxCtx128, aes128_encrypt, EAX_DIGEST_SIZE, macComputed);
+#endif
   } else {
     EAX_SET_NONCE(&eaxCtx256, aes256_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx256, aes256_encrypt, 2, ad);
     EAX_DECRYPT(&eaxCtx256, aes256_encrypt, length, (uint8_t*)end, data);
+#if NETTLE_VERSION_MAJOR >= 4
+    EAX_DIGEST(&eaxCtx256, aes256_encrypt, macComputed);
+#else
     EAX_DIGEST(&eaxCtx256, aes256_encrypt, EAX_DIGEST_SIZE, macComputed);
+#endif
   }
   if (memcmp(mac, macComputed, EAX_DIGEST_SIZE) != 0)
     throw std::runtime_error("AESInStream: Failed to authenticate message");

--- a/common/rdr/AESInStream.cxx
+++ b/common/rdr/AESInStream.cxx
@@ -49,29 +49,29 @@ bool AESInStream::fillBuffer()
     return false;
   const uint8_t* buf = in->getptr(2);
   size_t length = ((int)buf[0] << 8) | (int)buf[1];
-  if (!in->hasData(2 + length + 16))
+  if (!in->hasData(2 + length + EAX_DIGEST_SIZE))
     return false;
   ensureSpace(length);
-  buf = in->getptr(2 + length + 16);
+  buf = in->getptr(2 + length + EAX_DIGEST_SIZE);
   const uint8_t* ad = buf;
   const uint8_t* data = buf + 2;
   const uint8_t* mac = buf + 2 + length;
-  uint8_t macComputed[16];
+  uint8_t macComputed[EAX_DIGEST_SIZE];
 
   if (keySize == 128) {
     EAX_SET_NONCE(&eaxCtx128, aes128_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx128, aes128_encrypt, 2, ad);
     EAX_DECRYPT(&eaxCtx128, aes128_encrypt, length, (uint8_t*)end, data);
-    EAX_DIGEST(&eaxCtx128, aes128_encrypt, 16, macComputed);
+    EAX_DIGEST(&eaxCtx128, aes128_encrypt, EAX_DIGEST_SIZE, macComputed);
   } else {
     EAX_SET_NONCE(&eaxCtx256, aes256_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx256, aes256_encrypt, 2, ad);
     EAX_DECRYPT(&eaxCtx256, aes256_encrypt, length, (uint8_t*)end, data);
-    EAX_DIGEST(&eaxCtx256, aes256_encrypt, 16, macComputed);
+    EAX_DIGEST(&eaxCtx256, aes256_encrypt, EAX_DIGEST_SIZE, macComputed);
   }
-  if (memcmp(mac, macComputed, 16) != 0)
+  if (memcmp(mac, macComputed, EAX_DIGEST_SIZE) != 0)
     throw std::runtime_error("AESInStream: Failed to authenticate message");
-  in->setptr(2 + length + 16);
+  in->setptr(2 + length + EAX_DIGEST_SIZE);
   end += length;
 
   // Update nonce by incrementing the counter as a

--- a/common/rdr/AESOutStream.cxx
+++ b/common/rdr/AESOutStream.cxx
@@ -83,14 +83,14 @@ void AESOutStream::writeMessage(const uint8_t* data, size_t length)
     EAX_SET_NONCE(&eaxCtx128, aes128_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx128, aes128_encrypt, 2, msg);
     EAX_ENCRYPT(&eaxCtx128, aes128_encrypt, length, msg + 2, data);
-    EAX_DIGEST(&eaxCtx128, aes128_encrypt, 16, msg + 2 + length);
+    EAX_DIGEST(&eaxCtx128, aes128_encrypt, EAX_DIGEST_SIZE, msg + 2 + length);
   } else {
     EAX_SET_NONCE(&eaxCtx256, aes256_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx256, aes256_encrypt, 2, msg);
     EAX_ENCRYPT(&eaxCtx256, aes256_encrypt, length, msg + 2, data);
-    EAX_DIGEST(&eaxCtx256, aes256_encrypt, 16, msg + 2 + length);
+    EAX_DIGEST(&eaxCtx256, aes256_encrypt, EAX_DIGEST_SIZE, msg + 2 + length);
   }
-  out->writeBytes(msg, 2 + length + 16);
+  out->writeBytes(msg, 2 + length + EAX_DIGEST_SIZE);
   out->flush();
 
   // Update nonce by incrementing the counter as a

--- a/common/rdr/AESOutStream.cxx
+++ b/common/rdr/AESOutStream.cxx
@@ -27,6 +27,9 @@
 #include <rdr/AESOutStream.h>
 
 #ifdef HAVE_NETTLE
+
+#include <nettle/version.h>
+
 using namespace rdr;
 
 const int MaxMessageSize = 8192;
@@ -83,12 +86,20 @@ void AESOutStream::writeMessage(const uint8_t* data, size_t length)
     EAX_SET_NONCE(&eaxCtx128, aes128_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx128, aes128_encrypt, 2, msg);
     EAX_ENCRYPT(&eaxCtx128, aes128_encrypt, length, msg + 2, data);
+#if NETTLE_VERSION_MAJOR >= 4
+    EAX_DIGEST(&eaxCtx128, aes128_encrypt, msg + 2 + length);
+#else
     EAX_DIGEST(&eaxCtx128, aes128_encrypt, EAX_DIGEST_SIZE, msg + 2 + length);
+#endif
   } else {
     EAX_SET_NONCE(&eaxCtx256, aes256_encrypt, 16, counter);
     EAX_UPDATE(&eaxCtx256, aes256_encrypt, 2, msg);
     EAX_ENCRYPT(&eaxCtx256, aes256_encrypt, length, msg + 2, data);
+#if NETTLE_VERSION_MAJOR >= 4
+    EAX_DIGEST(&eaxCtx256, aes256_encrypt, msg + 2 + length);
+#else
     EAX_DIGEST(&eaxCtx256, aes256_encrypt, EAX_DIGEST_SIZE, msg + 2 + length);
+#endif
   }
   out->writeBytes(msg, 2 + length + EAX_DIGEST_SIZE);
   out->flush();

--- a/common/rfb/CSecurityDH.cxx
+++ b/common/rfb/CSecurityDH.cxx
@@ -121,11 +121,11 @@ void CSecurityDH::writeCredentials()
   std::vector<uint8_t> BBytes(keyLength);
   nettle_mpz_get_str_256(sharedSecret.size(), sharedSecret.data(), k);
   nettle_mpz_get_str_256(BBytes.size(), BBytes.data(), B);
-  uint8_t key[16];
+  uint8_t key[MD5_DIGEST_SIZE];
   struct md5_ctx md5Ctx;
   md5_init(&md5Ctx);
   md5_update(&md5Ctx, sharedSecret.size(), sharedSecret.data());
-  md5_digest(&md5Ctx, 16, key);
+  md5_digest(&md5Ctx, MD5_DIGEST_SIZE, key);
   struct aes128_ctx aesCtx;
   aes128_set_encrypt_key(&aesCtx, key);
 

--- a/common/rfb/CSecurityDH.cxx
+++ b/common/rfb/CSecurityDH.cxx
@@ -34,6 +34,7 @@
 #include <nettle/aes.h>
 #include <nettle/md5.h>
 #include <nettle/bignum.h>
+#include <nettle/version.h>
 #include <rfb/CSecurityDH.h>
 #include <rfb/CConnection.h>
 #include <rdr/InStream.h>
@@ -125,7 +126,11 @@ void CSecurityDH::writeCredentials()
   struct md5_ctx md5Ctx;
   md5_init(&md5Ctx);
   md5_update(&md5Ctx, sharedSecret.size(), sharedSecret.data());
+#if NETTLE_VERSION_MAJOR >= 4
+  md5_digest(&md5Ctx, key);
+#else
   md5_digest(&md5Ctx, MD5_DIGEST_SIZE, key);
+#endif
   struct aes128_ctx aesCtx;
   aes128_set_encrypt_key(&aesCtx, key);
 

--- a/common/rfb/CSecurityRSAAES.cxx
+++ b/common/rfb/CSecurityRSAAES.cxx
@@ -34,6 +34,7 @@
 #include <nettle/bignum.h>
 #include <nettle/sha1.h>
 #include <nettle/sha2.h>
+#include <nettle/version.h>
 
 #include <core/LogWriter.h>
 #include <core/string.h>
@@ -228,7 +229,11 @@ void CSecurityRSAAES::verifyServer()
 
   sha1_init(&ctx);
   sha1_update(&ctx, key.length(), key.data());
+#if NETTLE_VERSION_MAJOR >= 4
+  sha1_digest(&ctx, f);
+#else
   sha1_digest(&ctx, SHA1_DIGEST_SIZE, f);
+#endif
 
   // This is the format used by RealVNC, so use the same so users can
   // compare
@@ -308,24 +313,40 @@ void CSecurityRSAAES::setCipher()
     sha1_init(&ctx);
     sha1_update(&ctx, 16, clientRandom);
     sha1_update(&ctx, 16, serverRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, key);
+#else
     sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
+#endif
     rais = new rdr::AESInStream(rawis, key, 128);
     sha1_init(&ctx);
     sha1_update(&ctx, 16, serverRandom);
     sha1_update(&ctx, 16, clientRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, key);
+#else
     sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
+#endif
     raos = new rdr::AESOutStream(rawos, key, 128);
   } else {
     struct sha256_ctx ctx;
     sha256_init(&ctx);
     sha256_update(&ctx, 32, clientRandom);
     sha256_update(&ctx, 32, serverRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, key);
+#else
     sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
+#endif
     rais = new rdr::AESInStream(rawis, key, 256);
     sha256_init(&ctx);
     sha256_update(&ctx, 32, serverRandom);
     sha256_update(&ctx, 32, clientRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, key);
+#else
     sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
+#endif
     raos = new rdr::AESOutStream(rawos, key, 256);
   }
   if (isAllEncrypted)
@@ -361,7 +382,11 @@ void CSecurityRSAAES::writeHash()
     sha1_update(&ctx, 4, lenServerKey);
     sha1_update(&ctx, serverKey.size, serverKeyN);
     sha1_update(&ctx, serverKey.size, serverKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, hash);
+#else
     sha1_digest(&ctx, hashSize, hash);
+#endif
   } else {
     hashSize = SHA256_DIGEST_SIZE;
     struct sha256_ctx ctx;
@@ -372,7 +397,11 @@ void CSecurityRSAAES::writeHash()
     sha256_update(&ctx, 4, lenServerKey);
     sha256_update(&ctx, serverKey.size, serverKeyN);
     sha256_update(&ctx, serverKey.size, serverKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, hash);
+#else
     sha256_digest(&ctx, hashSize, hash);
+#endif
   }
   raos->writeBytes(hash, hashSize);
   raos->flush();
@@ -417,7 +446,11 @@ bool CSecurityRSAAES::readHash()
     sha1_update(&ctx, 4, lenClientKey);
     sha1_update(&ctx, clientKey.size, clientKeyN);
     sha1_update(&ctx, clientKey.size, clientKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, realHash);
+#else
     sha1_digest(&ctx, hashSize, realHash);
+#endif
   } else {
     struct sha256_ctx ctx;
     sha256_init(&ctx);
@@ -427,7 +460,11 @@ bool CSecurityRSAAES::readHash()
     sha256_update(&ctx, 4, lenClientKey);
     sha256_update(&ctx, clientKey.size, clientKeyN);
     sha256_update(&ctx, clientKey.size, clientKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, realHash);
+#else
     sha256_digest(&ctx, hashSize, realHash);
+#endif
   }
   if (memcmp(hash, realHash, hashSize) != 0)
     throw protocol_error("Hash doesn't match");

--- a/common/rfb/CSecurityRSAAES.cxx
+++ b/common/rfb/CSecurityRSAAES.cxx
@@ -302,6 +302,7 @@ void CSecurityRSAAES::setCipher()
   rawis = cc->getInStream();
   rawos = cc->getOutStream();
   uint8_t key[32];
+  memset(key, 0, sizeof(key));
   if (keySize == 128) {
     struct sha1_ctx ctx;
     sha1_init(&ctx);
@@ -334,6 +335,7 @@ void CSecurityRSAAES::setCipher()
 void CSecurityRSAAES::writeHash()
 {
   uint8_t hash[32];
+  memset(hash, 0, sizeof(hash));
   size_t len = serverKeyLength;
   uint8_t lenServerKey[4] = {
     (uint8_t)((len & 0xff000000) >> 24),
@@ -380,6 +382,8 @@ bool CSecurityRSAAES::readHash()
 {
   uint8_t hash[32];
   uint8_t realHash[32];
+  memset(hash, 0, sizeof(hash));
+  memset(realHash, 0, sizeof(realHash));
   int hashSize = keySize == 128 ? 20 : 32;
   if (!rais->hasData(hashSize))
     return false;

--- a/common/rfb/CSecurityRSAAES.cxx
+++ b/common/rfb/CSecurityRSAAES.cxx
@@ -218,7 +218,7 @@ void CSecurityRSAAES::verifyServer()
 {
   rdr::MemOutStream key(4 + serverKey.size * 2);
 
-  uint8_t f[8];
+  uint8_t f[SHA1_DIGEST_SIZE];
   struct sha1_ctx ctx;
   std::string fingerprint;
 
@@ -228,7 +228,7 @@ void CSecurityRSAAES::verifyServer()
 
   sha1_init(&ctx);
   sha1_update(&ctx, key.length(), key.data());
-  sha1_digest(&ctx, sizeof(f), f);
+  sha1_digest(&ctx, SHA1_DIGEST_SIZE, f);
 
   // This is the format used by RealVNC, so use the same so users can
   // compare
@@ -301,31 +301,31 @@ void CSecurityRSAAES::setCipher()
 {
   rawis = cc->getInStream();
   rawos = cc->getOutStream();
-  uint8_t key[32];
+  uint8_t key[SHA256_DIGEST_SIZE];
   memset(key, 0, sizeof(key));
   if (keySize == 128) {
     struct sha1_ctx ctx;
     sha1_init(&ctx);
     sha1_update(&ctx, 16, clientRandom);
     sha1_update(&ctx, 16, serverRandom);
-    sha1_digest(&ctx, 16, key);
+    sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
     rais = new rdr::AESInStream(rawis, key, 128);
     sha1_init(&ctx);
     sha1_update(&ctx, 16, serverRandom);
     sha1_update(&ctx, 16, clientRandom);
-    sha1_digest(&ctx, 16, key);
+    sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
     raos = new rdr::AESOutStream(rawos, key, 128);
   } else {
     struct sha256_ctx ctx;
     sha256_init(&ctx);
     sha256_update(&ctx, 32, clientRandom);
     sha256_update(&ctx, 32, serverRandom);
-    sha256_digest(&ctx, 32, key);
+    sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
     rais = new rdr::AESInStream(rawis, key, 256);
     sha256_init(&ctx);
     sha256_update(&ctx, 32, serverRandom);
     sha256_update(&ctx, 32, clientRandom);
-    sha256_digest(&ctx, 32, key);
+    sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
     raos = new rdr::AESOutStream(rawos, key, 256);
   }
   if (isAllEncrypted)
@@ -334,7 +334,7 @@ void CSecurityRSAAES::setCipher()
 
 void CSecurityRSAAES::writeHash()
 {
-  uint8_t hash[32];
+  uint8_t hash[SHA256_DIGEST_SIZE];
   memset(hash, 0, sizeof(hash));
   size_t len = serverKeyLength;
   uint8_t lenServerKey[4] = {
@@ -352,7 +352,7 @@ void CSecurityRSAAES::writeHash()
   };
   int hashSize;
   if (keySize == 128) {
-    hashSize = 20;
+    hashSize = SHA1_DIGEST_SIZE;
     struct sha1_ctx ctx;
     sha1_init(&ctx);
     sha1_update(&ctx, 4, lenClientKey);
@@ -363,7 +363,7 @@ void CSecurityRSAAES::writeHash()
     sha1_update(&ctx, serverKey.size, serverKeyE);
     sha1_digest(&ctx, hashSize, hash);
   } else {
-    hashSize = 32;
+    hashSize = SHA256_DIGEST_SIZE;
     struct sha256_ctx ctx;
     sha256_init(&ctx);
     sha256_update(&ctx, 4, lenClientKey);
@@ -380,11 +380,17 @@ void CSecurityRSAAES::writeHash()
 
 bool CSecurityRSAAES::readHash()
 {
-  uint8_t hash[32];
-  uint8_t realHash[32];
+  uint8_t hash[SHA256_DIGEST_SIZE];
+  uint8_t realHash[SHA256_DIGEST_SIZE];
   memset(hash, 0, sizeof(hash));
   memset(realHash, 0, sizeof(realHash));
-  int hashSize = keySize == 128 ? 20 : 32;
+  int hashSize;
+  if (keySize == 128) {
+    hashSize = SHA1_DIGEST_SIZE;
+  } else {
+    hashSize = SHA256_DIGEST_SIZE;
+  }
+
   if (!rais->hasData(hashSize))
     return false;
   rais->readBytes(hash, hashSize);

--- a/common/rfb/SSecurityRSAAES.cxx
+++ b/common/rfb/SSecurityRSAAES.cxx
@@ -406,31 +406,31 @@ void SSecurityRSAAES::setCipher()
 {
   rawis = sc->getInStream();
   rawos = sc->getOutStream();
-  uint8_t key[32];
+  uint8_t key[SHA256_DIGEST_SIZE];
   memset(key, 0, sizeof(key));
   if (keySize == 128) {
     struct sha1_ctx ctx;
     sha1_init(&ctx);
     sha1_update(&ctx, 16, serverRandom);
     sha1_update(&ctx, 16, clientRandom);
-    sha1_digest(&ctx, 16, key);
+    sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
     rais = new rdr::AESInStream(rawis, key, 128);
     sha1_init(&ctx);
     sha1_update(&ctx, 16, clientRandom);
     sha1_update(&ctx, 16, serverRandom);
-    sha1_digest(&ctx, 16, key);
+    sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
     raos = new rdr::AESOutStream(rawos, key, 128);
   } else {
     struct sha256_ctx ctx;
     sha256_init(&ctx);
     sha256_update(&ctx, 32, serverRandom);
     sha256_update(&ctx, 32, clientRandom);
-    sha256_digest(&ctx, 32, key);
+    sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
     rais = new rdr::AESInStream(rawis, key, 256);
     sha256_init(&ctx);
     sha256_update(&ctx, 32, clientRandom);
     sha256_update(&ctx, 32, serverRandom);
-    sha256_digest(&ctx, 32, key);
+    sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
     raos = new rdr::AESOutStream(rawos, key, 256);
   }
   if (isAllEncrypted)
@@ -456,7 +456,7 @@ void SSecurityRSAAES::writeHash()
   };
   int hashSize;
   if (keySize == 128) {
-    hashSize = 20;
+    hashSize = SHA1_DIGEST_SIZE;
     struct sha1_ctx ctx;
     sha1_init(&ctx);
     sha1_update(&ctx, 4, lenServerKey);
@@ -467,7 +467,7 @@ void SSecurityRSAAES::writeHash()
     sha1_update(&ctx, clientKey.size, clientKeyE);
     sha1_digest(&ctx, hashSize, hash);
   } else {
-    hashSize = 32;
+    hashSize = SHA256_DIGEST_SIZE;
     struct sha256_ctx ctx;
     sha256_init(&ctx);
     sha256_update(&ctx, 4, lenServerKey);
@@ -484,11 +484,17 @@ void SSecurityRSAAES::writeHash()
 
 bool SSecurityRSAAES::readHash()
 {
-  uint8_t hash[32];
-  uint8_t realHash[32];
+  uint8_t hash[SHA256_DIGEST_SIZE];
+  uint8_t realHash[SHA256_DIGEST_SIZE];
   memset(hash, 0, sizeof(hash));
   memset(realHash, 0, sizeof(realHash));
-  int hashSize = keySize == 128 ? 20 : 32;
+  int hashSize;
+  if (keySize == 128) {
+    hashSize = SHA1_DIGEST_SIZE;
+  } else {
+    hashSize = SHA256_DIGEST_SIZE;
+  }
+
   if (!rais->hasData(hashSize))
     return false;
   rais->readBytes(hash, hashSize);

--- a/common/rfb/SSecurityRSAAES.cxx
+++ b/common/rfb/SSecurityRSAAES.cxx
@@ -407,6 +407,7 @@ void SSecurityRSAAES::setCipher()
   rawis = sc->getInStream();
   rawos = sc->getOutStream();
   uint8_t key[32];
+  memset(key, 0, sizeof(key));
   if (keySize == 128) {
     struct sha1_ctx ctx;
     sha1_init(&ctx);
@@ -485,6 +486,8 @@ bool SSecurityRSAAES::readHash()
 {
   uint8_t hash[32];
   uint8_t realHash[32];
+  memset(hash, 0, sizeof(hash));
+  memset(realHash, 0, sizeof(realHash));
   int hashSize = keySize == 128 ? 20 : 32;
   if (!rais->hasData(hashSize))
     return false;

--- a/common/rfb/SSecurityRSAAES.cxx
+++ b/common/rfb/SSecurityRSAAES.cxx
@@ -36,6 +36,7 @@
 #include <nettle/sha2.h>
 #include <nettle/base64.h>
 #include <nettle/asn1.h>
+#include <nettle/version.h>
 
 #include <core/Exception.h>
 #include <core/LogWriter.h>
@@ -413,24 +414,40 @@ void SSecurityRSAAES::setCipher()
     sha1_init(&ctx);
     sha1_update(&ctx, 16, serverRandom);
     sha1_update(&ctx, 16, clientRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, key);
+#else
     sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
+#endif
     rais = new rdr::AESInStream(rawis, key, 128);
     sha1_init(&ctx);
     sha1_update(&ctx, 16, clientRandom);
     sha1_update(&ctx, 16, serverRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, key);
+#else
     sha1_digest(&ctx, SHA1_DIGEST_SIZE, key);
+#endif
     raos = new rdr::AESOutStream(rawos, key, 128);
   } else {
     struct sha256_ctx ctx;
     sha256_init(&ctx);
     sha256_update(&ctx, 32, serverRandom);
     sha256_update(&ctx, 32, clientRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, key);
+#else
     sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
+#endif
     rais = new rdr::AESInStream(rawis, key, 256);
     sha256_init(&ctx);
     sha256_update(&ctx, 32, clientRandom);
     sha256_update(&ctx, 32, serverRandom);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, key);
+#else
     sha256_digest(&ctx, SHA256_DIGEST_SIZE, key);
+#endif
     raos = new rdr::AESOutStream(rawos, key, 256);
   }
   if (isAllEncrypted)
@@ -465,7 +482,11 @@ void SSecurityRSAAES::writeHash()
     sha1_update(&ctx, 4, lenClientKey);
     sha1_update(&ctx, clientKey.size, clientKeyN);
     sha1_update(&ctx, clientKey.size, clientKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, hash);
+#else
     sha1_digest(&ctx, hashSize, hash);
+#endif
   } else {
     hashSize = SHA256_DIGEST_SIZE;
     struct sha256_ctx ctx;
@@ -476,7 +497,11 @@ void SSecurityRSAAES::writeHash()
     sha256_update(&ctx, 4, lenClientKey);
     sha256_update(&ctx, clientKey.size, clientKeyN);
     sha256_update(&ctx, clientKey.size, clientKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, hash);
+#else
     sha256_digest(&ctx, hashSize, hash);
+#endif
   }
   raos->writeBytes(hash, hashSize);
   raos->flush();
@@ -521,7 +546,11 @@ bool SSecurityRSAAES::readHash()
     sha1_update(&ctx, 4, lenServerKey);
     sha1_update(&ctx, serverKey.size, serverKeyN);
     sha1_update(&ctx, serverKey.size, serverKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha1_digest(&ctx, realHash);
+#else
     sha1_digest(&ctx, hashSize, realHash);
+#endif
   } else {
     struct sha256_ctx ctx;
     sha256_init(&ctx);
@@ -531,7 +560,11 @@ bool SSecurityRSAAES::readHash()
     sha256_update(&ctx, 4, lenServerKey);
     sha256_update(&ctx, serverKey.size, serverKeyN);
     sha256_update(&ctx, serverKey.size, serverKeyE);
+#if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&ctx, realHash);
+#else
     sha256_digest(&ctx, hashSize, realHash);
+#endif
   }
   if (memcmp(hash, realHash, hashSize) != 0)
     throw protocol_error("Hash doesn't match");


### PR DESCRIPTION
TODO:
- [x] Client builds with Nettle 3.10?
- [x] Client builds with Nettle 4.0?
- [x] Server builds with Nettle 3.10?
- [x] Server builds with Nettle 4.0?

There were a couple of places where we were using the old functionality that was removed. This needs some investigation. 
It looks like we are handling larger-than-expected-digest sizes properly. But let's be sure!

Closes #2073 