### PR TITLE
Minor compatibility fixes for macOS

### DIFF
--- a/vncviewer/KeyboardMacOS.mm
+++ b/vncviewer/KeyboardMacOS.mm
@@ -29,9 +29,18 @@
 
 #include <IOKit/hidsystem/IOHIDLib.h>
 #include <IOKit/hidsystem/IOHIDParameter.h>
+#include <AvailabilityMacros.h>
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
+#define kIOHIDCapsLockState 0
+#define kIOHIDNumLockState 1
+static inline kern_return_t IOHIDGetModifierLockState(io_connect_t, int, bool*) { return KERN_FAILURE; }
+static inline kern_return_t IOHIDSetModifierLockState(io_connect_t, int, bool) { return KERN_FAILURE; }
+#define TIGERVNC_NO_IOHID_MODIFIER_LOCK_STATE
+#endif
 
 // This wasn't added until 10.12
-#if !defined(MAC_OS_X_VERSION_10_12) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 101200
 const int kVK_RightCommand = 0x36;
 #endif
 // And this is still missing
@@ -260,6 +269,9 @@ std::list<uint32_t> KeyboardMacOS::translateToKeySyms(int systemKeyCode)
 
 unsigned KeyboardMacOS::getLEDState()
 {
+#ifdef TIGERVNC_NO_IOHID_MODIFIER_LOCK_STATE
+  return rfb::ledUnknown;
+#else
   unsigned state;
   int ret;
   bool on;
@@ -285,10 +297,15 @@ unsigned KeyboardMacOS::getLEDState()
   // No support for Scroll Lock //
 
   return state;
+#endif
 }
 
 void KeyboardMacOS::setLEDState(unsigned state)
 {
+#ifdef TIGERVNC_NO_IOHID_MODIFIER_LOCK_STATE
+  (void)state;
+  return;
+#else
   int ret;
 
   ret = setModifierLockState(kIOHIDCapsLockState, state & rfb::ledCapsLock);
@@ -304,6 +321,7 @@ void KeyboardMacOS::setLEDState(unsigned state)
   }
 
   // No support for Scroll Lock //
+#endif
 }
 
 bool KeyboardMacOS::isKeyboardEvent(const NSEvent* nsevent)

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -31,6 +31,10 @@
 #import <Cocoa/Cocoa.h>
 #import <ApplicationServices/ApplicationServices.h>
 
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
+#include <Carbon/Carbon.h>
+#endif
+
 #include "cocoa.h"
 
 static CFMachPortRef event_tap;
@@ -135,6 +139,7 @@ bool cocoa_is_trusted(bool prompt)
     }
 
     if (pid != 0) {
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
       NSRunningApplication* authApp;
 
       authApp = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
@@ -143,6 +148,12 @@ bool cocoa_is_trusted(bool prompt)
         // or NSApplicationActivateIgnoringOtherApps
         [authApp activateWithOptions:0];
       }
+#else
+      ProcessSerialNumber psn = {0, kNoProcess};
+      if (GetProcessForPID((pid_t)pid, &psn) == noErr) {
+        SetFrontProcess(&psn);
+      }
+#endif
     }
   }
 

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -26,6 +26,8 @@
 #include <FL/Fl_Window.H>
 #include <FL/x.H>
 
+#include <AvailabilityMacros.h>
+
 #import <Cocoa/Cocoa.h>
 #import <ApplicationServices/ApplicationServices.h>
 
@@ -39,7 +41,7 @@ void cocoa_prevent_native_fullscreen(Fl_Window *win)
   NSWindow *nsw;
   nsw = (NSWindow*)fl_xid(win);
   assert(nsw);
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 100700
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
   nsw.collectionBehavior |= NSWindowCollectionBehaviorFullScreenNone;
 #endif
 }
@@ -52,8 +54,7 @@ bool cocoa_is_trusted(bool prompt)
 
   Boolean trusted;
 
-#if !defined(MAC_OS_X_VERSION_10_9) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9
-  // FIXME: Raise system requirements so this isn't needed
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 1090
   void *lib;
   typedef Boolean (*AXIsProcessTrustedWithOptionsRef)(CFDictionaryRef);
   AXIsProcessTrustedWithOptionsRef AXIsProcessTrustedWithOptions;


### PR DESCRIPTION
1. Fix https://github.com/TigerVNC/tigervnc/issues/2110
2. Fix wrong macro for 10.7.
3. Include `AvailabilityMacros.h` explicitly to ensure consistency, use numerical macros for comparison uniformly.