### PR TITLE
Split rfb client and server libraries

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -13,6 +13,6 @@ add_subdirectory(rfb)
 # is passed (additionally, libvnc is not used on Windows.)
 
 if(NOT WIN32)
-  set_target_properties(core rdr network rfb
+  set_target_properties(core rdr network rfb rfbserver
     PROPERTIES COMPILE_FLAGS -fPIC)
 endif()

--- a/common/core/Configuration.cxx
+++ b/common/core/Configuration.cxx
@@ -59,15 +59,14 @@ Configuration* Configuration::global() {
 bool Configuration::set(const char* paramName, const char* val,
                         bool immutable)
 {
-  for (VoidParameter* current: params) {
-    if (strcasecmp(current->getName(), paramName) == 0) {
-      bool b = current->setParam(val);
-      if (b && immutable) 
-	current->setImmutable();
-      return b;
-    }
-  }
-  return false;
+  VoidParameter* current = get(paramName);
+  if (!current)
+    return false;
+
+  bool b = current->setParam(val);
+  if (b && immutable)
+    current->setImmutable();
+  return b;
 }
 
 VoidParameter* Configuration::get(const char* param)
@@ -163,37 +162,34 @@ int Configuration::handleArg(int argc, char* argv[], int index)
   if (equal)
     return set(param.c_str(), val.c_str()) ? 1 : 0;
 
-  for (VoidParameter* current: params) {
-    if (strcasecmp(current->getName(), param.c_str()) != 0)
-      continue;
+  VoidParameter* current = get(param.c_str());
+  if (!current)
+    return 0;
 
-    // We need to resolve an ambiguity for booleans
-    if (dynamic_cast<BoolParameter*>(current) != nullptr) {
-      if (index+1 < argc) {
-        // FIXME: Should not duplicate the list of values here
-        if ((strcasecmp(argv[index+1], "0") == 0) ||
-            (strcasecmp(argv[index+1], "1") == 0) ||
-            (strcasecmp(argv[index+1], "on") == 0) ||
-            (strcasecmp(argv[index+1], "off") == 0) ||
-            (strcasecmp(argv[index+1], "true") == 0) ||
-            (strcasecmp(argv[index+1], "false") == 0) ||
-            (strcasecmp(argv[index+1], "yes") == 0) ||
-            (strcasecmp(argv[index+1], "no") == 0)) {
-            return current->setParam(argv[index+1]) ? 2 : 0;
-        }
+  // We need to resolve an ambiguity for booleans
+  if (dynamic_cast<BoolParameter*>(current) != nullptr) {
+    if (index+1 < argc) {
+      // FIXME: Should not duplicate the list of values here
+      if ((strcasecmp(argv[index+1], "0") == 0) ||
+          (strcasecmp(argv[index+1], "1") == 0) ||
+          (strcasecmp(argv[index+1], "on") == 0) ||
+          (strcasecmp(argv[index+1], "off") == 0) ||
+          (strcasecmp(argv[index+1], "true") == 0) ||
+          (strcasecmp(argv[index+1], "false") == 0) ||
+          (strcasecmp(argv[index+1], "yes") == 0) ||
+          (strcasecmp(argv[index+1], "no") == 0)) {
+          return current->setParam(argv[index+1]) ? 2 : 0;
       }
     }
-
-    if (current->setParam())
-      return 1;
-
-    if (index+1 >= argc)
-      return 0;
-
-    return current->setParam(argv[index+1]) ? 2 : 0;
   }
 
-  return 0;
+  if (current->setParam())
+    return 1;
+
+  if (index+1 >= argc)
+    return 0;
+
+  return current->setParam(argv[index+1]) ? 2 : 0;
 }
 
 

--- a/common/core/Configuration.cxx
+++ b/common/core/Configuration.cxx
@@ -205,6 +205,14 @@ VoidParameter::VoidParameter(const char* name_, const char* desc_)
   Configuration *conf;
 
   conf = Configuration::global();
+
+  // Check and warn for conflicts
+  for (VoidParameter* param: conf->params) {
+    // FIXME: This generally runs before any loggers are set up
+    if (strcasecmp(param->getName(), name) == 0)
+      fprintf(stderr, "Error: Multiple parameters named %s\n", name);
+  }
+
   conf->params.push_back(this);
   conf->params.sort([](const VoidParameter* a, const VoidParameter* b) {
     return strcasecmp(a->getName(), b->getName()) < 0;

--- a/common/core/Configuration.cxx
+++ b/common/core/Configuration.cxx
@@ -71,11 +71,17 @@ bool Configuration::set(const char* paramName, const char* val,
 
 VoidParameter* Configuration::get(const char* param)
 {
+  VoidParameter* found;
+  found = nullptr;
   for (VoidParameter* current: params) {
-    if (strcasecmp(current->getName(), param) == 0)
-      return current;
+    if (strcasecmp(current->getName(), param) == 0) {
+      if (found != nullptr)
+        throw std::logic_error("Invalid access of ambigious "
+                               "parameter name");
+      found = current;
+    }
   }
-  return nullptr;
+  return found;
 }
 
 void Configuration::list(int width, int nameWidth) {

--- a/common/rfb/CMakeLists.txt
+++ b/common/rfb/CMakeLists.txt
@@ -6,6 +6,52 @@ add_library(rfb STATIC
   AccessRights.cxx
   Blacklist.cxx
   Congestion.cxx
+  ComparingUpdateTracker.cxx
+  Cursor.cxx
+  d3des.c
+  JpegCompressor.cxx
+  JpegDecompressor.cxx
+  KeyRemapper.cxx
+  KeysymStr.c
+  PixelBuffer.cxx
+  PixelFormat.cxx
+  Security.cxx
+  UpdateTracker.cxx
+  encodings.cxx
+  obfuscate.cxx)
+
+target_include_directories(rfb PUBLIC ${CMAKE_SOURCE_DIR}/common)
+target_include_directories(rfb SYSTEM PUBLIC ${JPEG_INCLUDE_DIR})
+target_link_libraries(rfb core rdr)
+target_link_libraries(rfb ${JPEG_LIBRARIES})
+
+add_library(rfbserver STATIC
+  ClientParams.cxx
+  EncodeManager.cxx
+  Encoder.cxx
+  HextileEncoder.cxx
+  JPEGEncoder.cxx
+  RREEncoder.cxx
+  RawEncoder.cxx
+  SConnection.cxx
+  SMsgReader.cxx
+  SMsgWriter.cxx
+  ServerCore.cxx
+  SecurityServer.cxx
+  SSecurityPlain.cxx
+  SSecurityStack.cxx
+  SSecurityVncAuth.cxx
+  SSecurityVeNCrypt.cxx
+  TightEncoder.cxx
+  TightJPEGEncoder.cxx
+  VNCSConnectionST.cxx
+  VNCServerST.cxx
+  ZRLEEncoder.cxx)
+
+target_include_directories(rfbserver PUBLIC ${CMAKE_SOURCE_DIR}/common)
+target_link_libraries(rfbserver core rdr network rfb)
+
+add_library(rfbclient STATIC
   CConnection.cxx
   CMsgReader.cxx
   CMsgWriter.cxx
@@ -13,104 +59,78 @@ add_library(rfb STATIC
   CSecurityStack.cxx
   CSecurityVeNCrypt.cxx
   CSecurityVncAuth.cxx
-  ClientParams.cxx
-  ComparingUpdateTracker.cxx
   CopyRectDecoder.cxx
-  Cursor.cxx
   DecodeManager.cxx
   Decoder.cxx
-  d3des.c
-  EncodeManager.cxx
-  Encoder.cxx
   HextileDecoder.cxx
-  HextileEncoder.cxx
-  JpegCompressor.cxx
-  JpegDecompressor.cxx
   JPEGDecoder.cxx
-  JPEGEncoder.cxx
-  KeyRemapper.cxx
-  KeysymStr.c
-  PixelBuffer.cxx
-  PixelFormat.cxx
-  RREEncoder.cxx
   RREDecoder.cxx
   RawDecoder.cxx
-  RawEncoder.cxx
-  SConnection.cxx
-  SMsgReader.cxx
-  SMsgWriter.cxx
-  ServerCore.cxx
-  ServerParams.cxx
-  Security.cxx
-  SecurityServer.cxx
   SecurityClient.cxx
-  SSecurityPlain.cxx
-  SSecurityStack.cxx
-  SSecurityVncAuth.cxx
-  SSecurityVeNCrypt.cxx
+  ServerParams.cxx
   TightDecoder.cxx
-  TightEncoder.cxx
-  TightJPEGEncoder.cxx
-  UpdateTracker.cxx
-  VNCSConnectionST.cxx
-  VNCServerST.cxx
-  ZRLEEncoder.cxx
-  ZRLEDecoder.cxx
-  encodings.cxx
-  obfuscate.cxx)
+  ZRLEDecoder.cxx)
 
-target_include_directories(rfb PUBLIC ${CMAKE_SOURCE_DIR}/common)
-target_include_directories(rfb SYSTEM PUBLIC ${JPEG_INCLUDE_DIR})
-target_link_libraries(rfb core rdr network)
-target_link_libraries(rfb ${JPEG_LIBRARIES})
+target_include_directories(rfbclient PUBLIC ${CMAKE_SOURCE_DIR}/common)
+target_link_libraries(rfbclient core rdr rfb)
 
 if(ENABLE_H264)
-  target_sources(rfb PRIVATE H264Decoder.cxx H264DecoderContext.cxx)
+  target_sources(rfbclient PRIVATE
+                 H264Decoder.cxx H264DecoderContext.cxx)
   if (AVCODEC_FOUND AND AVUTIL_FOUND AND SWSCALE_FOUND)
-    target_sources(rfb PRIVATE H264LibavDecoderContext.cxx)
-    target_include_directories(rfb SYSTEM PUBLIC
+    target_sources(rfbclient PRIVATE H264LibavDecoderContext.cxx)
+    target_include_directories(rfbclient SYSTEM PUBLIC
                                ${AVCODEC_INCLUDE_DIRS}
                                ${AVUTIL_INCLUDE_DIRS}
                                ${SWSCALE_INCLUDE_DIRS})
-    target_link_libraries(rfb ${AVCODEC_LIBRARIES} ${AVUTIL_LIBRARIES}
-                          ${SWSCALE_LIBRARIES})
+    target_link_libraries(rfbclient ${AVCODEC_LIBRARIES}
+                          ${AVUTIL_LIBRARIES} ${SWSCALE_LIBRARIES})
   endif()
   if(WIN32)
-    target_sources(rfb PRIVATE H264WinDecoderContext.cxx)
-    target_link_libraries(rfb ole32 mfplat mfuuid wmcodecdspuuid)
+    target_sources(rfbclient PRIVATE H264WinDecoderContext.cxx)
+    target_link_libraries(rfbclient ole32 mfplat mfuuid wmcodecdspuuid)
   endif()
-  target_include_directories(rfb SYSTEM PUBLIC ${H264_INCLUDE_DIRS})
-  target_link_libraries(rfb ${H264_LIBRARIES})
+  target_include_directories(rfbclient SYSTEM PUBLIC ${H264_INCLUDE_DIRS})
+  target_link_libraries(rfbclient ${H264_LIBRARIES})
 endif()
 
 if(WIN32)
-  target_include_directories(rfb PUBLIC ${CMAKE_SOURCE_DIR}/win)
-  target_sources(rfb PRIVATE WinPasswdValidator.cxx)
+  target_include_directories(rfbserver PUBLIC ${CMAKE_SOURCE_DIR}/win)
+  target_sources(rfbserver PRIVATE WinPasswdValidator.cxx)
 endif(WIN32)
 
 if(PAM_FOUND)
-  target_sources(rfb PRIVATE UnixPasswordValidator.cxx)
-  target_include_directories(rfb SYSTEM PRIVATE ${PAM_INCLUDE_DIRS})
-  target_link_libraries(rfb ${PAM_LIBRARIES})
+  target_sources(rfbserver PRIVATE UnixPasswordValidator.cxx)
+  target_include_directories(rfbserver SYSTEM PRIVATE ${PAM_INCLUDE_DIRS})
+  target_link_libraries(rfbserver ${PAM_LIBRARIES})
 endif()
 
 if(GNUTLS_FOUND)
-  target_sources(rfb PRIVATE CSecurityTLS.cxx SSecurityTLS.cxx)
-  target_include_directories(rfb SYSTEM PUBLIC ${GNUTLS_INCLUDE_DIR})
-  target_link_libraries(rfb ${GNUTLS_LIBRARIES})
+  target_sources(rfbserver PRIVATE SSecurityTLS.cxx)
+  target_sources(rfbclient PRIVATE CSecurityTLS.cxx)
+  target_include_directories(rfbserver SYSTEM PUBLIC ${GNUTLS_INCLUDE_DIR})
+  target_include_directories(rfbclient SYSTEM PUBLIC ${GNUTLS_INCLUDE_DIR})
+  target_link_libraries(rfbserver ${GNUTLS_LIBRARIES})
+  target_link_libraries(rfbclient ${GNUTLS_LIBRARIES})
   # FIXME: Hack to block it marking gnutls_free() as dllimport
   if(WIN32 AND BUILD_STATIC)
-    target_compile_definitions(rfb PRIVATE GNUTLS_INTERNAL_BUILD)
+    target_compile_definitions(rfbserver PRIVATE GNUTLS_INTERNAL_BUILD)
+    target_compile_definitions(rfbclient PRIVATE GNUTLS_INTERNAL_BUILD)
   endif()
 endif()
 
 if (NETTLE_FOUND)
-  target_sources(rfb PRIVATE CSecurityDH.cxx CSecurityMSLogonII.cxx
-                 CSecurityRSAAES.cxx SSecurityRSAAES.cxx)
-  target_include_directories(rfb SYSTEM PUBLIC ${NETTLE_INCLUDE_DIRS})
-  target_link_libraries(rfb ${HOGWEED_LIBRARIES} ${NETTLE_LIBRARIES})
+  target_sources(rfbserver PRIVATE SSecurityRSAAES.cxx)
+  target_sources(rfbclient PRIVATE CSecurityDH.cxx
+                 CSecurityMSLogonII.cxx CSecurityRSAAES.cxx)
+  target_include_directories(rfbserver SYSTEM PUBLIC ${NETTLE_INCLUDE_DIRS})
+  target_include_directories(rfbclient SYSTEM PUBLIC ${NETTLE_INCLUDE_DIRS})
+  target_link_libraries(rfbserver ${HOGWEED_LIBRARIES} ${NETTLE_LIBRARIES})
+  target_link_libraries(rfbclient ${HOGWEED_LIBRARIES} ${NETTLE_LIBRARIES})
 endif()
 
 if(UNIX)
   libtool_create_control_file(rfb)
+  libtool_create_control_file(rfbserver)
+  libtool_create_control_file(rfbclient)
 endif()

--- a/common/rfb/CMakeLists.txt
+++ b/common/rfb/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(rfb STATIC
 target_include_directories(rfb PUBLIC ${CMAKE_SOURCE_DIR}/common)
 target_include_directories(rfb SYSTEM PUBLIC ${JPEG_INCLUDE_DIR})
 target_link_libraries(rfb core rdr network)
-target_link_libraries(rfb ${JPEG_LIBRARIES} ${PIXMAN_LIBRARIES})
+target_link_libraries(rfb ${JPEG_LIBRARIES})
 
 if(ENABLE_H264)
   target_sources(rfb PRIVATE H264Decoder.cxx H264DecoderContext.cxx)

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -10,10 +10,10 @@ add_executable(convperf convperf.cxx)
 target_link_libraries(convperf test_util rfb)
 
 add_executable(decperf decperf.cxx)
-target_link_libraries(decperf test_util rdr rfb)
+target_link_libraries(decperf test_util rdr rfb rfbclient)
 
 add_executable(encperf encperf.cxx)
-target_link_libraries(encperf test_util core rdr rfb)
+target_link_libraries(encperf test_util core rdr rfb rfbclient rfbserver)
 
 if (BUILD_VIEWER)
   add_executable(fbperf

--- a/unix/w0vncserver/CMakeLists.txt
+++ b/unix/w0vncserver/CMakeLists.txt
@@ -86,7 +86,7 @@ target_include_directories(w0vncserver SYSTEM PUBLIC ${UUID_INCLUDE_DIRS})
 target_include_directories(w0vncserver SYSTEM PUBLIC ${WAYLANDCLIENT_INCLUDE_DIRS})
 target_include_directories(w0vncserver SYSTEM PUBLIC ${XKBCOMMON_INCLUDE_DIRS})
 
-target_link_libraries(w0vncserver core rfb network rdr)
+target_link_libraries(w0vncserver rfbserver rfb network rdr core)
 target_link_libraries(w0vncserver ${GLIB_LIBRARIES})
 target_link_libraries(w0vncserver ${GIO_LIBRARIES})
 target_link_libraries(w0vncserver ${GOBJECT_LIBRARIES})

--- a/unix/x0vncserver/CMakeLists.txt
+++ b/unix/x0vncserver/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(x0vncserver PUBLIC ${CMAKE_SOURCE_DIR}/unix/common)
 target_include_directories(x0vncserver PUBLIC ${CMAKE_SOURCE_DIR}/unix/tx)
 target_include_directories(x0vncserver PUBLIC ${CMAKE_SOURCE_DIR}/unix)
 target_include_directories(x0vncserver PUBLIC ${CMAKE_SOURCE_DIR}/common)
-target_link_libraries(x0vncserver core tx rfb network rdr unixcommon)
+target_link_libraries(x0vncserver tx rfbserver rfb network rdr unixcommon core)
 
 # systemd support (socket activation)
 if (SYSTEMD_FOUND)

--- a/unix/xserver/hw/vnc/Makefile.am
+++ b/unix/xserver/hw/vnc/Makefile.am
@@ -2,11 +2,12 @@ TIGERVNC_SRCDIR=$(abspath ${top_srcdir}/../..)
 TIGERVNC_BUILDDIR=$(abspath ${top_builddir}/../..)
 
 RFB_LIB=$(TIGERVNC_BUILDDIR)/common/rfb/librfb.la
+RFBSERVER_LIB=$(TIGERVNC_BUILDDIR)/common/rfb/librfbserver.la
 RDR_LIB=$(TIGERVNC_BUILDDIR)/common/rdr/librdr.la
 OS_LIB=$(TIGERVNC_BUILDDIR)/common/os/libos.la
 NETWORK_LIB=$(TIGERVNC_BUILDDIR)/common/network/libnetwork.la
 UNIXCOMMON_LIB=$(TIGERVNC_BUILDDIR)/unix/common/libunixcommon.la
-COMMON_LIBS=$(UNIXCOMMON_LIB) $(RFB_LIB) $(NETWORK_LIB) $(RDR_LIB) $(CORE_LIB)
+COMMON_LIBS=$(UNIXCOMMON_LIB) $(RFBSERVER_LIB) $(RFB_LIB) $(NETWORK_LIB) $(RDR_LIB) $(CORE_LIB)
 
 AM_CPPFLAGS = \
 	-I$(TIGERVNC_BUILDDIR) \

--- a/vncviewer/CMakeLists.txt
+++ b/vncviewer/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 target_include_directories(vncviewer SYSTEM PUBLIC ${FLTK_INCLUDE_DIR})
 target_include_directories(vncviewer SYSTEM PUBLIC ${Intl_INCLUDE_DIR})
 target_include_directories(vncviewer PUBLIC ${CMAKE_SOURCE_DIR}/common)
-target_link_libraries(vncviewer core rfb network rdr)
+target_link_libraries(vncviewer rfbclient rfb network rdr core)
 target_link_libraries(vncviewer ${FLTK_LIBRARIES} ${Intl_LIBRARIES})
 
 if(GNUTLS_FOUND)

--- a/win/vncconfig/CMakeLists.txt
+++ b/win/vncconfig/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(vncconfig WIN32
   vncconfig.rc)
 
 target_include_directories(vncconfig PUBLIC ${CMAKE_BINARY_DIR}/win)
-target_link_libraries(vncconfig rfb_win32 rfb network rdr ws2_32.lib)
+target_link_libraries(vncconfig rfb_win32 rfbserver rfb network rdr ws2_32.lib)
 
 install(TARGETS vncconfig
   RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}

--- a/win/winvnc/CMakeLists.txt
+++ b/win/winvnc/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(winvnc4 WIN32
 
 target_include_directories(winvnc4 PUBLIC ${CMAKE_BINARY_DIR}/win)
 target_include_directories(winvnc4 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(winvnc4 rfb rfb_win32 network rdr ws2_32.lib)
+target_link_libraries(winvnc4 rfbserver rfb rfb_win32 network rdr ws2_32.lib)
 
 install(TARGETS winvnc4
   RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}


### PR DESCRIPTION
We've previously relied on the linker picking only the relevant files out of the common librfb.a. Unfortunately, that isn't always reliable.
    
Template instantiation can result in the same function ending up in multiple object files. The linker will then pick the first copy it sees, which might drag in client object in a server (or vice versa).
    
Avoid this by explicitly splitting the library in to client and server variants.
