### PR TITLE
vncviewer: fix clipboard check incorrectly rejecting PRIMARY selections

### DIFF
--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -595,7 +595,7 @@ void Viewport::handleClipboardChange(int source, void *data)
     return;
 #endif
 
-  if (!Fl::clipboard_contains(Fl::clipboard_plain_text)) {
+  if (source != 0 && !Fl::clipboard_contains(Fl::clipboard_plain_text)) {
     vlog.debug("Got non-plain text in local clipboard, ignoring.");
     // Reset the state as if we don't have any clipboard data at all
     self->pendingClientClipboard = false;


### PR DESCRIPTION
Fl::clipboard_contains() doesn't query PRIMARY selection. When text is selected, the clipboard notify is sent with source=0 (PRIMARY), but the check performed by Fl::clipboard_contains() might be checking clipboard which may be empty, causing a false "Got non-plain text" rejection.

Fixes #2129