### PR TITLE
Rate-limit framebuffer resize requests to prevent memory DoS

### DIFF
--- a/common/rfb/VNCServerST.cxx
+++ b/common/rfb/VNCServerST.cxx
@@ -90,6 +90,7 @@ VNCServerST::VNCServerST(const char* name_, SDesktop* desktop_)
     desktopStarting(false), blockCounter(0), pb(nullptr),
     ledState(ledUnknown), name(name_), pointerClient(nullptr),
     clipboardClient(nullptr), pointerClientTime(0),
+    lastSetDesktopSizeTime(0),
     comparer(nullptr), cursor(new Cursor(0, 0, {}, nullptr)),
     renderedCursorInvalid(false),
     keyRemapper(&KeyRemapper::defInstance),
@@ -619,6 +620,16 @@ unsigned int VNCServerST::setDesktopSize(VNCSConnectionST* requester,
   if (!rfb::Server::acceptSetDesktopSize) {
     slog.debug("Rejecting unauthorized framebuffer resize request");
     return resultProhibited;
+  }
+
+  // Rate limit resize requests to prevent memory exhaustion DoS
+  {
+    time_t now = time(nullptr);
+    if (now - lastSetDesktopSizeTime < 1) {
+      slog.debug("Rate limiting framebuffer resize request");
+      return resultProhibited;
+    }
+    lastSetDesktopSizeTime = now;
   }
 
   // We can't handle a framebuffer larger than this, so don't let a

--- a/common/rfb/VNCServerST.h
+++ b/common/rfb/VNCServerST.h
@@ -197,6 +197,7 @@ namespace rfb {
     std::list<VNCSConnectionST*> clipboardRequestors;
 
     time_t pointerClientTime;
+    time_t lastSetDesktopSizeTime;
 
     ComparingUpdateTracker* comparer;
 


### PR DESCRIPTION
An authenticated client could request the maximum framebuffer size (16384x16384) repeatedly without any rate limiting, triggering ~1 GiB memory allocations each time and eventually causing the server to run out of memory.\n\nAdd a 1-second minimum interval between SetDesktopSize requests to prevent rapid memory exhaustion attacks.