### PR TITLE
Don't validate restore_token as UUID

### DIFF
--- a/unix/w0vncserver/portals/RemoteDesktop.cxx
+++ b/unix/w0vncserver/portals/RemoteDesktop.cxx
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <assert.h>
 #include <sys/select.h>
-#include <uuid/uuid.h>
 #include <linux/input-event-codes.h>
 
 #include <string>
@@ -657,7 +656,7 @@ bool RemoteDesktop::loadRestoreToken()
   char filepath[PATH_MAX];
   FILE* f;
   const char* stateDir;
-  char restoreToken_[37];
+  char restoreToken_[128];
 
   if (rememberDisplayChoice == "Never")
     return false;
@@ -688,14 +687,7 @@ bool RemoteDesktop::loadRestoreToken()
   }
 
   if (fgets(restoreToken_, sizeof(restoreToken_), f)) {
-    uuid_t uuid;
-
     fclose(f);
-    if (uuid_parse(restoreToken_, uuid) < 0) {
-      vlog.error("Invalid restore token, not a valid UUID string \"%s\"", restoreToken_);
-      return false;
-    }
-
     restoreToken = restoreToken_;
     return true;
   }


### PR DESCRIPTION
Looks like there was a recent change in xdg-desktop-portal to no longer use UUIDs, but rather random strings for `restore_token`. This breaks our usage of `restore_token` that tries to validate UUIDs.