### PR TITLE
Fix protocol desynchronization in readSetDesktopSize

### DIFF
--- a/common/rfb/SMsgReader.cxx
+++ b/common/rfb/SMsgReader.cxx
@@ -167,7 +167,7 @@ bool SMsgReader::readSetDesktopSize()
   ScreenSet layout;
 
   if (!is->hasData(1 + 2 + 2 + 1 + 1))
-    return true;
+    return false;
 
   is->setRestorePoint();
 


### PR DESCRIPTION
readSetDesktopSize() returned true instead of false when insufficient data was available, unlike every other message handler in SMsgReader. This caused the readMsg() state machine to reset to MSGSTATE_IDLE, leading to message boundary desynchronization — the first byte of subsequent data was consumed as a new message type rather than part of the pending SetDesktopSize message.