### PR TITLE
Avoid re-registering notification for deleted client.

### DIFF
--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -388,6 +388,7 @@ void XserverDesktop::blockHandler(int* timeout)
         server->removeSocket(*i);
         vncClientGone(fd);
         delete (*i);
+        continue;
       }
 
       /* Update existing NotifyFD to listen for write (or not) */


### PR DESCRIPTION
After disconnecting a client, the log file quickly filled up with lots of copies this line:
```
 XserverDesktop: Cannot find file descriptor for socket event
```

A new block was introduced with https://github.com/TigerVNC/tigervnc/commit/9198ccd1b28d4e05b9ede87da386adc64499e241 where `vncSetNotifyFd(fd, screenIndex, true, (*i)->outStream().hasBufferedData());` is called after `delete(*i);`
