### PR TITLE
Work around macOS NSWindowStyleMaskBorderless

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -1007,7 +1007,7 @@ void Viewport::popupContextMenu()
     // FIXME: Workaround for not being able to minimize in fullscreen
     // https://github.com/TigerVNC/tigervnc/pull/1813
     if (window()->fullscreen_active())
-      window()->fullscreen_off();
+      cocoa_enable_minimize(window());
 #endif
     window()->iconize();
     break;

--- a/vncviewer/cocoa.h
+++ b/vncviewer/cocoa.h
@@ -37,4 +37,6 @@ CGColorSpaceRef cocoa_win_color_space(Fl_Window *win);
 bool cocoa_win_is_zoomed(Fl_Window *win);
 void cocoa_win_zoom(Fl_Window *win);
 
+void cocoa_enable_minimize(Fl_Window *win);
+
 #endif

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -270,3 +270,11 @@ void cocoa_win_zoom(Fl_Window *win)
   assert(nsw);
   [nsw zoom:nsw];
 }
+
+void cocoa_enable_minimize(Fl_Window *win)
+{
+  NSWindow *nsw;
+  nsw = (NSWindow*)fl_xid(win);
+  assert(nsw);
+  nsw.styleMask |= NSWindowStyleMaskMiniaturizable;
+}


### PR DESCRIPTION
When FLTK puts a window fullscreen on macOS it has the style of
NSWindowStyleMaskBorderless.  This disables the minimize feature of the
window.  Masking NSWindowStyleMaskMiniaturizable allows the boarder less
window to be minimize.

This should be fixed in FLTK however given that we're pinned to 1.13.x
only security fixes will be accepted upstream?  Possible 1.14 or 1.15 do
not have this issue.
