### PR TITLE
vncviewer: prevent SSH option injection via -via gateway argument

### DIFF
--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -519,7 +519,7 @@ createTunnel(const char *gatewayHost, const char *remoteHost,
   setenv("R", rport, 1);
   setenv("L", lport, 1);
   if (!cmd)
-    cmd = "/usr/bin/ssh -f -L \"$L\":\"$H\":\"$R\" \"$G\" sleep 20";
+    cmd = "/usr/bin/ssh -f -L \"$L\":\"$H\":\"$R\" -- \"$G\" sleep 20";
   /* Compatibility with TigerVNC's method. */
   cmd2 = strdup(cmd);
   while ((percent = strchr(cmd2, '%')) != nullptr)


### PR DESCRIPTION
The via parameter (from CLI, GUI, or a loaded .vnc config file) is
passed to ssh as a bare positional argument inside createTunnel()'s
default command template. A value starting with "-" is parsed by
ssh as an option rather than a hostname, so via=-oProxyCommand=<cmd>
causes ssh to run an arbitrary command through ProxyCommand.

Shell quoting of "$G" only prevents shell metacharacter/word-splitting
issues, it does not stop ssh's own option parsing from treating the
value as an option.

This inserts "--" before the expanded gateway host so ssh stops
parsing options at that point and treats the remainder strictly as
the destination, closing off the option-injection path.

Tested by setting the via value to -oProxyCommand=<cmd> and
confirming the command executes before the fix and is rejected
by ssh as an invalid hostname after the fix.