### PR TITLE
Fix incorrect iterator used in ManagedListener cleanup

### DIFF
--- a/win/winvnc/ManagedListener.cxx
+++ b/win/winvnc/ManagedListener.cxx
@@ -118,7 +118,7 @@ void ManagedListener::refresh() {
       for (iter2 = sockets.begin(); iter2 != iter; ++iter2)
         manager->remListener(*iter2);
       for (; iter2 != sockets.end(); ++iter2)
-        delete *iter;
+        delete *iter2;
       sockets.clear();
       throw;
     }


### PR DESCRIPTION
This fixes a cleanup loop in ManagedListener::refresh().

The loop iterates with `iter2`, but deletes `*iter`.
This may repeatedly delete the same pointer instead of deleting the object pointed to by the current iterator.

Changed it to delete `*iter2`.

I have not tested the full Windows build locally.