### PR TITLE
Improve reproducibility of package builds

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -24,6 +24,7 @@ set(JAVA_PKCS11_PROVIDER_CLASS "sun.security.pkcs11.SunPKCS11" CACHE STRING "PKC
 set(JAVA_PKCS11_PROVIDER_ARG NOTFOUND CACHE STRING "Path to the PKCS11 security provider class config file")
 set(JAVA_TSA_URL NOTFOUND CACHE STRING "URL of Time Stamping Authority (TSA)")
 set(JAVA_CERT_CHAIN NOTFOUND CACHE STRING "Path to CA certificate chain file")
+option(JAVA_SIGN_JAR "Sign Java viewer jar" ON)
 
 if(NOT BUILD)
 	STRING(TIMESTAMP BUILD "%Y%m%d" UTC)
@@ -142,6 +143,25 @@ endif()
 string(REGEX REPLACE "jar" "" Java_PATH ${Java_JAR_EXECUTABLE})
 string(REGEX REPLACE ".exe" "" Java_PATH ${Java_PATH})
 
+set(SIGN_JAR_COMMAND)
+if(JAVA_SIGN_JAR)
+  set(SIGN_JAR_COMMAND
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -DJava_PATH=${Java_PATH} -DJAR_FILE=${BINDIR}/VncViewer.jar
+      -DJAVA_KEYSTORE=${JAVA_KEYSTORE}
+      -DJAVA_KEYSTORE_TYPE=${JAVA_KEYSTORE_TYPE}
+      -DJAVA_STOREPASS=${JAVA_STOREPASS}
+      -DJAVA_PKCS11_PROVIDER_CLASS=${JAVA_PKCS11_PROVIDER_CLASS}
+      -DJAVA_PKCS11_PROVIDER_ARG=${JAVA_PKCS11_PROVIDER_ARG}
+      -DJAVA_KEYPASS=${JAVA_KEYPASS}
+      -DJAVA_KEY_ALIAS=${JAVA_KEY_ALIAS}
+      -DJAVA_TSA_URL=${JAVA_TSA_URL}
+      -DJAVA_CERT_CHAIN=${JAVA_CERT_CHAIN}
+      -P ${SRCDIR}/cmake/SignJar.cmake)
+else()
+  message(STATUS "Java viewer jar signing disabled")
+endif()
+
 add_custom_command(OUTPUT VncViewer.jar
   DEPENDS ${JAVA_CLASSES}
     ${SRCDIR}/${CLASSPATH}/MANIFEST.MF
@@ -164,17 +184,6 @@ add_custom_command(OUTPUT VncViewer.jar
     com/jcraft/jsch/*.class
     com/tigervnc/vncviewer/*.png
     com/tigervnc/vncviewer/tigervnc.ico
-  COMMAND ${CMAKE_COMMAND}
-  ARGS -DJava_PATH=${Java_PATH} -DJAR_FILE=${BINDIR}/VncViewer.jar
-    -DJAVA_KEYSTORE=${JAVA_KEYSTORE}
-    -DJAVA_KEYSTORE_TYPE=${JAVA_KEYSTORE_TYPE}
-    -DJAVA_STOREPASS=${JAVA_STOREPASS}
-    -DJAVA_PKCS11_PROVIDER_CLASS=${JAVA_PKCS11_PROVIDER_CLASS}
-    -DJAVA_PKCS11_PROVIDER_ARG=${JAVA_PKCS11_PROVIDER_ARG}
-    -DJAVA_KEYPASS=${JAVA_KEYPASS}
-    -DJAVA_KEY_ALIAS=${JAVA_KEY_ALIAS}
-    -DJAVA_TSA_URL=${JAVA_TSA_URL}
-    -DJAVA_CERT_CHAIN=${JAVA_CERT_CHAIN}
-    -P ${SRCDIR}/cmake/SignJar.cmake)
+  ${SIGN_JAR_COMMAND})
 
 add_custom_target(java ALL DEPENDS VncViewer.jar)

--- a/unix/vncconfig/buildtime.c
+++ b/unix/vncconfig/buildtime.c
@@ -15,4 +15,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
  * USA.
  */
-char buildtime[] = __DATE__ " " __TIME__;
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+char buildtime[] = BUILD_TIMESTAMP;

--- a/unix/x0vncserver/buildtime.c
+++ b/unix/x0vncserver/buildtime.c
@@ -15,4 +15,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
  * USA.
  */
-char buildtime[] = __DATE__ " " __TIME__;
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+char buildtime[] = BUILD_TIMESTAMP;

--- a/unix/xserver/hw/vnc/buildtime.c
+++ b/unix/xserver/hw/vnc/buildtime.c
@@ -15,4 +15,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
  * USA.
  */
-char buildtime[] = __DATE__ " " __TIME__;
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#include "vncconfig.h"
+#endif
+
+char buildtime[] = BUILD_TIMESTAMP;

--- a/win/winvnc/buildTime.cxx
+++ b/win/winvnc/buildTime.cxx
@@ -15,4 +15,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
  * USA.
  */
-const char* buildTime = "Built on " __DATE__ " at " __TIME__;
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+const char* buildTime = "Built on " BUILD_TIMESTAMP;


### PR DESCRIPTION
This makes two small changes that help downstream distributions produce reproducible TigerVNC packages.

- Add a `JAVA_SIGN_JAR` CMake option, defaulting to enabled, so release builds keep the current behavior while distro/package builds can disable signing of the Java viewer jar.
- Replace `__DATE__`/`__TIME__` in native build-time strings with a deterministic Unix epoch timestamp.

The automatically generated/self-signed jar signature and compile-time date/time macros otherwise embed data that can vary between builds.