### PR TITLE
Xvnc.man: Fix description for `SendPrimary`

### DIFF
--- a/unix/xserver/hw/vnc/Xvnc.man
+++ b/unix/xserver/hw/vnc/Xvnc.man
@@ -304,7 +304,7 @@ Send clipboard changes to clients. Default is on.
 .
 .TP
 .B \-SendPrimary
-Send the primary selection and cut buffer to the server as well as the
+Send the primary selection and cut buffer to the client as well as the
 clipboard selection. Default is on.
 .
 .TP


### PR DESCRIPTION
client/server mix up