### PR TITLE
Prevent PAM error message disclosure to VNC clients

### DIFF
--- a/common/rfb/UnixPasswordValidator.cxx
+++ b/common/rfb/UnixPasswordValidator.cxx
@@ -72,11 +72,9 @@ static int pam_callback(int count, const struct pam_message **in,
     resp[i].resp_retcode = PAM_SUCCESS;
     switch (in[i]->msg_style) {
     case PAM_TEXT_INFO:
-      auth->msg = in[i]->msg;
       resp[i].resp = nullptr;
       break;
     case PAM_ERROR_MSG:
-      auth->msg = in[i]->msg;
       resp[i].resp = nullptr;
       break;
     case PAM_PROMPT_ECHO_ON:	/* Send Username */


### PR DESCRIPTION
The PAM conversation callback was forwarding PAM_ERROR_MSG and PAM_TEXT_INFO messages verbatim to unauthenticated clients. Depending on PAM configuration, this could reveal whether a username exists (e.g. 'User not known' vs 'Authentication failure'), enabling username enumeration without valid credentials.