### PR TITLE
Add fadeout before idle timer is triggered

### DIFF
--- a/common/rfb/CMakeLists.txt
+++ b/common/rfb/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(rfbserver STATIC
   ClientParams.cxx
   EncodeManager.cxx
   Encoder.cxx
+  FadingPixelBuffer.cxx
   HextileEncoder.cxx
   JPEGEncoder.cxx
   RREEncoder.cxx

--- a/common/rfb/FadingPixelBuffer.cxx
+++ b/common/rfb/FadingPixelBuffer.cxx
@@ -1,0 +1,178 @@
+/* Copyright 2026 Adam Halim for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#include <assert.h>
+
+#include <pixman.h>
+#include <stdexcept>
+#include <vector>
+
+#include <core/LogWriter.h>
+#include <core/Region.h>
+#include <core/i18n.h>
+
+#include "FadingPixelBuffer.h"
+
+using namespace rfb;
+
+static const PixelFormat pfRGBX(32, 24, false, true, 255, 255, 255, 0, 8, 16);
+static const PixelFormat pfBGRX(32, 24, false, true, 255, 255, 255, 16, 8, 0);
+static const PixelFormat pfXRGB(32, 24, false, true, 255, 255, 255, 8, 16, 24);
+static const PixelFormat pfXBGR(32, 24, false, true, 255, 255, 255, 24, 16, 8);
+
+static core::LogWriter vlog("FadingPixelBuffer");
+
+FadingPixelBuffer::FadingPixelBuffer(const PixelBuffer* pb)
+  : PixelBuffer(pb->getPF(), pb->width(), pb->height()),
+    parent(pb), fadeLevel(1.0f),
+    fadedBuffer(new uint8_t[width() * height() * (format.bpp/8)])
+{
+}
+
+FadingPixelBuffer::~FadingPixelBuffer()
+{
+  delete[] fadedBuffer;
+}
+
+void FadingPixelBuffer::setFadeLevel(float level)
+{
+  fadeLevel = level < 0.0f ? 0.0f : (level > 1.0f ? 1.0f : level);
+}
+
+const uint8_t* FadingPixelBuffer::getBuffer(const core::Rect& r,
+                                            int* stride_) const
+{
+  *stride_ = width();
+  return fadedBuffer + (r.tl.y * width() + r.tl.x) * format.bpp / 8;
+}
+
+void FadingPixelBuffer::syncBuffers(const core::Region& r)
+{
+  const uint8_t* buffer;
+  int stride_;
+  int bpp;
+  pixman_format_code_t pixmanFormat;
+  pixman_image_t* srcImg;
+  pixman_image_t* dstImg;
+  uint16_t alpha;
+  pixman_color_t black;
+  pixman_image_t* overlay;
+  std::vector<core::Rect> rects;
+
+  assert(fadeLevel <= 1.0f && fadeLevel >= 0.0f);
+
+  if (!r.get_rects(&rects))
+    return;
+
+  if (parent->getRect().width() != width() || parent->getRect().height() != height())
+    throw std::runtime_error(_("Parent PixelBuffer size mismatch"));
+
+  if (format != parent->getPF())
+    throw std::runtime_error(_("Parent PixelBuffer format mismatch"));
+
+  try {
+    pixmanFormat = rfbToPixmanFormat(format);
+  } catch (std::runtime_error&) {
+    syncBuffersFallback(r);
+    return;
+  }
+
+  buffer = parent->getBuffer(parent->getRect(), &stride_);
+  bpp = format.bpp / 8;
+
+  alpha = (1 - fadeLevel) * 0xffff;
+  black = {0, 0, 0, alpha};
+  overlay = pixman_image_create_solid_fill(&black);
+
+  srcImg = pixman_image_create_bits(pixmanFormat, width(), height(),
+                                    (uint32_t *)buffer, stride_ * bpp);
+  dstImg = pixman_image_create_bits(pixmanFormat, width(), height(),
+                                    (uint32_t *)fadedBuffer, width() * bpp);
+  for (core::Rect &rect : rects) {
+    pixman_image_composite32(PIXMAN_OP_SRC, srcImg, nullptr, dstImg,
+                             rect.tl.x, rect.tl.y, 0, 0, rect.tl.x,
+                             rect.tl.y, rect.width(), rect.height());
+
+    pixman_image_composite32(PIXMAN_OP_OVER, overlay, nullptr, dstImg,
+                             rect.tl.x, rect.tl.y, 0, 0, rect.tl.x,
+                             rect.tl.y, rect.width(), rect.height());
+  }
+
+  pixman_image_unref(overlay);
+  pixman_image_unref(srcImg);
+  pixman_image_unref(dstImg);
+}
+
+void FadingPixelBuffer::syncBuffersFallback(const core::Region& r)
+{
+  const uint8_t* buffer;
+  int stride_;
+  int bpp;
+  std::vector<core::Rect> rects;
+
+  assert(fadeLevel <= 1.0f && fadeLevel >= 0.0f);
+
+  if (!r.get_rects(&rects))
+    return;
+
+  if (parent->getRect().width() != width() || parent->getRect().height() != height())
+    throw std::runtime_error(_("Parent PixelBuffer size mismatch"));
+
+  if (format != parent->getPF())
+    throw std::runtime_error(_("Parent PixelBuffer format mismatch"));
+
+  buffer = parent->getBuffer(parent->getRect(), &stride_);
+  bpp = format.bpp / 8;
+
+  for (core::Rect &rect : rects) {
+    std::vector<uint8_t> rgb(rect.width() * 3);
+
+    for (int y = 0; y < rect.height(); y++) {
+      const uint8_t* srcRow;
+      uint8_t* dstRow;
+
+      srcRow = buffer + ((rect.tl.y + y) * stride_ + rect.tl.x) * bpp;
+      dstRow = fadedBuffer + ((rect.tl.y + y) * width() + rect.tl.x) * bpp;
+
+      format.rgbFromBuffer(rgb.data(), srcRow, rect.width());
+
+      for (int x = 0; x < rect.width(); x++) {
+        rgb[x*3 + 0] = (uint8_t)(rgb[x*3 + 0] * fadeLevel);
+        rgb[x*3 + 1] = (uint8_t)(rgb[x*3 + 1] * fadeLevel);
+        rgb[x*3 + 2] = (uint8_t)(rgb[x*3 + 2] * fadeLevel);
+      }
+
+      format.bufferFromRGB(dstRow, rgb.data(), rect.width());
+    }
+  }
+}
+
+pixman_format_code_t FadingPixelBuffer::rfbToPixmanFormat(PixelFormat pf)
+{
+  if (pf == pfBGRX)
+    return PIXMAN_x8r8g8b8;
+  if (pf == pfRGBX)
+    return PIXMAN_x8b8g8r8;
+  if (pf == pfXBGR)
+    return PIXMAN_r8g8b8x8;
+  if (pf == pfXRGB)
+    return PIXMAN_b8g8r8x8;
+
+  // FIXME: Support more pixman formats
+  throw std::runtime_error(_("Unsupported pixel format"));
+}

--- a/common/rfb/FadingPixelBuffer.h
+++ b/common/rfb/FadingPixelBuffer.h
@@ -1,0 +1,56 @@
+/* Copyright 2026 Adam Halim for Cendio AB
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307,
+ * USA.
+ */
+
+#ifndef __FADING_PIXELBUFFER_H__
+#define __FADING_PIXELBUFFER_H__
+
+#include <pixman.h>
+
+#include <rfb/PixelBuffer.h>
+
+namespace rfb {
+  class FadingPixelBuffer : public PixelBuffer {
+  public:
+    FadingPixelBuffer(const PixelBuffer* parent);
+    virtual ~FadingPixelBuffer();
+
+    float getFadeLevel() const { return fadeLevel; }
+    void setFadeLevel(float level);
+
+    // Get a pointer into the faded buffer
+    virtual const uint8_t* getBuffer(const core::Rect& r, int* stride) const override;
+
+    // Sync the faded buffer with the parent for the given region
+    void syncBuffers(const core::Region& r);
+
+  private:
+    // Slow fallback in case pixman fails
+    void syncBuffersFallback(const core::Region& r);
+
+    // Convert from rfb::PixelFormat to pixman_format_code_t
+    pixman_format_code_t rfbToPixmanFormat(PixelFormat format);
+
+  private:
+    const PixelBuffer* parent;
+    float fadeLevel;
+    uint8_t* fadedBuffer;
+  };
+
+};
+
+#endif // __FADING_PIXELBUFFER_H__

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -61,7 +61,7 @@ static const unsigned LOGIN_GRACE_TIME = 120;
 // Number of seconds allowed to flush a closing socket
 static const unsigned CLOSE_GRACE_TIME = 5;
 // Number of seconds the framebuffer will fade to black before
-// disconnecting client due to idle timeout
+// disconnecting the client or shutting down the server
 static const unsigned FADING_TIME = 10;
 
 static core::LogWriter vlog("VNCSConnST");
@@ -503,14 +503,15 @@ void VNCSConnectionST::queryConnection(const char* userName)
 
 void VNCSConnectionST::clientReady(bool shared)
 {
-  if (rfb::Server::idleTimeout) {
+  if (rfb::Server::idleTimeout)
     idleTimer.start(core::secsToMillis(rfb::Server::idleTimeout));
 
+  if (rfb::Server::idleTimeout || rfb::Server::maxIdleTime) {
     // Trigger the timer just as we are about to start fading
-    if (idleTimer.getRemainingMs() < FADING_TIME * 1000.0f)
+    if (timeToIdleTimeout() < FADING_TIME * 1000.0f)
       fadeTimer.start(1000 / rfb::Server::frameRate);
     else
-      fadeTimer.start(idleTimer.getRemainingMs() - FADING_TIME * 1000.0f);
+      fadeTimer.start(timeToIdleTimeout() - FADING_TIME * 1000.0f);
   }
 
   if (rfb::Server::alwaysShared || reverseConnection) shared = true;
@@ -878,7 +879,7 @@ void VNCSConnectionST::handleTimeout(core::Timer* t)
 
   if (t == &fadeTimer) {
     if (server->getPixelBuffer()) {
-      if (idleTimer.getRemainingMs() < FADING_TIME * 1000.0f) {
+      if (timeToIdleTimeout() < FADING_TIME * 1000.0f) {
         bool needsUpdate;
         float oldLevel;
         float newLevel;
@@ -891,7 +892,7 @@ void VNCSConnectionST::handleTimeout(core::Timer* t)
         }
 
         oldLevel = fadedBuffer->getFadeLevel();
-        newLevel = (idleTimer.getRemainingMs() / (FADING_TIME * 1000.0f));
+        newLevel = (timeToIdleTimeout() / (FADING_TIME * 1000.0f));
 
         // FIXME: Don't hardcode 255
         if ((int)(oldLevel*255) != (int)(newLevel*255)) {
@@ -918,10 +919,10 @@ void VNCSConnectionST::handleTimeout(core::Timer* t)
     // currently fading, we need to trigger the timer at the same
     // rate as the server framerate. This is to ensure that the fading
     // still occurs even if there is nothing happening on-screen.
-    if (idleTimer.getRemainingMs() < FADING_TIME * 1000.0f)
+    if (timeToIdleTimeout() < FADING_TIME * 1000.0f)
       fadeTimer.repeat(1000 / rfb::Server::frameRate);
     else
-      fadeTimer.repeat(idleTimer.getRemainingMs() - FADING_TIME * 1000.0f);
+      fadeTimer.repeat(timeToIdleTimeout() - FADING_TIME * 1000.0f);
   }
 
   if (t == &idleTimer)
@@ -940,6 +941,24 @@ bool VNCSConnectionST::isShiftPressed()
     }
 
   return false;
+}
+
+// Returns the number of milliseconds left until the closest idle timer
+// is about to trigger
+int VNCSConnectionST::timeToIdleTimeout()
+{
+  assert(rfb::Server::idleTimeout || rfb::Server::maxIdleTime);
+
+  if (!rfb::Server::maxIdleTime)
+    return idleTimer.getRemainingMs();
+
+  if (!rfb::Server::idleTimeout)
+    return server->getIdleRemainingMs();
+
+  if (idleTimer.getRemainingMs() < server->getIdleRemainingMs())
+    return idleTimer.getRemainingMs();
+
+  return server->getIdleRemainingMs();
 }
 
 void VNCSConnectionST::writeRTTPing()
@@ -1138,7 +1157,7 @@ void VNCSConnectionST::writeDataUpdate()
     float oldFadeLevel;
     float newFadeLevel;
 
-    newFadeLevel = (idleTimer.getRemainingMs() / (FADING_TIME * 1000.0f));
+    newFadeLevel = (timeToIdleTimeout() / (FADING_TIME * 1000.0f));
     oldFadeLevel = fadedBuffer->getFadeLevel();
 
     if ((int)(oldFadeLevel * 255) != (int)(newFadeLevel * 255)) {

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -37,6 +37,7 @@
 #include <rfb/ComparingUpdateTracker.h>
 #include <rfb/Encoder.h>
 #include <rfb/Exception.h>
+#include <rfb/FadingPixelBuffer.h>
 #include <rfb/KeyRemapper.h>
 #include <rfb/KeysymStr.h>
 #include <rfb/Security.h>
@@ -59,6 +60,9 @@ using namespace rfb;
 static const unsigned LOGIN_GRACE_TIME = 120;
 // Number of seconds allowed to flush a closing socket
 static const unsigned CLOSE_GRACE_TIME = 5;
+// Number of seconds the framebuffer will fade to black before
+// disconnecting client due to idle timeout
+static const unsigned FADING_TIME = 10;
 
 static core::LogWriter vlog("VNCSConnST");
 
@@ -71,10 +75,10 @@ VNCSConnectionST::VNCSConnectionST(VNCServerST* server_, network::Socket *s,
     inProcessMessages(false),
     pendingSyncFence(false), syncFence(false), fenceFlags(0),
     fenceDataLen(0), fenceData(nullptr), congestionTimer(this),
-    losslessTimer(this), server(server_),
+    losslessTimer(this), server(server_), fadedBuffer(nullptr),
     updateRenderedCursor(false), removeRenderedCursor(false),
     continuousUpdates(false), encodeManager(this), idleTimer(this),
-    pointerEventTime(0), clientHasCursor(false)
+    fadeTimer(this), pointerEventTime(0), clientHasCursor(false)
 {
   socketTimer.start(core::secsToMillis(LOGIN_GRACE_TIME));
 
@@ -104,6 +108,7 @@ VNCSConnectionST::~VNCSConnectionST()
   }
 
   delete [] fenceData;
+  delete fadedBuffer;
 }
 
 
@@ -269,6 +274,12 @@ void VNCSConnectionST::pixelBufferChange()
       // Drop any lossy tracking that is now outside the framebuffer
       encodeManager.pruneLosslessRefresh(server->getPixelBuffer()->getRect());
     }
+
+    if (fadedBuffer) {
+      delete fadedBuffer;
+      fadedBuffer = new FadingPixelBuffer(server->getPixelBuffer());
+    }
+
     // Just update the whole screen at the moment because we're too lazy to
     // work out what's actually changed.
     updates.clear();
@@ -492,8 +503,15 @@ void VNCSConnectionST::queryConnection(const char* userName)
 
 void VNCSConnectionST::clientReady(bool shared)
 {
-  if (rfb::Server::idleTimeout)
+  if (rfb::Server::idleTimeout) {
     idleTimer.start(core::secsToMillis(rfb::Server::idleTimeout));
+
+    // Trigger the timer just as we are about to start fading
+    if (idleTimer.getRemainingMs() < FADING_TIME * 1000.0f)
+      fadeTimer.start(1000 / rfb::Server::frameRate);
+    else
+      fadeTimer.start(idleTimer.getRemainingMs() - FADING_TIME * 1000.0f);
+  }
 
   if (rfb::Server::alwaysShared || reverseConnection) shared = true;
   if (!accessCheck(AccessNonShared)) shared = true;
@@ -858,6 +876,54 @@ void VNCSConnectionST::handleTimeout(core::Timer* t)
     close(e.what());
   }
 
+  if (t == &fadeTimer) {
+    if (server->getPixelBuffer()) {
+      if (idleTimer.getRemainingMs() < FADING_TIME * 1000.0f) {
+        bool needsUpdate;
+        float oldLevel;
+        float newLevel;
+
+        needsUpdate = false;
+
+        if (!fadedBuffer) {
+          fadedBuffer = new FadingPixelBuffer(server->getPixelBuffer());
+          needsUpdate = true;
+        }
+
+        oldLevel = fadedBuffer->getFadeLevel();
+        newLevel = (idleTimer.getRemainingMs() / (FADING_TIME * 1000.0f));
+
+        // FIXME: Don't hardcode 255
+        if ((int)(oldLevel*255) != (int)(newLevel*255)) {
+          fadedBuffer->setFadeLevel(newLevel);
+          needsUpdate = true;
+        }
+
+        if (needsUpdate) {
+          updates.clear();
+          updates.add_changed(server->getPixelBuffer()->getRect());
+          writeFramebufferUpdate();
+        }
+      } else if (fadedBuffer) {
+        delete fadedBuffer;
+        fadedBuffer = nullptr;
+
+        updates.clear();
+        updates.add_changed(server->getPixelBuffer()->getRect());
+        writeFramebufferUpdate();
+      }
+    }
+
+    // Trigger the timer just as we are about to start fading. If we are
+    // currently fading, we need to trigger the timer at the same
+    // rate as the server framerate. This is to ensure that the fading
+    // still occurs even if there is nothing happening on-screen.
+    if (idleTimer.getRemainingMs() < FADING_TIME * 1000.0f)
+      fadeTimer.repeat(1000 / rfb::Server::frameRate);
+    else
+      fadeTimer.repeat(idleTimer.getRemainingMs() - FADING_TIME * 1000.0f);
+  }
+
   if (t == &idleTimer)
     close(_("Idle for too long"));
 }
@@ -1068,6 +1134,29 @@ void VNCSConnectionST::writeDataUpdate()
     damagedCursorRegion.assign_union(ui.changed.intersect(renderedCursorRect));
   }
 
+  if (fadedBuffer) {
+    float oldFadeLevel;
+    float newFadeLevel;
+
+    newFadeLevel = (idleTimer.getRemainingMs() / (FADING_TIME * 1000.0f));
+    oldFadeLevel = fadedBuffer->getFadeLevel();
+
+    if ((int)(oldFadeLevel * 255) != (int)(newFadeLevel * 255)) {
+      updates.clear();
+      updates.add_changed(server->getPixelBuffer()->getRect());
+      fadedBuffer->setFadeLevel(newFadeLevel);
+      updates.getUpdateInfo(&ui, req);
+    }
+
+    try {
+      fadedBuffer->syncBuffers(ui.changed);
+    } catch (std::exception& e) {
+      vlog.error(_("Failed to sync faded buffer: %s"), e.what());
+      delete fadedBuffer;
+      fadedBuffer = nullptr;
+    }
+  }
+
   // If we don't have a normal update, then try a lossless refresh
   if (ui.is_empty() && !writer()->needFakeUpdate()) {
     writeLosslessRefresh();
@@ -1078,7 +1167,11 @@ void VNCSConnectionST::writeDataUpdate()
 
   writeRTTPing();
 
-  encodeManager.writeUpdate(ui, server->getPixelBuffer(), cursor);
+  if (fadedBuffer)
+    // FIXME: Fade the cursor as well
+    encodeManager.writeUpdate(ui, fadedBuffer, nullptr);
+  else
+    encodeManager.writeUpdate(ui, server->getPixelBuffer(), cursor);
 
   writeRTTPing();
 
@@ -1155,8 +1248,23 @@ void VNCSConnectionST::writeLosslessRefresh()
 
   writeRTTPing();
 
-  encodeManager.writeLosslessRefresh(req, server->getPixelBuffer(),
-                                     cursor, maxUpdateSize);
+  if (fadedBuffer) {
+    try {
+      fadedBuffer->syncBuffers(req);
+    } catch (std::exception& e) {
+      vlog.error(_("Failed to sync faded buffer: %s"), e.what());
+      delete fadedBuffer;
+      fadedBuffer = nullptr;
+    }
+  }
+
+  if (fadedBuffer) {
+    encodeManager.writeLosslessRefresh(req, fadedBuffer,
+                                       nullptr, maxUpdateSize);
+  } else {
+    encodeManager.writeLosslessRefresh(req, server->getPixelBuffer(),
+                                       cursor, maxUpdateSize);
+  }
 
   writeRTTPing();
 

--- a/common/rfb/VNCSConnectionST.h
+++ b/common/rfb/VNCSConnectionST.h
@@ -155,6 +155,8 @@ namespace rfb {
 
     bool isShiftPressed();
 
+    int timeToIdleTimeout();
+
     // Congestion control
     void writeRTTPing();
     bool isCongested();

--- a/common/rfb/VNCSConnectionST.h
+++ b/common/rfb/VNCSConnectionST.h
@@ -37,6 +37,7 @@
 
 namespace rfb {
   class VNCServerST;
+  class FadingPixelBuffer;
 
   class VNCSConnectionST : private SConnection,
                            public core::Timer::Callback {
@@ -191,6 +192,7 @@ namespace rfb {
     core::Timer losslessTimer;
 
     VNCServerST* server;
+    FadingPixelBuffer* fadedBuffer;
     SimpleUpdateTracker updates;
     core::Region requested;
     bool updateRenderedCursor, removeRenderedCursor;
@@ -202,6 +204,7 @@ namespace rfb {
     std::map<uint32_t, uint32_t> pressedKeys;
 
     core::Timer idleTimer;
+    core::Timer fadeTimer;
 
     time_t pointerEventTime;
     core::Point pointerEventPos;

--- a/common/rfb/VNCServerST.h
+++ b/common/rfb/VNCServerST.h
@@ -117,6 +117,7 @@ namespace rfb {
     const char* getName() const { return name.c_str(); }
     unsigned getLEDState() const { return ledState; }
     bool isDesktopReady() const { return desktopStarted; }
+    int getIdleRemainingMs() { return idleTimer.getRemainingMs(); }
 
     // Event handlers
     void keyEvent(uint32_t keysym, uint32_t keycode, bool down);


### PR DESCRIPTION
This PR adds a fadeout timer if the `idleTimer` parameter is used. It will start fading the screen to black 10 seconds before the idle timer is triggered. The idea is to give users a chance to prevent being disconnected if they notice the screen fading.

Tested with `Xvnc`, `x0vncserver` and `w0vncserver`. During the fading animation, if nothing else is happening on screen, I could see ~20% CPU usage with `Xvnc` on my machine.

I had a quick look at what durations other desktop environments have for this, and it seemed to range between 5-10 seconds.

I left out fading the cursor in this PR. Instead, the cursor will be invisible during the fading animation.