### PR TITLE
Declare the viewer DPI-aware on Windows

### DIFF
--- a/vncviewer/CMakeLists.txt
+++ b/vncviewer/CMakeLists.txt
@@ -30,10 +30,28 @@ if(WIN32 AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   set_target_properties(vncviewer PROPERTIES WIN32_EXECUTABLE TRUE)
 endif()
 
+option(ENABLE_DPI_AWARE "Declare the viewer DPI-aware on Windows (sharp 1:1 rendering; see vncviewer.exe.manifest)" ON)
+
 if(WIN32)
   # Since vncviewer.rc is generated, local includes will be looking
   # in the wrong directory. We need to help it out.
   target_include_directories(vncviewer PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # The application manifest carries the DPI-awareness declaration. MSVC's
+  # linker synthesises its own manifest, so a second RT_MANIFEST resource
+  # compiled in via the .rc would collide with it; CMake instead merges a
+  # .manifest listed as a source (via /MANIFESTINPUT). MinGW's linker does
+  # no such synthesis, so there the manifest has to go through the .rc.
+  set(VNCVIEWER_MANIFEST_RC "")
+  if(ENABLE_DPI_AWARE)
+    if(MSVC)
+      target_sources(vncviewer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/vncviewer.exe.manifest)
+    else()
+      # 1 = CREATEPROCESS_MANIFEST_RESOURCE_ID, 24 = RT_MANIFEST
+      set(VNCVIEWER_MANIFEST_RC "1 24 \"${CMAKE_CURRENT_SOURCE_DIR}/vncviewer.exe.manifest\"")
+    endif()
+  endif()
+
   configure_file(vncviewer.rc.in vncviewer.rc)
   target_sources(vncviewer PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/vncviewer.rc)
 endif()

--- a/vncviewer/vncviewer.exe.manifest
+++ b/vncviewer/vncviewer.exe.manifest
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+     type="win32"
+     name="TigerVNC.vncviewer.exe"
+     version="1.0.0.0"
+  />
+  <description>TigerVNC Viewer</description>
+
+  <!--
+    Declare DPI awareness so Windows hands us the real pixel grid instead of
+    rendering to a virtualized logical desktop and bitmap stretching the
+    result. Without this, on a 200% display a 3270x2180 panel is reported as
+    1635x1090: a 1920x1200 remote framebuffer no longer fits (DesktopWindow
+    logs "Reducing window size to fit on current monitor") and every pixel we
+    draw is upscaled 2x by the compositor, which is exactly the blur you do
+    not want on a remote desktop.
+
+    "true" is system DPI awareness, deliberately not PerMonitorV2.
+    Per-monitor awareness requires the app to rescale itself on WM_DPICHANGED
+    when moved between differently scaled monitors. FLTK 1.3 has no HiDPI
+    support at all (Fl::screen_scale() arrived in 1.4, and TigerVNC hard
+    requires 1.3; see the FL_MINOR_VERSION check in the top level
+    CMakeLists.txt), so we cannot honour that contract. Claiming PerMonitorV2
+    we cannot implement would give a wrongly sized window on a secondary
+    monitor; system awareness lets Windows fall back to bitmap scaling there,
+    which is the correct degradation.
+  -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+  <!-- Without an explicit supportedOS list Windows applies legacy
+       compatibility shims, which can re-enable DPI virtualization. -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/vncviewer/vncviewer.rc.in
+++ b/vncviewer/vncviewer.rc.in
@@ -72,6 +72,16 @@ END
 // remains consistent on all systems.
 IDI_ICON                ICON    DISCARDABLE     "@CMAKE_SOURCE_DIR@/media/icons/tigervnc.ico"
 
+/////////////////////////////////////////////////////////////////////////////
+//
+// Manifest (DPI awareness)
+//
+// Empty under MSVC, whose linker merges the manifest itself -- see
+// vncviewer/CMakeLists.txt.
+//
+
+@VNCVIEWER_MANIFEST_RC@
+
 #endif    // English (U.K.) resources
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Windows renders the viewer to a virtualised logical desktop and
bitmap-stretches the result unless the application declares itself
DPI-aware. On a 200% display a 3270x2180 panel is reported as 1635x1090, so
a 1920x1200 remote framebuffer no longer fits — `DesktopWindow` logs
"Reducing window size to fit on current monitor" — and every pixel that is
drawn is then upscaled by the compositor. Blur on a remote desktop is the
one thing worth avoiding.

### Why "true" and not PerMonitorV2

Per-monitor awareness obliges the application to rescale itself on
`WM_DPICHANGED` when it is dragged between differently scaled monitors, and
FLTK 1.3 has no HiDPI support to build that on. Claiming it would replace
stretching with a viewer that draws at the wrong size, which is worse.
System DPI awareness is what the toolkit can actually honour today.

If FLTK ever grows per-monitor support, the manifest is the only thing that
needs revisiting.

### Why the manifest is delivered two ways

The linkers differ. MSVC synthesises its own application manifest, so a
second `RT_MANIFEST` compiled in through the `.rc` collides with it; CMake
merges a `.manifest` listed as a source instead. MinGW's linker synthesises
nothing, so there it has to go through the `.rc`. Both paths are in the
`CMakeLists.txt` change and the comment says which is which.

### Scope

Behind `ENABLE_DPI_AWARE`, default ON, Windows only. Nothing changes on any
other platform, and turning it off restores exactly the current behaviour.

### Testing

Built and run on Windows. I have not exercised the MinGW path your CI uses —
I build this tree with MSVC through a local change that is not part of this
pull request — so the `.rc` branch is the one that would benefit from a
second pair of eyes. It is the path upstream builds today, and the manifest
resource id it uses (`1 24`) is the standard `CREATEPROCESS_MANIFEST_RESOURCE_ID`
/ `RT_MANIFEST` pair.
